### PR TITLE
Generates ServiceRunner with newer execute and run APIs

### DIFF
--- a/legend-sdlc-generation-service/pom.xml
+++ b/legend-sdlc-generation-service/pom.xml
@@ -132,6 +132,11 @@
             <artifactId>eclipse-collections-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+        </dependency>
+
         <!-- TEST -->
         <dependency>
             <groupId>junit</groupId>
@@ -181,6 +186,11 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- TEST -->

--- a/legend-sdlc-generation-service/pom.xml
+++ b/legend-sdlc-generation-service/pom.xml
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <scope>test</scope>
+            <!--not define as test scope to avoid overriding the scope from the transitive dependency-->
         </dependency>
         <!-- TEST -->
     </dependencies>

--- a/legend-sdlc-generation-service/src/main/resources/generation/service/ServiceExecutionClassGenerator.ftl
+++ b/legend-sdlc-generation-service/src/main/resources/generation/service/ServiceExecutionClassGenerator.ftl
@@ -1,0 +1,56 @@
+<#--
+Copyright 2022 Goldman Sachs
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+package ${classPackage};
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
+import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.shared.core.url.StreamProvider;
+
+${imports?map(import->"import ${import};")?join("\n", "", "\n")}
+public class ${service.name} extends AbstractServicePlanExecutor
+{
+    public ${service.name}()
+    {
+        super("${service.path}", "${planResourceName}", false);
+    }
+
+    public Result execute(${executionParameters?map(param->param.javaSignature)?join(", ")})
+    {
+        return this.execute(${executionParameters?map(param->param.javaParamName)?join(", ", "", ", ")}null);
+    }
+
+    public Result execute(${executionParameters?map(param->param.javaSignature)?join(", ", "", ", ")}StreamProvider ${streamProviderParameterName})
+    {
+        return this.newExecutionBuilder(${executionParameters?size})
+                     .withStreamProvider(${streamProviderParameterName})
+    <#list executionParameters as param>
+                     .withParameter("${param.legendParamName}", ${param.javaParamName})
+    </#list>
+                     .execute();
+    }
+
+    @Override
+    public final List<ServiceVariable> getServiceVariables()
+    {
+    <#if executionParameters?size != 0>
+        return Lists.mutable.of(${executionParameters?map(param-> "\n            this.newServiceVariable(\"${param.legendParamName}\", ${param.serviceParameterType}.class, ${param.multiplicity.lowerBound}, ${param.multiplicity.upperBound!'null'})")?join(",", ");", "\n        );")}
+    <#else>
+        return Lists.mutable.empty();
+    </#if>
+    }
+}

--- a/legend-sdlc-generation-service/src/main/resources/generation/service/ServiceExecutionClassGenerator.ftl
+++ b/legend-sdlc-generation-service/src/main/resources/generation/service/ServiceExecutionClassGenerator.ftl
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
 import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
 import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
 import org.finos.legend.engine.shared.core.url.StreamProvider;
 
 ${imports?map(import->"import ${import};")?join("\n", "", "\n")}
@@ -27,6 +28,11 @@ public class ${service.name} extends AbstractServicePlanExecutor
     public ${service.name}()
     {
         super("${service.path}", "${planResourceName}", false);
+    }
+
+    public ${service.name}(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("${service.path}", "${planResourceName}", storeExecutorConfigurations);
     }
 
     public Result execute(${executionParameters?map(param->param.javaSignature)?join(", ")})

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelService.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelService.generated.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
 import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
 import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
 import org.finos.legend.engine.shared.core.url.StreamProvider;
 
 import java.util.List;
@@ -13,6 +14,11 @@ public class ModelToModelService extends AbstractServicePlanExecutor
     public ModelToModelService()
     {
         super("service::ModelToModelService", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelService.json", false);
+    }
+
+    public ModelToModelService(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("service::ModelToModelService", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelService.json", storeExecutorConfigurations);
     }
 
     public Result execute()

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelService.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelService.generated.java
@@ -1,0 +1,35 @@
+package org.finos.service;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
+import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.shared.core.url.StreamProvider;
+
+import java.util.List;
+
+public class ModelToModelService extends AbstractServicePlanExecutor
+{
+    public ModelToModelService()
+    {
+        super("service::ModelToModelService", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelService.json", false);
+    }
+
+    public Result execute()
+    {
+        return this.execute(null);
+    }
+
+    public Result execute(StreamProvider streamProvider)
+    {
+        return this.newExecutionBuilder(0)
+                     .withStreamProvider(streamProvider)
+                     .execute();
+    }
+
+    @Override
+    public final List<ServiceVariable> getServiceVariables()
+    {
+        return Lists.mutable.empty();
+    }
+}

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceMulti.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceMulti.generated.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
 import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
 import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
 import org.finos.legend.engine.shared.core.url.StreamProvider;
 
 import java.util.List;
@@ -13,6 +14,11 @@ public class ModelToModelServiceMulti extends AbstractServicePlanExecutor
     public ModelToModelServiceMulti()
     {
         super("service::ModelToModelServiceMulti", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceMulti.json", false);
+    }
+
+    public ModelToModelServiceMulti(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("service::ModelToModelServiceMulti", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceMulti.json", storeExecutorConfigurations);
     }
 
     public Result execute(String env)

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceMulti.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceMulti.generated.java
@@ -1,0 +1,38 @@
+package org.finos.service;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
+import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.shared.core.url.StreamProvider;
+
+import java.util.List;
+
+public class ModelToModelServiceMulti extends AbstractServicePlanExecutor
+{
+    public ModelToModelServiceMulti()
+    {
+        super("service::ModelToModelServiceMulti", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceMulti.json", false);
+    }
+
+    public Result execute(String env)
+    {
+        return this.execute(env, null);
+    }
+
+    public Result execute(String env, StreamProvider streamProvider)
+    {
+        return this.newExecutionBuilder(1)
+                     .withStreamProvider(streamProvider)
+                     .withParameter("env", env)
+                     .execute();
+    }
+
+    @Override
+    public final List<ServiceVariable> getServiceVariables()
+    {
+        return Lists.mutable.of(
+            this.newServiceVariable("env", String.class, 1, 1)
+        );
+    }
+}

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithMultipleParams.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithMultipleParams.generated.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
 import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
 import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
 import org.finos.legend.engine.shared.core.url.StreamProvider;
 
 import java.math.BigDecimal;
@@ -17,6 +18,11 @@ public class ModelToModelServiceWithMultipleParams extends AbstractServicePlanEx
     public ModelToModelServiceWithMultipleParams()
     {
         super("service::ModelToModelServiceWithMultipleParams", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithMultipleParams.json", false);
+    }
+
+    public ModelToModelServiceWithMultipleParams(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("service::ModelToModelServiceWithMultipleParams", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithMultipleParams.json", storeExecutorConfigurations);
     }
 
     public Result execute(String i_s, long i_i, double i_f, BigDecimal i_dec, boolean i_b, LocalDate i_sd, ZonedDateTime i_dt, Temporal i_d, Long i_oi, List<? extends Long> i_li)

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithMultipleParams.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithMultipleParams.generated.java
@@ -1,0 +1,60 @@
+package org.finos.service;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
+import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.shared.core.url.StreamProvider;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import java.util.List;
+
+public class ModelToModelServiceWithMultipleParams extends AbstractServicePlanExecutor
+{
+    public ModelToModelServiceWithMultipleParams()
+    {
+        super("service::ModelToModelServiceWithMultipleParams", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithMultipleParams.json", false);
+    }
+
+    public Result execute(String i_s, long i_i, double i_f, BigDecimal i_dec, boolean i_b, LocalDate i_sd, ZonedDateTime i_dt, Temporal i_d, Long i_oi, List<? extends Long> i_li)
+    {
+        return this.execute(i_s, i_i, i_f, i_dec, i_b, i_sd, i_dt, i_d, i_oi, i_li, null);
+    }
+
+    public Result execute(String i_s, long i_i, double i_f, BigDecimal i_dec, boolean i_b, LocalDate i_sd, ZonedDateTime i_dt, Temporal i_d, Long i_oi, List<? extends Long> i_li, StreamProvider streamProvider)
+    {
+        return this.newExecutionBuilder(10)
+                     .withStreamProvider(streamProvider)
+                     .withParameter("i_s", i_s)
+                     .withParameter("i_i", i_i)
+                     .withParameter("i_f", i_f)
+                     .withParameter("i_dec", i_dec)
+                     .withParameter("i_b", i_b)
+                     .withParameter("i_sd", i_sd)
+                     .withParameter("i_dt", i_dt)
+                     .withParameter("i_d", i_d)
+                     .withParameter("i_oi", i_oi)
+                     .withParameter("i_li", i_li)
+                     .execute();
+    }
+
+    @Override
+    public final List<ServiceVariable> getServiceVariables()
+    {
+        return Lists.mutable.of(
+            this.newServiceVariable("i_s", String.class, 1, 1),
+            this.newServiceVariable("i_i", Long.class, 1, 1),
+            this.newServiceVariable("i_f", Double.class, 1, 1),
+            this.newServiceVariable("i_dec", BigDecimal.class, 1, 1),
+            this.newServiceVariable("i_b", Boolean.class, 1, 1),
+            this.newServiceVariable("i_sd", LocalDate.class, 1, 1),
+            this.newServiceVariable("i_dt", ZonedDateTime.class, 1, 1),
+            this.newServiceVariable("i_d", Temporal.class, 1, 1),
+            this.newServiceVariable("i_oi", Long.class, 0, 1),
+            this.newServiceVariable("i_li", Long.class, 0, null)
+        );
+    }
+}

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithNMultiplicityParam.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithNMultiplicityParam.generated.java
@@ -1,0 +1,38 @@
+package org.finos.service;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
+import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.shared.core.url.StreamProvider;
+
+import java.util.List;
+
+public class ModelToModelServiceWithNMultiplicityParam extends AbstractServicePlanExecutor
+{
+    public ModelToModelServiceWithNMultiplicityParam()
+    {
+        super("service::ModelToModelServiceWithNMultiplicityParam", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithNMultiplicityParam.json", false);
+    }
+
+    public Result execute(List<? extends String> var)
+    {
+        return this.execute(var, null);
+    }
+
+    public Result execute(List<? extends String> var, StreamProvider streamProvider)
+    {
+        return this.newExecutionBuilder(1)
+                     .withStreamProvider(streamProvider)
+                     .withParameter("var", var)
+                     .execute();
+    }
+
+    @Override
+    public final List<ServiceVariable> getServiceVariables()
+    {
+        return Lists.mutable.of(
+            this.newServiceVariable("var", String.class, 1, null)
+        );
+    }
+}

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithNMultiplicityParam.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithNMultiplicityParam.generated.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
 import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
 import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
 import org.finos.legend.engine.shared.core.url.StreamProvider;
 
 import java.util.List;
@@ -13,6 +14,11 @@ public class ModelToModelServiceWithNMultiplicityParam extends AbstractServicePl
     public ModelToModelServiceWithNMultiplicityParam()
     {
         super("service::ModelToModelServiceWithNMultiplicityParam", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithNMultiplicityParam.json", false);
+    }
+
+    public ModelToModelServiceWithNMultiplicityParam(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("service::ModelToModelServiceWithNMultiplicityParam", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithNMultiplicityParam.json", storeExecutorConfigurations);
     }
 
     public Result execute(List<? extends String> var)

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithParam.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithParam.generated.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
 import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
 import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
 import org.finos.legend.engine.shared.core.url.StreamProvider;
 
 import java.util.List;
@@ -13,6 +14,11 @@ public class ModelToModelServiceWithParam extends AbstractServicePlanExecutor
     public ModelToModelServiceWithParam()
     {
         super("service::ModelToModelServiceWithParam", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithParam.json", false);
+    }
+
+    public ModelToModelServiceWithParam(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("service::ModelToModelServiceWithParam", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithParam.json", storeExecutorConfigurations);
     }
 
     public Result execute(String var)

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithParam.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/ModelToModelServiceWithParam.generated.java
@@ -1,0 +1,38 @@
+package org.finos.service;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
+import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.shared.core.url.StreamProvider;
+
+import java.util.List;
+
+public class ModelToModelServiceWithParam extends AbstractServicePlanExecutor
+{
+    public ModelToModelServiceWithParam()
+    {
+        super("service::ModelToModelServiceWithParam", "org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithParam.json", false);
+    }
+
+    public Result execute(String var)
+    {
+        return this.execute(var, null);
+    }
+
+    public Result execute(String var, StreamProvider streamProvider)
+    {
+        return this.newExecutionBuilder(1)
+                     .withStreamProvider(streamProvider)
+                     .withParameter("var", var)
+                     .execute();
+    }
+
+    @Override
+    public final List<ServiceVariable> getServiceVariables()
+    {
+        return Lists.mutable.of(
+            this.newServiceVariable("var", String.class, 1, 1)
+        );
+    }
+}

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalService.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalService.generated.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
 import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
 import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
 import org.finos.legend.engine.shared.core.url.StreamProvider;
 
 import java.util.List;
@@ -13,6 +14,11 @@ public class RelationalService extends AbstractServicePlanExecutor
     public RelationalService()
     {
         super("service::RelationalService", "org/finos/legend/sdlc/generation/service/entities/service/RelationalService.json", false);
+    }
+
+    public RelationalService(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("service::RelationalService", "org/finos/legend/sdlc/generation/service/entities/service/RelationalService.json", storeExecutorConfigurations);
     }
 
     public Result execute()

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalService.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalService.generated.java
@@ -1,0 +1,35 @@
+package org.finos.service;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
+import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.shared.core.url.StreamProvider;
+
+import java.util.List;
+
+public class RelationalService extends AbstractServicePlanExecutor
+{
+    public RelationalService()
+    {
+        super("service::RelationalService", "org/finos/legend/sdlc/generation/service/entities/service/RelationalService.json", false);
+    }
+
+    public Result execute()
+    {
+        return this.execute(null);
+    }
+
+    public Result execute(StreamProvider streamProvider)
+    {
+        return this.newExecutionBuilder(0)
+                     .withStreamProvider(streamProvider)
+                     .execute();
+    }
+
+    @Override
+    public final List<ServiceVariable> getServiceVariables()
+    {
+        return Lists.mutable.empty();
+    }
+}

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalServiceWithParams.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalServiceWithParams.generated.java
@@ -1,0 +1,40 @@
+package org.finos.service;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
+import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.shared.core.url.StreamProvider;
+
+import java.util.List;
+
+public class RelationalServiceWithParams extends AbstractServicePlanExecutor
+{
+    public RelationalServiceWithParams()
+    {
+        super("service::RelationalServiceWithParams", "org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithParams.json", false);
+    }
+
+    public Result execute(String firstName, String lastName)
+    {
+        return this.execute(firstName, lastName, null);
+    }
+
+    public Result execute(String firstName, String lastName, StreamProvider streamProvider)
+    {
+        return this.newExecutionBuilder(2)
+                     .withStreamProvider(streamProvider)
+                     .withParameter("firstName", firstName)
+                     .withParameter("lastName", lastName)
+                     .execute();
+    }
+
+    @Override
+    public final List<ServiceVariable> getServiceVariables()
+    {
+        return Lists.mutable.of(
+            this.newServiceVariable("firstName", String.class, 1, 1),
+            this.newServiceVariable("lastName", String.class, 1, 1)
+        );
+    }
+}

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalServiceWithParams.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalServiceWithParams.generated.java
@@ -4,6 +4,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
 import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
 import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
 import org.finos.legend.engine.shared.core.url.StreamProvider;
 
 import java.util.List;
@@ -13,6 +14,11 @@ public class RelationalServiceWithParams extends AbstractServicePlanExecutor
     public RelationalServiceWithParams()
     {
         super("service::RelationalServiceWithParams", "org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithParams.json", false);
+    }
+
+    public RelationalServiceWithParams(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("service::RelationalServiceWithParams", "org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithParams.json", storeExecutorConfigurations);
     }
 
     public Result execute(String firstName, String lastName)

--- a/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithNMultiplicityParam.json
+++ b/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/service/ModelToModelServiceWithNMultiplicityParam.json
@@ -1,0 +1,179 @@
+{
+  "classifierPath": "meta::legend::service::metamodel::Service",
+  "content": {
+    "_type": "service",
+    "autoActivateUpdates": true,
+    "documentation": "",
+    "execution": {
+      "_type": "pureSingleExecution",
+      "func": {
+        "_type": "lambda",
+        "body": [
+          {
+            "_type": "func",
+            "function": "serialize",
+            "parameters": [
+              {
+                "_type": "func",
+                "function": "graphFetchChecked",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "getAll",
+                    "parameters": [
+                      {
+                        "_type": "class",
+                        "fullPath": "model::TargetPerson"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "rootGraphFetchTree",
+                    "class": "model::TargetPerson",
+                    "subTrees": [
+                      {
+                        "_type": "propertyGraphFetchTree",
+                        "parameters": [],
+                        "property": "age",
+                        "subTrees": []
+                      },
+                      {
+                        "_type": "propertyGraphFetchTree",
+                        "parameters": [],
+                        "property": "fullName",
+                        "subTrees": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "_type": "rootGraphFetchTree",
+                "class": "model::TargetPerson",
+                "subTrees": [
+                  {
+                    "_type": "propertyGraphFetchTree",
+                    "parameters": [],
+                    "property": "age",
+                    "subTrees": []
+                  },
+                  {
+                    "_type": "propertyGraphFetchTree",
+                    "parameters": [],
+                    "property": "fullName",
+                    "subTrees": []
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "_type": "var",
+            "class": "String",
+            "multiplicity": {
+              "lowerBound": 1
+            },
+            "name": "var"
+          }
+        ]
+      },
+      "mapping": "model::SimpleModelToModelMapping",
+      "runtime": {
+        "_type": "engineRuntime",
+        "connections": [
+          {
+            "store": {
+              "path": "ModelStore",
+              "type": "STORE"
+            },
+            "storeConnections": [
+              {
+                "connection": {
+                  "_type": "JsonModelConnection",
+                  "class": "model::SourcePerson",
+                  "element": "ModelStore",
+                  "url": "data:application/json,%7B%22firstName%22%3A%22firstName%2073%22%2C%22lastName%22%3A%22lastName%2079%22%2C%22age%22%3A27%7D"
+                },
+                "id": "connection_1"
+              }
+            ]
+          }
+        ],
+        "mappings": [
+          {
+            "path": "model::SimpleModelToModelMapping",
+            "type": "MAPPING"
+          }
+        ]
+      }
+    },
+    "name": "ModelToModelServiceWithNMultiplicityParam",
+    "owners": [
+      "testOwner"
+    ],
+    "package": "service",
+    "pattern": "/myService/{var}",
+    "test": {
+      "_type": "singleExecutionTest",
+      "asserts": [
+        {
+          "assert": {
+            "_type": "lambda",
+            "body": [
+              {
+                "_type": "func",
+                "function": "equal",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "cast",
+                    "parameters": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "res"
+                          }
+                        ],
+                        "property": "values"
+                      },
+                      {
+                        "_type": "hackedClass",
+                        "fullPath": "String"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "string",
+                    "multiplicity": {
+                      "lowerBound": 1,
+                      "upperBound": 1
+                    },
+                    "values": [
+                      "{\n  \"defects\": [\n\n  ],\n  \"source\": {\n    \"defects\": [\n\n    ],\n    \"source\": {\n      \"number\": 1,\n      \"record\": \"{\\\"firstName\\\":\\\"firstName 73\\\",\\\"lastName\\\":\\\"lastName 79\\\",\\\"age\\\":27}\"\n    },\n    \"value\": {\n      \"age\": 27,\n      \"lastName\": \"lastName 79\",\n      \"firstName\": \"firstName 73\"\n    }\n  },\n  \"value\": {\n    \"age\": 27,\n    \"fullName\": \"firstName 73 lastName 79\"\n  }\n}"
+                    ]
+                  }
+                ]
+              }
+            ],
+            "parameters": [
+              {
+                "_type": "var",
+                "class": "meta::pure::mapping::Result",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "name": "res"
+              }
+            ]
+          }
+        }
+      ],
+      "data": "{\n  \"firstName\": \"firstName 73\",\n  \"lastName\": \"lastName 79\",\n  \"age\": 27\n}"
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <pac4j.version>3.8.3</pac4j.version>
         <slf4j.version>1.7.25</slf4j.version>
         <snakeyaml.version>1.27</snakeyaml.version>
+        <freemarker.version>2.3.30</freemarker.version>
         <hibernate-validator.version>5.4.3.Final</hibernate-validator.version>
     </properties>
 
@@ -1302,6 +1303,11 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.freemarker</groupId>
+                <artifactId>freemarker</artifactId>
+                <version>${freemarker.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This PR aims to reduce execution related code on the service generation, keeping only the description of the service, and letting legend-egine control how to execute.

It also move code generation to free mark, which should help developers follow what code is generated and how the code looks.