### PR TITLE
speed up fetching projects by enabling `simple` mode

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectApi.java
@@ -137,7 +137,7 @@ public class GitLabProjectApi extends GitLabApiWithFileAccess implements Project
             Set<String> tagSet = (tags == null) ? Collections.emptySet() : toLegendSDLCTagSet(tags);
             for (GitLabMode mode : modes)
             {
-                Pager<org.gitlab4j.api.models.Project> pager = withRetries(() -> getGitLabApi(mode).getProjectApi().getProjects(null, null, null, null, search, null, null, user, null, null, ITEMS_PER_PAGE));
+                Pager<org.gitlab4j.api.models.Project> pager = withRetries(() -> getGitLabApi(mode).getProjectApi().getProjects(null, null, null, null, search, true, null, user, null, null, ITEMS_PER_PAGE));
                 Stream<org.gitlab4j.api.models.Project> stream = PagerTools.stream(pager).filter(this::isLegendSDLCProject);
                 if (!tagSet.isEmpty())
                 {


### PR DESCRIPTION
Enable `simple` [mode](https://docs.gitlab.com/ee/api/projects.html#list-all-projects) when fetching projects to improve performance. @kevin-m-knight-gs did some profiling with this and it did show certain sign of improvements.

This change is covered by `IntegrationTestGitLabProjectApis.runGetProjectTest()` to prove that even in `simple` mode all fields we need for constructing `Project` object are still available.