### PR TITLE
Update README.md to clarify about redirect URIs for GitLab applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=legend-sdlc&metric=security_rating&token=69394360757d5e1356312ddfee658a6b205e2c97)](https://sonarcloud.io/dashboard?id=legend-sdlc)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=legend-sdlc&metric=bugs&token=69394360757d5e1356312ddfee658a6b205e2c97)](https://sonarcloud.io/dashboard?id=legend-sdlc)
 
-
 # legend-sdlc
 
 The Legend SDLC Server provides a rich REST API allowing users to safely manage metadata. Most SDLCs are file- and
@@ -11,6 +10,7 @@ text-centric, but the Legend SDLC is model-centric. That is, users interact with
 and folders.
 
 To this end, the Legend SDLC enables:
+
 * Users to develop with tools designed for editing models (rather than files or code)
 * Users to view changes with tools designed for viewing model-level changes (rather than text changes)
 * Clients to create their own tools for their own particular use cases
@@ -25,15 +25,19 @@ on.
 You will also need an instance of GitLab to connect to, such as [gitlab.com](https://gitlab.com). On GitLab, you will
 need to create an "Application", which is used for authorization so that the SDLC Server can act on behalf of users.
 See [GitLab's documentation](https://docs.gitlab.com/ee/api/oauth2.html) for general information about creating an
-application in GitLab. The application will need to have "api" scope and have [http://`SDLC_SERVER`/api/auth/callback](http://127.0.0.1:7070/api/auth/callback) as a
-redirect URI, where `SDLC_SERVER` is the host and possibly port needed to connect to the SDLC Server. (For testing
-purposes, you can use `127.0.0.1:7070`) This redirect URI will also need to appear in your configuration file.
+application in GitLab. The application will need to have "api" scope and
+have [http://`SDLC_SERVER`/api/auth/callback](http://127.0.0.1:7070/api/auth/callback) as a redirect URI,
+where `SDLC_SERVER` is the host and possibly port needed to connect to the SDLC Server. (For testing purposes, you can
+use `127.0.0.1:7070` or `localhost:7070` or both. You can have many redirect URIs specified for the application, so it
+is advisable to add all you think you might want.) This redirect URI will also need to appear in your configuration
+file.
 
 If you are using the GitlabClient for authentication (see the pac4j section of the configuration), you will need a
 GitLab application for that as well. It will need "openid" and "profile" scopes, and will require
-[http://`SDLC_SERVER`/api/pac4j/login/callback](http://127.0.0.1:7070/api/pac4j/login/callback) as a redirect URI (where, again, `SDLC_SERVER` is the host and port needed to
-connect to the SDLC Server). You can either create a new application for this, or you can add these scopes and redirect
-URI to your existing application. We recommend you use a single application for both purposes, as it makes the
+[http://`SDLC_SERVER`/api/pac4j/login/callback](http://127.0.0.1:7070/api/pac4j/login/callback) as a redirect URI.
+Again, `SDLC_SERVER` is the host and port needed to connect to the SDLC Server, and the same advice mentioned above
+applies for this case as well. You can either create a new application for this, or you can add these scopes and
+redirect URIs to your existing application. We recommend you use a single application for both purposes, as it makes the
 authentication and authorization process simpler and faster.
 
 Once you have your configuration file, you can run the server with Java 8 or later. You can use a command such as this
@@ -43,8 +47,9 @@ to start the server:
 java -cp $SHADED_JAR_PATH org.finos.legend.sdlc.server.LegendSDLCServer server $CONFIG_DIR/config.yaml
 ```
 
-If you want to use the shaded JAR built by `mvn install` in this project, you can get it from `legend-sdlc-server/target/legend-sdlc-server-*-shaded.jar`.
-You may also include additional libraries on the classpath to add functionality extensions.
+If you want to use the shaded JAR built by `mvn install` in this project, you can get it
+from `legend-sdlc-server/target/legend-sdlc-server-*-shaded.jar`. You may also include additional libraries on the
+classpath to add functionality extensions.
 
 ## Development setup
 
@@ -56,7 +61,8 @@ Visit our [roadmap](https://github.com/finos/legend#roadmap) to know more about 
 
 ## Contributing
 
-Visit Legend [Contribution Guide](https://github.com/finos/legend/blob/master/CONTRIBUTING.md) to learn how to contribute to Legend.
+Visit Legend [Contribution Guide](https://github.com/finos/legend/blob/master/CONTRIBUTING.md) to learn how to
+contribute to Legend.
 
 ## License
 


### PR DESCRIPTION
Update README.md to add some clarifications about redirect URIs for GitLab applications. In particular, to suggest that people use both 127.0.0.1 and localhost for testing purposes.