### PR TITLE
Configure failsafe v3-m5 to measure surefire module path bug

### DIFF
--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/server/AbstractGitLabServerApiTest.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/server/AbstractGitLabServerApiTest.java
@@ -116,9 +116,9 @@ public class AbstractGitLabServerApiTest
             }
             catch (Exception e)
             {
-                LOGGER.error("Failed to delete project id {}, name: {} during cleanup.", projectId, projectName);
+                LOGGER.error("Failed to delete project id {}, name: {} during cleanup.", projectId, projectName, e);
             }
-            LOGGER.info("Deleted test project id: {}, name: {}", projectId, projectName);
+            LOGGER.info("Handled test project id: {}, name: {}", projectId, projectName);
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,8 @@
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>3.0.0-M5</version>
                     <configuration>
+                        <!-- This is to measure the module path issue from maven failsafe V3.0.0-M5 that introduces NoClassDefFoundError
+                        during integration tests via failsafe; for reference: https://issues.apache.org/jira/browse/SUREFIRE-1831.-->
                         <useModulePath>false</useModulePath>
                         <trimStackTrace>false</trimStackTrace>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,8 @@
                     <version>3.0.0-M5</version>
                     <configuration>
                         <!-- This is to measure the module path issue from maven failsafe V3.0.0-M5 that introduces NoClassDefFoundError
-                        during integration tests via failsafe; for reference: https://issues.apache.org/jira/browse/SUREFIRE-1831.-->
+                        during integration tests via failsafe. Flag useModulePath should be set to false in order to disable modular paths.
+                        for reference: https://issues.apache.org/jira/browse/SUREFIRE-1831.-->
                         <useModulePath>false</useModulePath>
                         <trimStackTrace>false</trimStackTrace>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>3.0.0-M5</version>
                     <configuration>
+                        <useModulePath>false</useModulePath>
                         <trimStackTrace>false</trimStackTrace>
                     </configuration>
                     <executions>


### PR DESCRIPTION
Configure failsafe v3-m5 to measure surefire module path bug.