### PR TITLE
Upgrade Dropwizard metrics to 4.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <dropwizard.version>1.3.28</dropwizard.version>
-        <dropwizard.metrics.version>4.0.5</dropwizard.metrics.version>
+        <dropwizard.metrics.version>4.1.16</dropwizard.metrics.version>
         <dropwizard-guicier.version>1.3.5.2</dropwizard-guicier.version>
         <dropwizard-swagger.version>1.3.17-1</dropwizard-swagger.version>
         <eclipsecollections.version>10.2.0</eclipsecollections.version>


### PR DESCRIPTION
The 4.0.5 metrics version is incompatible with the version of the HealthCheck module and results in NoSuchMethodErrors during ser/deser of the Healthcheck result.