### PR TITLE
Remove module exclusion for sonar build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,4 +60,4 @@ jobs:
       run: mvn install javadoc:javadoc
     - name: Build + Test + Sonar + Maven Deploy
       if: github.ref == 'refs/heads/master'
-      run: mvn javadoc:javadoc deploy -Psonar -pl test-reports
+      run: mvn javadoc:javadoc deploy -Psonar


### PR DESCRIPTION
Reproduced build issue locally, by running:
```
mvn javadoc:javadoc deploy -Psonar -pl test-reports
```

Running `mvn javadoc:javadoc deploy -Psonar` works; this PR removes the `-pl test-reports` part of the command from the build GitHub Action.
