### PR TITLE
fix API performance problem with limit being used as items per page

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabApiWithFileAccess.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabApiWithFileAccess.java
@@ -731,12 +731,11 @@ abstract class GitLabApiWithFileAccess extends BaseGitLabApi
                 }
                 limited = true;
             }
-            int itemsPerPage = limited ? Math.min(limit, ITEMS_PER_PAGE) : ITEMS_PER_PAGE;
             try
             {
                 CommitsApi commitsApi = getGitLabApi().getCommitsApi();
                 String branchName = getReference();
-                Stream<Commit> commitStream = getAllCommits(commitsApi, branchName, toDateIfNotNull(since), toDateIfNotNull(until), itemsPerPage);
+                Stream<Commit> commitStream = getAllCommits(commitsApi, branchName, toDateIfNotNull(since), toDateIfNotNull(until), ITEMS_PER_PAGE);
                 if (commitStream == null)
                 {
                     if (!referenceExists())

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabBuildApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabBuildApi.java
@@ -190,9 +190,8 @@ public class GitLabBuildApi extends GitLabApiWithFileAccess implements BuildApi
                     }
                     limited = true;
                 }
-                int itemsPerPage = limited ? Math.min(limit, ITEMS_PER_PAGE) : ITEMS_PER_PAGE;
                 PipelineApi pipelineApi = getGitLabApi().getPipelineApi();
-                Pager<Pipeline> pager = withRetries(() -> pipelineApi.getPipelines(this.projectId.getGitLabId(), null, null, getRef(), false, null, null, null, null, itemsPerPage));
+                Pager<Pipeline> pager = withRetries(() -> pipelineApi.getPipelines(this.projectId.getGitLabId(), null, null, getRef(), false, null, null, null, null, ITEMS_PER_PAGE));
                 Stream<Pipeline> pipelineStream = PagerTools.stream(pager);
                 Set<String> revisionIdSet = (revisionIds == null)
                     ? Collections.emptySet()

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectApi.java
@@ -123,11 +123,10 @@ public class GitLabProjectApi extends GitLabApiWithFileAccess implements Project
             }
             limited = true;
         }
-        int itemsPerPage = limited ? Math.min(limit, ITEMS_PER_PAGE) : ITEMS_PER_PAGE;
         try
         {
             Set<String> tagSet = (tags == null) ? Collections.emptySet() : toLegendSDLCTagSet(tags);
-            Pager<org.gitlab4j.api.models.Project> pager = withRetries(() -> getGitLabApi().getProjectApi().getProjects(null, null, null, null, search, true, null, user, null, null, itemsPerPage));
+            Pager<org.gitlab4j.api.models.Project> pager = withRetries(() -> getGitLabApi().getProjectApi().getProjects(null, null, null, null, search, true, null, user, null, null, ITEMS_PER_PAGE));
             Stream<org.gitlab4j.api.models.Project> stream = PagerTools.stream(pager).filter(this::isLegendSDLCProject);
             if (!tagSet.isEmpty())
             {

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitlabWorkflowApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitlabWorkflowApi.java
@@ -231,9 +231,8 @@ public class GitlabWorkflowApi extends GitLabApiWithFileAccess implements Workfl
                     }
                     limited = true;
                 }
-                int itemsPerPage = limited ? Math.min(limit, ITEMS_PER_PAGE) : ITEMS_PER_PAGE;
                 PipelineApi pipelineApi = getGitLabApi().getPipelineApi();
-                Pager<Pipeline> pager = withRetries(() -> pipelineApi.getPipelines(this.projectId.getGitLabId(), null, null, getRef(), false, null, null, null, null, itemsPerPage));
+                Pager<Pipeline> pager = withRetries(() -> pipelineApi.getPipelines(this.projectId.getGitLabId(), null, null, getRef(), false, null, null, null, null, ITEMS_PER_PAGE));
                 Stream<Pipeline> pipelineStream = PagerTools.stream(pager);
                 if (revisionIds != null)
                 {


### PR DESCRIPTION
I have observed that by setting `limit` as the `itemsPerPage` in `fetch...` APIs, their performance actually degrade a lot. See the video of Studio loading projects with `limit=3`. See the videos below:

#### Before
https://user-images.githubusercontent.com/13574879/162664509-330919f5-d93d-44ef-af02-ed1a882bc545.mov

#### After
https://user-images.githubusercontent.com/13574879/162664513-b6c9bf95-f2e9-43d7-940b-12e1ef14ad47.mov


