### PR TITLE
Improve error handling in TestModelBuilder and add more tests

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/depot/api/DepotMetadataApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/depot/api/DepotMetadataApi.java
@@ -55,7 +55,7 @@ public class DepotMetadataApi extends BaseDepotApi implements MetadataApi
     }
 
     @Override
-    public List<Entity> getEntities(String projectId, String versionId)
+    public List<Entity> getEntities(DepotProjectId projectId, String versionId)
     {
         LegendSDLCServerException.validateNonNull(projectId, "Project id may be null");
         LegendSDLCServerException.validateNonNull(versionId, "Version id may be null");
@@ -74,7 +74,7 @@ public class DepotMetadataApi extends BaseDepotApi implements MetadataApi
     }
 
     @Override
-    public Set<DepotProjectVersion> getProjectDependencies(String projectId, String versionId, boolean transitive)
+    public Set<DepotProjectVersion> getProjectDependencies(DepotProjectId projectId, String versionId, boolean transitive)
     {
         LegendSDLCServerException.validateNonNull(projectId, "Project id may be null");
         LegendSDLCServerException.validateNonNull(versionId, "Version id may be null");
@@ -93,12 +93,9 @@ public class DepotMetadataApi extends BaseDepotApi implements MetadataApi
         }
     }
 
-    private HttpGet prepareGetRequest(String projectId, String versionId, String requestPatch, List<NameValuePair> parameters)
+    private HttpGet prepareGetRequest(DepotProjectId projectId, String versionId, String requestPatch, List<NameValuePair> parameters)
     {
-        DepotProjectId depotProjectId = DepotProjectId.parseProjectId(projectId);
-        LegendSDLCServerException.validateNonNull(depotProjectId, "Project id may be null");
-
-        String path = String.format(requestPatch, depotProjectId.getGroupId(), depotProjectId.getArtifactId(), versionId);
+        String path = String.format(requestPatch, projectId.getGroupId(), projectId.getArtifactId(), versionId);
         URI uri = buildURI(path, parameters);
 
         return new HttpGet(uri);

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/depot/api/DepotMetadataApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/depot/api/DepotMetadataApi.java
@@ -46,7 +46,7 @@ public class DepotMetadataApi extends BaseDepotApi implements MetadataApi
     private final JsonMapper jsonMapper = JsonMapper.builder().addMixIn(Entity.class, EntityMixIn.class).build();
 
     private static final String GET_ENTITIES_PATH = "/api/projects/%s/%s/versions/%s";
-    private static final String GET_DEPENDENCIES_PATH = "/api/projects/%s/%s/version/%s/projectDependencies";
+    private static final String GET_DEPENDENCIES_PATH = "/api/projects/%s/%s/versions/%s/projectDependencies";
 
     @Inject
     public DepotMetadataApi(DepotConfiguration configuration)

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/depot/api/DepotMetadataApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/depot/api/DepotMetadataApi.java
@@ -46,7 +46,7 @@ public class DepotMetadataApi extends BaseDepotApi implements MetadataApi
     private final JsonMapper jsonMapper = JsonMapper.builder().addMixIn(Entity.class, EntityMixIn.class).build();
 
     private static final String GET_ENTITIES_PATH = "/api/projects/%s/%s/versions/%s";
-    private static final String GET_DEPENDENCIES_PATH = "/api/projects/%s/%s/versions/%s/projectDependencies";
+    private static final String GET_DEPENDENCIES_PATH = "/api/projects/%s/%s/version/%s/projectDependencies";
 
     @Inject
     public DepotMetadataApi(DepotConfiguration configuration)

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/depot/api/DepotMetadataApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/depot/api/DepotMetadataApi.java
@@ -93,9 +93,9 @@ public class DepotMetadataApi extends BaseDepotApi implements MetadataApi
         }
     }
 
-    private HttpGet prepareGetRequest(DepotProjectId projectId, String versionId, String requestPatch, List<NameValuePair> parameters)
+    private HttpGet prepareGetRequest(DepotProjectId projectId, String versionId, String requestPath, List<NameValuePair> parameters)
     {
-        String path = String.format(requestPatch, projectId.getGroupId(), projectId.getArtifactId(), versionId);
+        String path = String.format(requestPath, projectId.getGroupId(), projectId.getArtifactId(), versionId);
         URI uri = buildURI(path, parameters);
 
         return new HttpGet(uri);

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/depot/api/MetadataApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/depot/api/MetadataApi.java
@@ -15,6 +15,7 @@
 package org.finos.legend.sdlc.server.depot.api;
 
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.server.depot.model.DepotProjectId;
 import org.finos.legend.sdlc.server.depot.model.DepotProjectVersion;
 
 import java.util.List;
@@ -22,7 +23,7 @@ import java.util.Set;
 
 public interface MetadataApi
 {
-    List<Entity> getEntities(String projectId, String versionId);
+    List<Entity> getEntities(DepotProjectId projectId, String versionId);
 
-    Set<DepotProjectVersion> getProjectDependencies(String projectId, String versionId, boolean transitive);
+    Set<DepotProjectVersion> getProjectDependencies(DepotProjectId projectId, String versionId, boolean transitive);
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/test/TestModelBuilder.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/test/TestModelBuilder.java
@@ -142,13 +142,11 @@ public class TestModelBuilder
                 dependencies.addAll(this.metadataApi.getProjectDependencies(dependency.getDepotProjectId().toString(), dependency.getVersionId(), true));
             }
 
-            Set<DepotProjectId> dependenciesProjects = SetAdapter.adapt(dependencies).collect(DepotProjectVersion::getDepotProjectId);
-            if (dependenciesProjects.contains(upstreamProjectId))
-            {
-                throw new IllegalArgumentException("Project " + downstreamProjectId + " does not directly depend on " + upstreamProjectId.toString());
-            }
             // finally add the new dependency tree of the upstream project
             dependencies.addAll(latestUpstreamDependencies);
+
+            //make sure that downstream or upstream projects were not included in dependencies list (it will cause entity duplication error)
+            dependencies.removeIf(project -> project.getDepotProjectId().toString().equals(downstreamProjectId) || project.getDepotProjectId().equals(upstreamProjectId));
 
             return dependencies;
         }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/test/TestModelBuilder.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/test/TestModelBuilder.java
