### PR TITLE
support configuring CORS filter allowed headers

### DIFF
--- a/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/BaseServer.java
+++ b/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/BaseServer.java
@@ -95,7 +95,17 @@ public abstract class BaseServer<C extends ServerConfiguration> extends Applicat
         corsFilter.setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, "GET,PUT,POST,DELETE,OPTIONS");
         corsFilter.setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, "*");
         corsFilter.setInitParameter(CrossOriginFilter.ALLOWED_TIMING_ORIGINS_PARAM, "*");
-        corsFilter.setInitParameter(CrossOriginFilter.ALLOWED_HEADERS_PARAM, "X-Requested-With,Content-Type,Accept,Origin,Access-Control-Allow-Credentials" + (configuration.getCORSConfiguration() != null && configuration.getCORSConfiguration().getAllowedHeaders() != null ? LazyIterate.adapt(configuration.getCORSConfiguration().getAllowedHeaders()).makeString(",", ",", "") : ""));
+
+        if (configuration.getCORSConfiguration() != null && configuration.getCORSConfiguration().getAllowedHeaders() != null)
+        {
+            corsFilter.setInitParameter(CrossOriginFilter.ALLOWED_HEADERS_PARAM, LazyIterate.adapt(configuration.getCORSConfiguration().getAllowedHeaders()).makeString(","));
+        }
+        else
+        {
+            // NOTE: this set of headers are kept as default for backward compatibility, the headers starting with prefix `x-` are meant for Zipkin
+            // client using SDLC server. We should consider using the CORS configuration and remove those from this default list.
+            corsFilter.setInitParameter(CrossOriginFilter.ALLOWED_HEADERS_PARAM, "X-Requested-With,Content-Type,Accept,Origin,Access-Control-Allow-Credentials,x-b3-parentspanid,x-b3-sampled,x-b3-spanid,x-b3-traceid");
+        }
         corsFilter.setInitParameter(CrossOriginFilter.CHAIN_PREFLIGHT_PARAM, "false");
         corsFilter.addMappingForUrlPatterns(EnumSet.of(DispatcherType.REQUEST), false, "*");
 

--- a/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/config/CORSConfiguration.java
+++ b/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/config/CORSConfiguration.java
@@ -1,0 +1,30 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.server.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class CORSConfiguration
+{
+    @JsonProperty("allowedHeaders")
+    private List<String> allowedHeaders;
+
+    public List<String> getAllowedHeaders()
+    {
+        return this.allowedHeaders;
+    }
+}

--- a/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/config/ServerConfiguration.java
+++ b/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/config/ServerConfiguration.java
@@ -32,6 +32,9 @@ public class ServerConfiguration extends Configuration
     @JsonProperty("pac4j")
     private LegendPac4jConfiguration pac4jConfiguration;
 
+    @JsonProperty("cors")
+    private CORSConfiguration corsConfiguration;
+
     @JsonProperty("filterPriorities")
     private Map<String, Integer> filterPriorities;
 
@@ -56,6 +59,11 @@ public class ServerConfiguration extends Configuration
     public LegendPac4jConfiguration getPac4jConfiguration()
     {
         return this.pac4jConfiguration;
+    }
+
+    public CORSConfiguration getCORSConfiguration()
+    {
+        return this.corsConfiguration;
     }
 
     public Map<String, Integer> getFilterPriorities()


### PR DESCRIPTION
I'm trying to create end-to-end test for Studio pointing at SDLC and trying to bypass authentication by using private access token via `org.finos.legend.server.pac4j.gitlab.GitlabPersonalAccessTokenClient`. The `Pac4j` config of this looks like this

```yml
pac4j:
  callbackPrefix: /api/pac4j/login
  clients:
    - org.finos.legend.server.pac4j.gitlab.GitlabPersonalAccessTokenClient:
        headerTokenName: legend-test-pat
        scheme: https
        gitlabHost: gitlab.com
        gitlabApiVersion: v4
  bypassPaths:
    - /api/info
```

I found out that If I'm trying to use this from a browser, I also need to specify `legend-test-pat` as an `allowed header` otherwise, I would bump into CORS issue. The logic for this is:

https://github.com/finos/legend-sdlc/blob/fda3d8f6b82001fc7e31ec9c016c4087feb71a00/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/BaseServer.java#L95-L104

There are 2 ways to achieve this:

1. Simply add the header that we agree to the list of allowed headers, i.e. `legend-test-pat`
2. Add a server configuration to allow setting `extra` allowed headers. I found stuffs that we already included like `x-b3-parentspanid,x-b3-sampled,x-b3-spanid,x-b3-traceid` for Zipkin there, I thought these should live in the config ideally. With this, the part we need to add to the config looks like this

```yml
cors:
  allowedHeaders:
    - x-b3-parentspanid
    - x-b3-sampled
    - x-b3-spanid
    - x-b3-traceid
    - legend-test-pat
```

@kevin-m-knight-gs Please let me know what you think