### PR TITLE
Revert "Remove SourceInformation from serialized entities (#245)"

### DIFF
--- a/legend-sdlc-protocol-pure/src/main/java/org/finos/legend/sdlc/protocol/pure/v1/PureEntitySerializer.java
+++ b/legend-sdlc-protocol-pure/src/main/java/org/finos/legend/sdlc/protocol/pure/v1/PureEntitySerializer.java
@@ -155,7 +155,7 @@ public class PureEntitySerializer implements EntityTextSerializer
 
     private PackageableElement deserializeToElement(String content)
     {
-        PureModelContextData pureModelContextData = this.pureParser.parseModel(content, false);
+        PureModelContextData pureModelContextData = this.pureParser.parseModel(content);
         List<PackageableElement> elements = pureModelContextData.getElements();
         switch (elements.size())
         {

--- a/legend-sdlc-protocol-pure/src/test/java/org/finos/legend/sdlc/protocol/pure/v1/TestPureEntitySerializer.java
+++ b/legend-sdlc-protocol-pure/src/test/java/org/finos/legend/sdlc/protocol/pure/v1/TestPureEntitySerializer.java
@@ -139,7 +139,7 @@ public class TestPureEntitySerializer
         assertTextEquivalent(pureCode, this.pureSerializer.serializeToString(fullEntity));
         Assert.assertTrue(this.pureSerializer.canSerialize(reducedEntity));
         assertTextEquivalent(pureCode, this.pureSerializer.serializeToString(reducedEntity));
-        assertEntitiesEqual(reducedEntity, this.pureSerializer.deserialize(pureCode));
+        assertEntitiesEqual(fullEntity, this.pureSerializer.deserialize(pureCode));
     }
 
     private void testPureSyntaxError(String expectedErrorMessage, String... names)

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/association/TestAssociation_reduced.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/association/TestAssociation_reduced.json
@@ -1,33 +1,31 @@
 {
-  "classifierPath" : "meta::pure::metamodel::relationship::Association",
-  "content" : {
-    "_type" : "association",
-    "name" : "TestAssociation",
-    "originalMilestonedProperties" : [ ],
-    "package" : "model::domain",
-    "properties" : [ {
-      "multiplicity" : {
-        "lowerBound" : 0
+  "classifierPath": "meta::pure::metamodel::relationship::Association",
+  "content": {
+    "_type": "association",
+    "name": "TestAssociation",
+    "package": "model::domain",
+    "properties": [
+      {
+        "multiplicity": {
+          "lowerBound": 0
+        },
+        "name": "employees",
+        "type": "model::domain::Person"
       },
-      "name" : "employees",
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "type" : "model::domain::Person"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 0,
-        "upperBound" : 1
-      },
-      "name" : "employer",
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "type" : "model::domain::Firm"
-    } ],
-    "qualifiedProperties" : [ ],
-    "stereotypes" : [ {
-      "profile" : "model::domain::TestProfile",
-      "value" : "stereotype1"
-    } ],
-    "taggedValues" : [ ]
+      {
+        "multiplicity": {
+          "lowerBound": 0,
+          "upperBound": 1
+        },
+        "name": "employer",
+        "type": "model::domain::Firm"
+      }
+    ],
+    "stereotypes": [
+      {
+        "profile": "model::domain::TestProfile",
+        "value": "stereotype1"
+      }
+    ]
   }
 }

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/class/TestClass_reduced.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/class/TestClass_reduced.json
@@ -1,95 +1,113 @@
 {
-  "classifierPath" : "meta::pure::metamodel::type::Class",
-  "content" : {
-    "_type" : "class",
-    "constraints" : [ ],
-    "name" : "TestClass",
-    "originalMilestonedProperties" : [ ],
-    "package" : "model::domain",
-    "properties" : [ {
-      "multiplicity" : {
-        "lowerBound" : 1,
-        "upperBound" : 1
-      },
-      "name" : "oneName",
-      "stereotypes" : [ {
-        "profile" : "model::domain::TestProfile",
-        "value" : "identifier"
-      } ],
-      "taggedValues" : [ {
-        "tag" : {
-          "profile" : "model::domain::TestProfile",
-          "value" : "tag1"
+  "classifierPath": "meta::pure::metamodel::type::Class",
+  "content": {
+    "_type": "class",
+    "name": "TestClass",
+    "package": "model::domain",
+    "properties": [
+      {
+        "multiplicity": {
+          "lowerBound": 1,
+          "upperBound": 1
         },
-        "value" : "some value"
-      }, {
-        "tag" : {
-          "profile" : "model::domain::TestProfile",
-          "value" : "tag2"
+        "name": "oneName",
+        "stereotypes": [
+          {
+            "profile": "model::domain::TestProfile",
+            "profileSourceInformation": {
+              "endColumn": 30,
+              "endLine": 3,
+              "sourceId": "",
+              "startColumn": 5,
+              "startLine": 3
+            },
+            "sourceInformation": {
+              "endColumn": 41,
+              "endLine": 3,
+              "sourceId": "",
+              "startColumn": 5,
+              "startLine": 3
+            },
+            "value": "identifier"
+          }
+        ],
+        "taggedValues": [
+          {
+            "tag": {
+              "profile": "model::domain::TestProfile",
+              "value": "tag1"
+            },
+            "value": "some value"
+          },
+          {
+            "tag": {
+              "profile": "model::domain::TestProfile",
+              "value": "tag2"
+            },
+            "value": "some other value"
+          }
+        ],
+        "type": "String"
+      },
+      {
+        "multiplicity": {
+          "lowerBound": 0,
+          "upperBound": 1
         },
-        "value" : "some other value"
-      } ],
-      "type" : "String"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 0,
-        "upperBound" : 1
+        "name": "anotherName",
+        "type": "String"
       },
-      "name" : "anotherName",
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "type" : "String"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 0,
-        "upperBound" : 1
-      },
-      "name" : "oneDate",
-      "stereotypes" : [ ],
-      "taggedValues" : [ {
-        "tag" : {
-          "profile" : "model::domain::TestProfile",
-          "value" : "tag1"
+      {
+        "multiplicity": {
+          "lowerBound": 0,
+          "upperBound": 1
         },
-        "value" : "some kind of date"
-      } ],
-      "type" : "StrictDate"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 0,
-        "upperBound" : 1
+        "name": "oneDate",
+        "taggedValues": [
+          {
+            "tag": {
+              "profile": "model::domain::TestProfile",
+              "value": "tag1"
+            },
+            "value": "some kind of date"
+          }
+        ],
+        "type": "StrictDate"
       },
-      "name" : "anotherDate",
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "type" : "DateTime"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 1,
-        "upperBound" : 1
+      {
+        "multiplicity": {
+          "lowerBound": 0,
+          "upperBound": 1
+        },
+        "name": "anotherDate",
+        "type": "DateTime"
       },
-      "name" : "oneNumber",
-      "stereotypes" : [ {
-        "profile" : "model::domain::TestProfile",
-        "value" : "stereotype1"
-      }, {
-        "profile" : "model::domain::TestProfile",
-        "value" : "stereotype2"
-      } ],
-      "taggedValues" : [ ],
-      "type" : "Integer"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 0
+      {
+        "multiplicity": {
+          "lowerBound": 1,
+          "upperBound": 1
+        },
+        "name": "oneNumber",
+        "stereotypes": [
+          {
+            "profile": "model::domain::TestProfile",
+            "value": "stereotype1"
+          },
+          {
+            "profile": "model::domain::TestProfile",
+            "value": "stereotype2"
+          }
+        ],
+        "taggedValues": [],
+        "type": "Integer"
       },
-      "name" : "moreNumbers",
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "type" : "Float"
-    } ],
-    "qualifiedProperties" : [ ],
-    "stereotypes" : [ ],
-    "superTypes" : [ ],
-    "taggedValues" : [ ]
+      {
+        "multiplicity": {
+          "lowerBound": 0
+        },
+        "name": "moreNumbers",
+        "type": "Float"
+      }
+    ]
   }
 }

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/enumeration/TestEnumeration_reduced.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/enumeration/TestEnumeration_reduced.json
@@ -1,54 +1,67 @@
 {
-  "classifierPath" : "meta::pure::metamodel::type::Enumeration",
-  "content" : {
-    "_type" : "Enumeration",
-    "name" : "TestEnumeration",
-    "package" : "model::domain",
-    "stereotypes" : [ ],
-    "taggedValues" : [ ],
-    "values" : [ {
-      "stereotypes" : [ {
-        "profile" : "model::domain::TestProfile",
-        "value" : "stereotype1"
-      } ],
-      "taggedValues" : [ ],
-      "value" : "VALUE1"
-    }, {
-      "stereotypes" : [ ],
-      "taggedValues" : [ {
-        "tag" : {
-          "profile" : "model::domain::TestProfile",
-          "value" : "tag1"
-        },
-        "value" : "some value"
-      } ],
-      "value" : "VALUE2"
-    }, {
-      "stereotypes" : [ {
-        "profile" : "model::domain::TestProfile",
-        "value" : "stereotype1"
-      }, {
-        "profile" : "model::domain::TestProfile",
-        "value" : "stereotype2"
-      } ],
-      "taggedValues" : [ {
-        "tag" : {
-          "profile" : "model::domain::TestProfile",
-          "value" : "tag1"
-        },
-        "value" : "some other value"
-      }, {
-        "tag" : {
-          "profile" : "model::domain::TestProfile",
-          "value" : "tag2"
-        },
-        "value" : "yet another value"
-      } ],
-      "value" : "VALUE3"
-    }, {
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "value" : "VALUE4"
-    } ]
+  "classifierPath": "meta::pure::metamodel::type::Enumeration",
+  "content": {
+    "_type": "Enumeration",
+    "name": "TestEnumeration",
+    "package": "model::domain",
+    "values": [
+      {
+        "stereotypes": [
+          {
+            "profile": "model::domain::TestProfile",
+            "value": "stereotype1"
+          }
+        ],
+        "taggedValues": [],
+        "value": "VALUE1"
+      },
+      {
+        "stereotypes": [],
+        "taggedValues": [
+          {
+            "tag": {
+              "profile": "model::domain::TestProfile",
+              "value": "tag1"
+            },
+            "value": "some value"
+          }
+        ],
+        "value": "VALUE2"
+      },
+      {
+        "stereotypes": [
+          {
+            "profile": "model::domain::TestProfile",
+            "value": "stereotype1"
+          },
+          {
+            "profile": "model::domain::TestProfile",
+            "value": "stereotype2"
+          }
+        ],
+        "taggedValues": [
+          {
+            "tag": {
+              "profile": "model::domain::TestProfile",
+              "value": "tag1"
+            },
+            "value": "some other value"
+          },
+          {
+            "tag": {
+              "profile": "model::domain::TestProfile",
+              "value": "tag2"
+            },
+            "value": "yet another value"
+          }
+        ],
+        "value": "VALUE3"
+      },
+      {
+        "stereotypes": [],
+        "taggedValues": [],
+        "value": "VALUE4"
+      }
+    ]
   }
 }

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/m2m/TestMapping_reduced.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/m2m/TestMapping_reduced.json
@@ -1,206 +1,328 @@
 {
-  "classifierPath" : "meta::pure::mapping::Mapping",
-  "content" : {
-    "_type" : "mapping",
-    "associationMappings" : [ ],
-    "classMappings" : [ {
-      "_type" : "pureInstance",
-      "class" : "model::domain::TargetClass1",
-      "id" : "tc1",
-      "propertyMappings" : [ {
-        "_type" : "purePropertyMapping",
-        "explodeProperty" : false,
-        "property" : {
-          "class" : "model::domain::TargetClass1",
-          "property" : "id"
-        },
-        "source" : "tc1",
-        "transform" : {
-          "_type" : "lambda",
-          "body" : [ {
-            "_type" : "property",
-            "parameters" : [ {
-              "_type" : "var",
-              "name" : "src"
-            } ],
-            "property" : "id"
-          } ],
-          "parameters" : [ ]
-        }
-      }, {
-        "_type" : "purePropertyMapping",
-        "enumMappingId" : "TestEnumerationMappingInt",
-        "explodeProperty" : false,
-        "property" : {
-          "class" : "model::domain::TargetClass1",
-          "property" : "type"
-        },
-        "source" : "tc1",
-        "transform" : {
-          "_type" : "lambda",
-          "body" : [ {
-            "_type" : "property",
-            "parameters" : [ {
-              "_type" : "var",
-              "name" : "src"
-            } ],
-            "property" : "type"
-          } ],
-          "parameters" : [ ]
-        }
-      }, {
-        "_type" : "purePropertyMapping",
-        "enumMappingId" : "TestEnumerationMappingString",
-        "explodeProperty" : false,
-        "property" : {
-          "class" : "model::domain::TargetClass1",
-          "property" : "otherType"
-        },
-        "source" : "tc1",
-        "transform" : {
-          "_type" : "lambda",
-          "body" : [ {
-            "_type" : "property",
-            "parameters" : [ {
-              "_type" : "var",
-              "name" : "src"
-            } ],
-            "property" : "otherType"
-          } ],
-          "parameters" : [ ]
-        }
-      }, {
-        "_type" : "purePropertyMapping",
-        "explodeProperty" : false,
-        "property" : {
-          "class" : "model::domain::TargetClass1",
-          "property" : "other"
-        },
-        "source" : "tc1",
-        "target" : "tc2",
-        "transform" : {
-          "_type" : "lambda",
-          "body" : [ {
-            "_type" : "property",
-            "parameters" : [ {
-              "_type" : "var",
-              "name" : "src"
-            } ],
-            "property" : "other"
-          } ],
-          "parameters" : [ ]
-        }
-      } ],
-      "root" : false,
-      "srcClass" : "model::domain::SourceClass1"
-    }, {
-      "_type" : "pureInstance",
-      "class" : "model::domain::TargetClass2",
-      "id" : "tc2",
-      "propertyMappings" : [ {
-        "_type" : "purePropertyMapping",
-        "explodeProperty" : false,
-        "property" : {
-          "class" : "model::domain::TargetClass2",
-          "property" : "id"
-        },
-        "source" : "tc2",
-        "transform" : {
-          "_type" : "lambda",
-          "body" : [ {
-            "_type" : "property",
-            "parameters" : [ {
-              "_type" : "var",
-              "name" : "src"
-            } ],
-            "property" : "id"
-          } ],
-          "parameters" : [ ]
-        }
-      }, {
-        "_type" : "purePropertyMapping",
-        "explodeProperty" : false,
-        "property" : {
-          "class" : "model::domain::TargetClass2",
-          "property" : "name"
-        },
-        "source" : "tc2",
-        "transform" : {
-          "_type" : "lambda",
-          "body" : [ {
-            "_type" : "func",
-            "function" : "toLowerCase",
-            "parameters" : [ {
-              "_type" : "property",
-              "parameters" : [ {
-                "_type" : "var",
-                "name" : "src"
-              } ],
-              "property" : "name"
-            } ]
-          } ],
-          "parameters" : [ ]
-        }
-      } ],
-      "root" : false,
-      "srcClass" : "model::domain::SourceClass2"
-    } ],
-    "enumerationMappings" : [ {
-      "enumValueMappings" : [ {
-        "enumValue" : "TYPE1",
-        "sourceValues" : [ {
-          "_type" : "integerSourceValue",
-          "value" : 100
-        } ]
-      }, {
-        "enumValue" : "TYPE2",
-        "sourceValues" : [ {
-          "_type" : "integerSourceValue",
-          "value" : 200
-        } ]
-      }, {
-        "enumValue" : "TYPE3",
-        "sourceValues" : [ {
-          "_type" : "integerSourceValue",
-          "value" : 300
-        }, {
-          "_type" : "integerSourceValue",
-          "value" : 400
-        } ]
-      } ],
-      "enumeration" : "model::domain::TestEnumeration",
-      "id" : "TestEnumerationMappingInt"
-    }, {
-      "enumValueMappings" : [ {
-        "enumValue" : "TYPE1",
-        "sourceValues" : [ {
-          "_type" : "stringSourceValue",
-          "value" : "abc"
-        } ]
-      }, {
-        "enumValue" : "TYPE2",
-        "sourceValues" : [ {
-          "_type" : "stringSourceValue",
-          "value" : "def"
-        }, {
-          "_type" : "stringSourceValue",
-          "value" : "ghi"
-        } ]
-      }, {
-        "enumValue" : "TYPE3",
-        "sourceValues" : [ {
-          "_type" : "stringSourceValue",
-          "value" : "jlk"
-        } ]
-      } ],
-      "enumeration" : "model::domain::TestEnumeration",
-      "id" : "TestEnumerationMappingString"
-    } ],
-    "includedMappings" : [ {
-      "includedMapping" : "model::mapping::OtherMapping"
-    } ],
-    "name" : "TestMapping",
-    "package" : "model::mapping",
-    "tests" : [ ]
+  "classifierPath": "meta::pure::mapping::Mapping",
+  "content": {
+    "_type": "mapping",
+    "classMappings": [
+      {
+        "_type": "pureInstance",
+        "class": "model::domain::TargetClass1",
+        "id": "tc1",
+        "propertyMappings": [
+          {
+            "_type": "purePropertyMapping",
+            "explodeProperty": false,
+            "property": {
+              "class": "model::domain::TargetClass1",
+              "property": "id"
+            },
+            "source": "tc1",
+            "transform": {
+              "_type": "lambda",
+              "body": [
+                {
+                  "_type": "property",
+                  "parameters": [
+                    {
+                      "_type": "var",
+                      "name": "src"
+                    }
+                  ],
+                  "property": "id"
+                }
+              ],
+              "parameters": [
+                {
+                  "_type": "var",
+                  "class": "model::domain::SourceClass1",
+                  "multiplicity": {
+                    "lowerBound": 1,
+                    "upperBound": 1
+                  },
+                  "name": "src"
+                }
+              ]
+            }
+          },
+          {
+            "_type": "purePropertyMapping",
+            "enumMappingId": "TestEnumerationMappingInt",
+            "explodeProperty": false,
+            "property": {
+              "class": "model::domain::TargetClass1",
+              "property": "type"
+            },
+            "source": "tc1",
+            "transform": {
+              "_type": "lambda",
+              "body": [
+                {
+                  "_type": "property",
+                  "parameters": [
+                    {
+                      "_type": "var",
+                      "name": "src"
+                    }
+                  ],
+                  "property": "type"
+                }
+              ],
+              "parameters": [
+                {
+                  "_type": "var",
+                  "class": "model::domain::SourceClass1",
+                  "multiplicity": {
+                    "lowerBound": 1,
+                    "upperBound": 1
+                  },
+                  "name": "src"
+                }
+              ]
+            }
+          },
+          {
+            "_type": "purePropertyMapping",
+            "enumMappingId": "TestEnumerationMappingString",
+            "explodeProperty": false,
+            "property": {
+              "class": "model::domain::TargetClass1",
+              "property": "otherType"
+            },
+            "source": "tc1",
+            "transform": {
+              "_type": "lambda",
+              "body": [
+                {
+                  "_type": "property",
+                  "parameters": [
+                    {
+                      "_type": "var",
+                      "name": "src"
+                    }
+                  ],
+                  "property": "otherType"
+                }
+              ],
+              "parameters": [
+                {
+                  "_type": "var",
+                  "class": "model::domain::SourceClass1",
+                  "multiplicity": {
+                    "lowerBound": 1,
+                    "upperBound": 1
+                  },
+                  "name": "src"
+                }
+              ]
+            }
+          },
+          {
+            "_type": "purePropertyMapping",
+            "explodeProperty": false,
+            "property": {
+              "class": "model::domain::TargetClass1",
+              "property": "other"
+            },
+            "source": "tc1",
+            "target": "tc2",
+            "transform": {
+              "_type": "lambda",
+              "body": [
+                {
+                  "_type": "property",
+                  "parameters": [
+                    {
+                      "_type": "var",
+                      "name": "src"
+                    }
+                  ],
+                  "property": "other"
+                }
+              ],
+              "parameters": [
+                {
+                  "_type": "var",
+                  "class": "model::domain::SourceClass1",
+                  "multiplicity": {
+                    "lowerBound": 1,
+                    "upperBound": 1
+                  },
+                  "name": "src"
+                }
+              ]
+            }
+          }
+        ],
+        "root": false,
+        "srcClass": "model::domain::SourceClass1"
+      },
+      {
+        "_type": "pureInstance",
+        "class": "model::domain::TargetClass2",
+        "id": "tc2",
+        "propertyMappings": [
+          {
+            "_type": "purePropertyMapping",
+            "explodeProperty": false,
+            "property": {
+              "class": "model::domain::TargetClass2",
+              "property": "id"
+            },
+            "source": "tc2",
+            "transform": {
+              "_type": "lambda",
+              "body": [
+                {
+                  "_type": "property",
+                  "parameters": [
+                    {
+                      "_type": "var",
+                      "name": "src"
+                    }
+                  ],
+                  "property": "id"
+                }
+              ],
+              "parameters": [
+                {
+                  "_type": "var",
+                  "class": "model::domain::SourceClass2",
+                  "multiplicity": {
+                    "lowerBound": 1,
+                    "upperBound": 1
+                  },
+                  "name": "src"
+                }
+              ]
+            }
+          },
+          {
+            "_type": "purePropertyMapping",
+            "explodeProperty": false,
+            "property": {
+              "class": "model::domain::TargetClass2",
+              "property": "name"
+            },
+            "source": "tc2",
+            "transform": {
+              "_type": "lambda",
+              "body": [
+                {
+                  "_type": "func",
+                  "function": "toLowerCase",
+                  "parameters": [
+                    {
+                      "_type": "property",
+                      "parameters": [
+                        {
+                          "_type": "var",
+                          "name": "src"
+                        }
+                      ],
+                      "property": "name"
+                    }
+                  ]
+                }
+              ],
+              "parameters": [
+                {
+                  "_type": "var",
+                  "class": "model::domain::SourceClass2",
+                  "multiplicity": {
+                    "lowerBound": 1,
+                    "upperBound": 1
+                  },
+                  "name": "src"
+                }
+              ]
+            }
+          }
+        ],
+        "root": false,
+        "srcClass": "model::domain::SourceClass2"
+      }
+    ],
+    "enumerationMappings": [
+      {
+        "enumValueMappings": [
+          {
+            "enumValue": "TYPE1",
+            "sourceValues": [
+              {
+                "_type": "integerSourceValue",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "enumValue": "TYPE2",
+            "sourceValues": [
+              {
+                "_type": "integerSourceValue",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "enumValue": "TYPE3",
+            "sourceValues": [
+              {
+                "_type": "integerSourceValue",
+                "value": 300
+              },
+              {
+                "_type": "integerSourceValue",
+                "value": 400
+              }
+            ]
+          }
+        ],
+        "enumeration": "model::domain::TestEnumeration",
+        "id": "TestEnumerationMappingInt"
+      },
+      {
+        "enumValueMappings": [
+          {
+            "enumValue": "TYPE1",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "abc"
+              }
+            ]
+          },
+          {
+            "enumValue": "TYPE2",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "def"
+              },
+              {
+                "_type": "stringSourceValue",
+                "value": "ghi"
+              }
+            ]
+          },
+          {
+            "enumValue": "TYPE3",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "jlk"
+              }
+            ]
+          }
+        ],
+        "enumeration": "model::domain::TestEnumeration",
+        "id": "TestEnumerationMappingString"
+      }
+    ],
+    "includedMappings": [
+      {
+        "includedMapping": "model::mapping::OtherMapping"
+      }
+    ],
+    "name": "TestMapping",
+    "package": "model::mapping"
   }
 }

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/relational/TestMapping_reduced.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/relational/TestMapping_reduced.json
@@ -1,199 +1,235 @@
 {
-  "classifierPath" : "meta::pure::mapping::Mapping",
-  "content" : {
-    "_type" : "mapping",
-    "associationMappings" : [ ],
-    "classMappings" : [ {
-      "_type" : "relational",
-      "class" : "model::domain::TargetClass1",
-      "distinct" : false,
-      "groupBy" : [ ],
-      "id" : "tc1",
-      "primaryKey" : [ ],
-      "propertyMappings" : [ {
-        "_type" : "relationalPropertyMapping",
-        "property" : {
-          "class" : "model::domain::TargetClass1",
-          "property" : "id"
-        },
-        "relationalOperation" : {
-          "_type" : "column",
-          "column" : "id",
-          "table" : {
-            "_type" : "Table",
-            "database" : "model::domain::TestDatabase",
-            "mainTableDb" : "model::domain::TestDatabase",
-            "schema" : "default",
-            "table" : "Table1"
-          },
-          "tableAlias" : "Table1"
-        },
-        "source" : "tc1"
-      }, {
-        "_type" : "relationalPropertyMapping",
-        "enumMappingId" : "TestEnumerationMappingInt",
-        "property" : {
-          "class" : "model::domain::TargetClass1",
-          "property" : "type"
-        },
-        "relationalOperation" : {
-          "_type" : "column",
-          "column" : "type",
-          "table" : {
-            "_type" : "Table",
-            "database" : "model::domain::TestDatabase",
-            "mainTableDb" : "model::domain::TestDatabase",
-            "schema" : "default",
-            "table" : "Table1"
-          },
-          "tableAlias" : "Table1"
-        },
-        "source" : "tc1"
-      }, {
-        "_type" : "relationalPropertyMapping",
-        "enumMappingId" : "TestEnumerationMappingString",
-        "property" : {
-          "class" : "model::domain::TargetClass1",
-          "property" : "otherType"
-        },
-        "relationalOperation" : {
-          "_type" : "column",
-          "column" : "otherType",
-          "table" : {
-            "_type" : "Table",
-            "database" : "model::domain::TestDatabase",
-            "mainTableDb" : "model::domain::TestDatabase",
-            "schema" : "default",
-            "table" : "Table1"
-          },
-          "tableAlias" : "Table1"
-        },
-        "source" : "tc1"
-      }, {
-        "_type" : "relationalPropertyMapping",
-        "property" : {
-          "class" : "model::domain::TargetClass1",
-          "property" : "other"
-        },
-        "relationalOperation" : {
-          "_type" : "elemtWithJoins",
-          "joins" : [ {
-            "db" : "model::domain::TestDatabase",
-            "name" : "Table1_Table2"
-          } ]
-        },
-        "source" : "tc1",
-        "target" : "tc2"
-      } ],
-      "root" : false
-    }, {
-      "_type" : "relational",
-      "class" : "model::domain::TargetClass2",
-      "distinct" : false,
-      "groupBy" : [ ],
-      "id" : "tc2",
-      "primaryKey" : [ ],
-      "propertyMappings" : [ {
-        "_type" : "relationalPropertyMapping",
-        "property" : {
-          "class" : "model::domain::TargetClass2",
-          "property" : "id"
-        },
-        "relationalOperation" : {
-          "_type" : "column",
-          "column" : "id",
-          "table" : {
-            "_type" : "Table",
-            "database" : "model::domain::TestDatabase",
-            "mainTableDb" : "model::domain::TestDatabase",
-            "schema" : "default",
-            "table" : "Table2"
-          },
-          "tableAlias" : "Table2"
-        },
-        "source" : "tc2"
-      }, {
-        "_type" : "relationalPropertyMapping",
-        "property" : {
-          "class" : "model::domain::TargetClass2",
-          "property" : "name"
-        },
-        "relationalOperation" : {
-          "_type" : "dynaFunc",
-          "funcName" : "lower",
-          "parameters" : [ {
-            "_type" : "column",
-            "column" : "name",
-            "table" : {
-              "_type" : "Table",
-              "database" : "model::domain::TestDatabase",
-              "mainTableDb" : "model::domain::TestDatabase",
-              "schema" : "default",
-              "table" : "Table2"
+  "classifierPath": "meta::pure::mapping::Mapping",
+  "content": {
+    "_type": "mapping",
+    "classMappings": [
+      {
+        "_type": "relational",
+        "class": "model::domain::TargetClass1",
+        "distinct": false,
+        "id": "tc1",
+        "propertyMappings": [
+          {
+            "_type": "relationalPropertyMapping",
+            "property": {
+              "class": "model::domain::TargetClass1",
+              "property": "id"
             },
-            "tableAlias" : "Table2"
-          } ]
-        },
-        "source" : "tc2"
-      } ],
-      "root" : false
-    } ],
-    "enumerationMappings" : [ {
-      "enumValueMappings" : [ {
-        "enumValue" : "TYPE1",
-        "sourceValues" : [ {
-          "_type" : "integerSourceValue",
-          "value" : 100
-        } ]
-      }, {
-        "enumValue" : "TYPE2",
-        "sourceValues" : [ {
-          "_type" : "integerSourceValue",
-          "value" : 200
-        } ]
-      }, {
-        "enumValue" : "TYPE3",
-        "sourceValues" : [ {
-          "_type" : "integerSourceValue",
-          "value" : 300
-        }, {
-          "_type" : "integerSourceValue",
-          "value" : 400
-        } ]
-      } ],
-      "enumeration" : "model::domain::TestEnumeration",
-      "id" : "TestEnumerationMappingInt"
-    }, {
-      "enumValueMappings" : [ {
-        "enumValue" : "TYPE1",
-        "sourceValues" : [ {
-          "_type" : "stringSourceValue",
-          "value" : "abc"
-        } ]
-      }, {
-        "enumValue" : "TYPE2",
-        "sourceValues" : [ {
-          "_type" : "stringSourceValue",
-          "value" : "def"
-        }, {
-          "_type" : "stringSourceValue",
-          "value" : "ghi"
-        } ]
-      }, {
-        "enumValue" : "TYPE3",
-        "sourceValues" : [ {
-          "_type" : "stringSourceValue",
-          "value" : "jlk"
-        } ]
-      } ],
-      "enumeration" : "model::domain::TestEnumeration",
-      "id" : "TestEnumerationMappingString"
-    } ],
-    "includedMappings" : [ {
-      "includedMapping" : "model::mapping::OtherMapping"
-    } ],
-    "name" : "TestMapping",
-    "package" : "model::mapping",
-    "tests" : [ ]
+            "relationalOperation": {
+              "_type": "column",
+              "column": "id",
+              "table": {
+                "_type": "Table",
+                "database": "model::domain::TestDatabase",
+                "mainTableDb": "model::domain::TestDatabase",
+                "schema": "default",
+                "table": "Table1"
+              },
+              "tableAlias": "Table1"
+            },
+            "source": "tc1"
+          },
+          {
+            "_type": "relationalPropertyMapping",
+            "enumMappingId": "TestEnumerationMappingInt",
+            "property": {
+              "class": "model::domain::TargetClass1",
+              "property": "type"
+            },
+            "relationalOperation": {
+              "_type": "column",
+              "column": "type",
+              "table": {
+                "_type": "Table",
+                "database": "model::domain::TestDatabase",
+                "mainTableDb": "model::domain::TestDatabase",
+                "schema": "default",
+                "table": "Table1"
+              },
+              "tableAlias": "Table1"
+            },
+            "source": "tc1"
+          },
+          {
+            "_type": "relationalPropertyMapping",
+            "enumMappingId": "TestEnumerationMappingString",
+            "property": {
+              "class": "model::domain::TargetClass1",
+              "property": "otherType"
+            },
+            "relationalOperation": {
+              "_type": "column",
+              "column": "otherType",
+              "table": {
+                "_type": "Table",
+                "database": "model::domain::TestDatabase",
+                "mainTableDb": "model::domain::TestDatabase",
+                "schema": "default",
+                "table": "Table1"
+              },
+              "tableAlias": "Table1"
+            },
+            "source": "tc1"
+          },
+          {
+            "_type": "relationalPropertyMapping",
+            "property": {
+              "class": "model::domain::TargetClass1",
+              "property": "other"
+            },
+            "relationalOperation": {
+              "_type": "elemtWithJoins",
+              "joins": [
+                {
+                  "db": "model::domain::TestDatabase",
+                  "name": "Table1_Table2"
+                }
+              ]
+            },
+            "source": "tc1",
+            "target": "tc2"
+          }
+        ],
+        "root": false
+      },
+      {
+        "_type": "relational",
+        "class": "model::domain::TargetClass2",
+        "distinct": false,
+        "id": "tc2",
+        "propertyMappings": [
+          {
+            "_type": "relationalPropertyMapping",
+            "property": {
+              "class": "model::domain::TargetClass2",
+              "property": "id"
+            },
+            "relationalOperation": {
+              "_type": "column",
+              "column": "id",
+              "table": {
+                "_type": "Table",
+                "database": "model::domain::TestDatabase",
+                "mainTableDb": "model::domain::TestDatabase",
+                "schema": "default",
+                "table": "Table2"
+              },
+              "tableAlias": "Table2"
+            },
+            "source": "tc2"
+          },
+          {
+            "_type": "relationalPropertyMapping",
+            "property": {
+              "class": "model::domain::TargetClass2",
+              "property": "name"
+            },
+            "relationalOperation": {
+              "_type": "dynaFunc",
+              "funcName": "lower",
+              "parameters": [
+                {
+                  "_type": "column",
+                  "column": "name",
+                  "table": {
+                    "_type": "Table",
+                    "database": "model::domain::TestDatabase",
+                    "mainTableDb": "model::domain::TestDatabase",
+                    "schema": "default",
+                    "table": "Table2"
+                  },
+                  "tableAlias": "Table2"
+                }
+              ]
+            },
+            "source": "tc2"
+          }
+        ],
+        "root": false
+      }
+    ],
+    "enumerationMappings": [
+      {
+        "enumValueMappings": [
+          {
+            "enumValue": "TYPE1",
+            "sourceValues": [
+              {
+                "_type": "integerSourceValue",
+                "value": 100
+              }
+            ]
+          },
+          {
+            "enumValue": "TYPE2",
+            "sourceValues": [
+              {
+                "_type": "integerSourceValue",
+                "value": 200
+              }
+            ]
+          },
+          {
+            "enumValue": "TYPE3",
+            "sourceValues": [
+              {
+                "_type": "integerSourceValue",
+                "value": 300
+              },
+              {
+                "_type": "integerSourceValue",
+                "value": 400
+              }
+            ]
+          }
+        ],
+        "enumeration": "model::domain::TestEnumeration",
+        "id": "TestEnumerationMappingInt"
+      },
+      {
+        "enumValueMappings": [
+          {
+            "enumValue": "TYPE1",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "abc"
+              }
+            ]
+          },
+          {
+            "enumValue": "TYPE2",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "def"
+              },
+              {
+                "_type": "stringSourceValue",
+                "value": "ghi"
+              }
+            ]
+          },
+          {
+            "enumValue": "TYPE3",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "jlk"
+              }
+            ]
+          }
+        ],
+        "enumeration": "model::domain::TestEnumeration",
+        "id": "TestEnumerationMappingString"
+      }
+    ],
+    "includedMappings": [
+      {
+        "includedMapping": "model::mapping::OtherMapping"
+      }
+    ],
+    "name": "TestMapping",
+    "package": "model::mapping"
   }
 }


### PR DESCRIPTION
This reverts commit c808552bf5b7e512370f8232c9a34bb0a0fdbbd3.
Reverting as the corresponding change in legend-engine https://github.com/finos/legend-engine/pull/339 is incomplete and requires relational parse tree walkers to be updated to handle no source information