### PR TITLE
Fix and extend PureModelContextData resources

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/BaseLegendSDLCServer.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/BaseLegendSDLCServer.java
@@ -19,6 +19,7 @@ import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.finos.legend.engine.protocol.pure.v1.PureProtocolObjectMapperFactory;
 import org.finos.legend.sdlc.server.config.LegendSDLCServerConfiguration;
 import org.finos.legend.sdlc.server.depot.DepotConfiguration;
 import org.finos.legend.sdlc.server.gitlab.GitLabBundle;
@@ -63,6 +64,7 @@ public abstract class BaseLegendSDLCServer<T extends LegendSDLCServerConfigurati
         ProjectStructureConfiguration.configureObjectMapper(bootstrap.getObjectMapper());
         GitLabConfiguration.configureObjectMapper(bootstrap.getObjectMapper());
         DepotConfiguration.configureObjectMapper(bootstrap.getObjectMapper());
+        PureProtocolObjectMapperFactory.withPureProtocolExtensions(bootstrap.getObjectMapper());
     }
 
     protected void configureApis(Bootstrap<T> bootstrap)

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspacePureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspacePureModelContextDataResource.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.finos.legend.sdlc.server.resources;
 
 import io.swagger.annotations.Api;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspacePureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspacePureModelContextDataResource.java
@@ -1,0 +1,51 @@
+package org.finos.legend.sdlc.server.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.sdlc.domain.model.revision.Revision;
+import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
+import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
+import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/projects/{projectId}/groupWorkspaces/{workspaceId}/pureModelContextData")
+@Api("Pure Model Context")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class GroupWorkspacePureModelContextDataResource extends PureModelContextDataResource
+{
+    private final EntityApi entityApi;
+    private final RevisionApi revisionApi;
+
+    @Inject
+    public GroupWorkspacePureModelContextDataResource(EntityApi entityApi, RevisionApi revisionApi)
+    {
+        this.entityApi = entityApi;
+        this.revisionApi = revisionApi;
+    }
+
+    @GET
+    @ApiOperation("Get Pure model context data for a group workspace (at the latest revision)")
+    public PureModelContextData getPureModelContextData(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId)
+    {
+        return executeWithLogging(
+                "getting Pure model context data for group workspace " + workspaceId + " in project " + projectId,
+                () ->
+                {
+                    Revision revision = this.revisionApi.getGroupWorkspaceRevisionContext(projectId, workspaceId).getCurrentRevision();
+                    if (revision == null)
+                    {
+                        throw new LegendSDLCServerException("Could not find latest revision for group workspace " + workspaceId + " in project " + projectId + "; project may be corrupt");
+                    }
+                    return getPureModelContextData(projectId, revision.getId(), this.entityApi.getGroupWorkspaceEntityAccessContext(projectId, workspaceId));
+                });
+    }
+}

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionPureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionPureModelContextDataResource.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.finos.legend.sdlc.server.resources;
 
 import io.swagger.annotations.Api;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionPureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionPureModelContextDataResource.java
@@ -1,0 +1,42 @@
+package org.finos.legend.sdlc.server.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/projects/{projectId}/groupWorkspaces/{workspaceId}/revisions/{revisionId}/pureModelContextData")
+@Api("Pure Model Context")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class GroupWorkspaceRevisionPureModelContextDataResource extends PureModelContextDataResource
+{
+    private final EntityApi entityApi;
+
+    @Inject
+    protected GroupWorkspaceRevisionPureModelContextDataResource(EntityApi entityApi)
+    {
+        this.entityApi = entityApi;
+    }
+
+    @GET
+    @ApiOperation("Get Pure model context data for a group workspace at a revision")
+    public PureModelContextData getPureModelContextData(@PathParam("projectId") String projectId,
+                                                        @PathParam("workspaceId") String workspaceId,
+                                                        @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId)
+    {
+        return executeWithLogging(
+                "getting Pure model context data for group workspace " + workspaceId + " in project " + projectId + " at revision " + revisionId,
+                () -> getPureModelContextData(projectId, revisionId, this.entityApi.getGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId))
+        );
+    }
+}

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspacePureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspacePureModelContextDataResource.java
@@ -1,0 +1,51 @@
+package org.finos.legend.sdlc.server.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.sdlc.domain.model.revision.Revision;
+import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
+import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
+import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/projects/{projectId}/workspaces/{workspaceId}/pureModelContextData")
+@Api("Pure Model Context")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class WorkspacePureModelContextDataResource extends PureModelContextDataResource
+{
+    private final EntityApi entityApi;
+    private final RevisionApi revisionApi;
+
+    @Inject
+    public WorkspacePureModelContextDataResource(EntityApi entityApi, RevisionApi revisionApi)
+    {
+        this.entityApi = entityApi;
+        this.revisionApi = revisionApi;
+    }
+
+    @GET
+    @ApiOperation("Get Pure model context data for a user workspace (at the latest revision)")
+    public PureModelContextData getPureModelContextData(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId)
+    {
+        return executeWithLogging(
+                "getting Pure model context data for user workspace " + workspaceId + " in project " + projectId,
+                () ->
+                {
+                    Revision revision = this.revisionApi.getUserWorkspaceRevisionContext(projectId, workspaceId).getCurrentRevision();
+                    if (revision == null)
+                    {
+                        throw new LegendSDLCServerException("Could not find latest revision for user workspace " + workspaceId + " in project " + projectId + "; project may be corrupt");
+                    }
+                    return getPureModelContextData(projectId, revision.getId(), this.entityApi.getUserWorkspaceEntityAccessContext(projectId, workspaceId));
+                });
+    }
+}

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspacePureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspacePureModelContextDataResource.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.finos.legend.sdlc.server.resources;
 
 import io.swagger.annotations.Api;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceRevisionPureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceRevisionPureModelContextDataResource.java
@@ -1,0 +1,42 @@
+package org.finos.legend.sdlc.server.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/projects/{projectId}/workspaces/{workspaceId}/revisions/{revisionId}/pureModelContextData")
+@Api("Pure Model Context")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class WorkspaceRevisionPureModelContextDataResource extends PureModelContextDataResource
+{
+    private final EntityApi entityApi;
+
+    @Inject
+    protected WorkspaceRevisionPureModelContextDataResource(EntityApi entityApi)
+    {
+        this.entityApi = entityApi;
+    }
+
+    @GET
+    @ApiOperation("Get Pure model context data for a user workspace at a revision")
+    public PureModelContextData getPureModelContextData(@PathParam("projectId") String projectId,
+                                                        @PathParam("workspaceId") String workspaceId,
+                                                        @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId)
+    {
+        return executeWithLogging(
+                "getting Pure model context data for user workspace " + workspaceId + " in project " + projectId + " at revision " + revisionId,
+                () -> getPureModelContextData(projectId, revisionId, this.entityApi.getUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId))
+        );
+    }
+}

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceRevisionPureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceRevisionPureModelContextDataResource.java
@@ -1,3 +1,17 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.finos.legend.sdlc.server.resources;
 
 import io.swagger.annotations.Api;


### PR DESCRIPTION
Configure the DropWizard ObjectMapper with Pure protocol extensions so that PureModelContextData objects are properly serialized to JSON. Add APIs for getting PureModelContextData from user and group workspaces and revisions.