### PR TITLE
Define Jetty-IO version to avoid enforcer problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1219,6 +1219,11 @@
                 <artifactId>jetty-xml</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.gitlab4j</groupId>


### PR DESCRIPTION
Next Legend Engine will cause some enforcer issues around Jetty IO

RE: https://github.com/finos/legend-engine/pull/681