### PR TITLE
Send 403 instead of 401 when there is an auth issue with GitLab

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/auth/GitLabUserContext.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/auth/GitLabUserContext.java
@@ -107,7 +107,7 @@ public class GitLabUserContext extends UserContext
                         }
                         else
                         {
-                            throw new LegendSDLCServerException("{\"message\":\"Authorization required\",\"auth_uri\":\"/auth/authorize\"}", Status.UNAUTHORIZED);
+                            throw new LegendSDLCServerException("{\"message\":\"Authorization required\",\"auth_uri\":\"/auth/authorize\"}", Status.FORBIDDEN);
                         }
                     }
                     api = new GitLabApi(ApiVersion.V4, modeInfo.getServerInfo().getGitLabURLString(), TokenType.OAUTH2_ACCESS, accessToken);

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/auth/GitLabUserContext.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/auth/GitLabUserContext.java
@@ -93,7 +93,7 @@ public class GitLabUserContext extends UserContext
                             }
                             catch (GitLabAuthFailureException e)
                             {
-                                throw new LegendSDLCServerException(e.getMessage(), Status.UNAUTHORIZED, e);
+                                throw new LegendSDLCServerException(e.getMessage(), Status.FORBIDDEN, e);
                             }
                             catch (GitLabAuthException e)
                             {

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthResource.java
@@ -155,7 +155,7 @@ public class GitLabAuthResource extends BaseResource
                                         }
                                         case 401:
                                         {
-                                            errorStatus = Status.UNAUTHORIZED;
+                                            errorStatus = Status.FORBIDDEN;
                                             break;
                                         }
                                         default:


### PR DESCRIPTION
Send 403 instead of 401 when there is an issue with authentication or authorization with GitLab (but not with Legend SDLC). Sending a 401 confuses client browsers, which will interpret it as an authentication issue with Legend SDLC itself.