@@ -107,7 +107,8 @@ public class TestModelBuilder
             }
 
             //get transitive dependencies for upstream project from metadata
-            Set<DepotProjectVersion> latestUpstreamTransitiveDependencies = latestUpstreamDependencies.stream().map(depotProjectVersion -> {
+            Set<DepotProjectVersion> latestUpstreamTransitiveDependencies = latestUpstreamDependencies.stream().map(depotProjectVersion ->
+            {
                 Set<DepotProjectVersion> upstreamDependencies = this.metadataApi.getProjectDependencies(depotProjectVersion.getDepotProjectId(), depotProjectVersion.getVersionId(), true);
                 upstreamDependencies.add(depotProjectVersion);
                 return upstreamDependencies;

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/metadata/InMemoryMetadataApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/metadata/InMemoryMetadataApi.java
@@ -18,6 +18,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 import org.finos.legend.sdlc.server.depot.api.MetadataApi;
+import org.finos.legend.sdlc.server.depot.model.DepotProjectId;
 import org.finos.legend.sdlc.server.depot.model.DepotProjectVersion;
 
 import javax.inject.Inject;
@@ -35,24 +36,24 @@ public class InMemoryMetadataApi implements MetadataApi
     }
 
     @Override
-    public List<Entity> getEntities(String projectId, String versionId)
+    public List<Entity> getEntities(DepotProjectId projectId, String versionId)
     {
-        InMemoryProjectMetadata project = this.backend.getProject(projectId);
+        InMemoryProjectMetadata project = this.backend.getProject(projectId.toString());
         if (project == null)
         {
             return Lists.mutable.empty();
         }
         else
         {
-            InMemoryVersionMetadata version = this.backend.getProject(projectId).getVersion(versionId);
+            InMemoryVersionMetadata version = this.backend.getProject(projectId.toString()).getVersion(versionId);
             return version.getEntities();
         }
     }
 
     @Override
-    public Set<DepotProjectVersion> getProjectDependencies(String projectId, String versionId, boolean transitive)
+    public Set<DepotProjectVersion> getProjectDependencies(DepotProjectId projectId, String versionId, boolean transitive)
     {
-        InMemoryProjectMetadata project = this.backend.getProject(projectId);
+        InMemoryProjectMetadata project = this.backend.getProject(projectId.toString());
         if (project == null)
         {
             return Sets.mutable.empty();

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/utils/TestModelBuilderTest.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/utils/TestModelBuilderTest.java
@@ -22,6 +22,7 @@ import org.finos.legend.sdlc.domain.model.TestTools;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
+import org.finos.legend.sdlc.server.depot.model.DepotProjectId;
 import org.finos.legend.sdlc.server.depot.model.DepotProjectVersion;
 import org.finos.legend.sdlc.server.domain.api.dependency.DependenciesApi;
 import org.finos.legend.sdlc.server.domain.api.dependency.DependenciesApiImpl;
@@ -837,9 +838,10 @@ public class TestModelBuilderTest
 
     private List<Entity> findEntitiesInMetadata(String projectId, String versionId)
     {
-        Set<DepotProjectVersion> dependencies = this.metadata.getMetadataApi().getProjectDependencies(projectId, versionId, true);
-        List<Entity> entities = Lists.mutable.withAll(this.metadata.getMetadataApi().getEntities(projectId, versionId));
-        dependencies.stream().map(d -> this.metadata.getMetadataApi().getEntities(d.getDepotProjectId().toString(), d.getVersionId())).forEach(entities::addAll);
+        DepotProjectId depotProjectId = DepotProjectId.parseProjectId(projectId);
+        Set<DepotProjectVersion> dependencies = this.metadata.getMetadataApi().getProjectDependencies(depotProjectId, versionId, true);
+        List<Entity> entities = Lists.mutable.withAll(this.metadata.getMetadataApi().getEntities(depotProjectId, versionId));
+        dependencies.stream().map(d -> this.metadata.getMetadataApi().getEntities(d.getDepotProjectId(), d.getVersionId())).forEach(entities::addAll);
         return entities;
     }
 


### PR DESCRIPTION
- Make sure to throw an error if user mistakenly specified upstream project as downstream and vice versa
- Add support for not directly depend projects
- Make sure TestModelBuilder doesn't throw ConcurrentModificationException