### PR TITLE
upgrade Dockerfile to use standard openjdk image

### DIFF
--- a/legend-sdlc-server/Dockerfile
+++ b/legend-sdlc-server/Dockerfile
@@ -1,3 +1,7 @@
-FROM openjdk:11.0.12-bullseye
+FROM openjdk:11.0.12
 COPY target/legend-sdlc-server-*-shaded.jar /app/bin/
-CMD java -XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=60 -Xss4M -cp /app/bin/*.jar -Dfile.encoding=UTF8 org.finos.legend.sdlc.server.LegendSDLCServer server /config/config.json
+CMD java -cp /app/bin/*.jar \
+-XX:+ExitOnOutOfMemoryError \
+-XX:MaxRAMPercentage=60 \
+-Xss4M -Dfile.encoding=UTF8 \
+org.finos.legend.sdlc.server.LegendSDLCServer server /config/config.json


### PR DESCRIPTION
Use `openjdk:11.0.12` instead of `openjdk:11.0.12-bullseye` as `openjdk:11.0.12` already uses `bullseye`