### PR TITLE
Don't try to commit empty content

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
@@ -600,9 +600,9 @@ public class GitLabEntityApi extends GitLabApiWithFileAccess implements EntityAp
             ProjectStructure projectStructure = ProjectStructure.getProjectStructure(fileAccessContext);
             MutableList<ProjectFileOperation> fileOperations = ListIterate.collect(changes, c -> entityChangeToFileOperation(c, projectStructure, fileAccessContext));
             fileOperations.removeIf(Objects::isNull);
-            if (fileOperations.size() == 0)
+            if (fileOperations.isEmpty())
             {
-                LOGGER.debug("No changes for {} {} in project {}", workspaceType.getLabel() + " " + workspaceAccessType.getLabel(), workspaceId, projectId);
+                LOGGER.debug("No changes for {} {} {} in project {}", workspaceType.getLabel(), workspaceAccessType.getLabel(), workspaceId, projectId);
                 return null;
             }
             return getProjectFileAccessProvider().getFileModificationContext(projectId, workspaceId, workspaceType, workspaceAccessType, referenceRevisionId).submit(message, fileOperations);

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
@@ -600,6 +600,11 @@ public class GitLabEntityApi extends GitLabApiWithFileAccess implements EntityAp
             ProjectStructure projectStructure = ProjectStructure.getProjectStructure(fileAccessContext);
             MutableList<ProjectFileOperation> fileOperations = ListIterate.collect(changes, c -> entityChangeToFileOperation(c, projectStructure, fileAccessContext));
             fileOperations.removeIf(Objects::isNull);
+            if (fileOperations.size() == 0)
+            {
+                LOGGER.debug("No changes for {} {} in project {}", workspaceType.getLabel() + " " + workspaceAccessType.getLabel(), workspaceId, projectId);
+                return null;
+            }
             return getProjectFileAccessProvider().getFileModificationContext(projectId, workspaceId, workspaceType, workspaceAccessType, referenceRevisionId).submit(message, fileOperations);
         }
         catch (Exception e)


### PR DESCRIPTION
This is a bug fix to prevent "actions cannot be null or empty" response from gitlab when committing 