### PR TITLE
Make GitLab Docker tests as PR and master push optional checks.

### DIFF
--- a/.github/workflows/gitlab-docker-int-test-latest-twelve.yml
+++ b/.github/workflows/gitlab-docker-int-test-latest-twelve.yml
@@ -23,6 +23,12 @@ env:
 on:
   schedule:
     - cron: '0 20 * * *' # daily at 20:00 UTC
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - "**"
   workflow_dispatch:
     inputs:
       logLevel:

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApiTestResource.java
@@ -170,8 +170,8 @@ public class GitLabEntityApiTestResource
         CallUntil<MergeRequest, GitLabApiException> callUntil = CallUntil.callUntil(
                 () -> mergeRequestApi.getMergeRequest(gitlabProjectId, parsedMergeRequestId),
                 mr -> requiredStatus.equals(mr.getMergeStatus()),
-                10,
-                500);
+                20,
+                1000);
         if (!callUntil.succeeded())
         {
             throw new RuntimeException("Merge request " + approvedReview.getId() + " still does not have status \"" + requiredStatus + "\" after " + callUntil.getTryCount() + " tries");
@@ -318,8 +318,8 @@ public class GitLabEntityApiTestResource
         CallUntil<MergeRequest, GitLabApiException> callUntil = CallUntil.callUntil(
                 () -> mergeRequestApi.getMergeRequest(gitlabProjectId, parsedMergeRequestId),
                 mr -> requiredStatus.equals(mr.getMergeStatus()),
-                10,
-                500);
+                20,
+                1000);
         if (!callUntil.succeeded())
         {
             throw new RuntimeException("Merge request " + approvedReview.getId() + " still does not have status \"" + requiredStatus + "\" after " + callUntil.getTryCount() + " tries");

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabWorkspaceApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabWorkspaceApiTestResource.java
@@ -215,8 +215,8 @@ public class GitLabWorkspaceApiTestResource
         CallUntil<MergeRequest, GitLabApiException> callUntil = CallUntil.callUntil(
                 () -> mergeRequestApi.getMergeRequest(gitlabProjectId, parsedMergeRequestId),
                 mr -> requiredStatus.equals(mr.getMergeStatus()),
-                10,
-                500);
+                20,
+                1000);
         if (!callUntil.succeeded())
         {
             throw new RuntimeException("Merge request " + approvedReview.getId() + " still does not have status \"" + requiredStatus + "\" after " + callUntil.getTryCount() + " tries");
@@ -353,8 +353,8 @@ public class GitLabWorkspaceApiTestResource
         CallUntil<MergeRequest, GitLabApiException> callUntil = CallUntil.callUntil(
                 () -> mergeRequestApi.getMergeRequest(gitlabProjectId, parsedMergeRequestId),
                 mr -> requiredStatus.equals(mr.getMergeStatus()),
-                10,
-                500);
+                20,
+                1000);
         if (!callUntil.succeeded())
         {
             throw new RuntimeException("Merge request " + approvedReview.getId() + " still does not have status \"" + requiredStatus + "\" after " + callUntil.getTryCount() + " tries");


### PR DESCRIPTION
- Make GitLab integration tests for three versions (nightly, latest, latest-12) Docker images PR and master push optional checks.
- Relax merge check on certain integration tests for better visibility.