### PR TITLE
only publish test result in PR builds

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,66 @@
+# Copyright 2020 Goldman Sachs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Pull Request CI
+
+env:
+  CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
+  CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    # NOTE: do not run this on release commits and when it is not part of a PR
+    if: "!contains(github.event.head_commit.message, '[maven-release-plugin]') && ((github.repository != 'finos/legend-sdlc') && (github.ref != 'refs/heads/master'))"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Cache Maven dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-mvn-deps
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          server-id: ossrh
+          server-username: CI_DEPLOY_USERNAME
+          server-password: CI_DEPLOY_PASSWORD
+      - name: Download deps and plugins
+        run: mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+      - name: Build + Test
+        run: mvn install javadoc:javadoc -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSSZ -Dmaven.test.failure.ignore=true
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: test-reports/surefire-reports-aggregate/*.xml
+      - name: Upload CI Event
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: event-file
+          path: ${{ github.event_path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build CI
+name: CI
 
 env:
   CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
@@ -25,7 +25,8 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build
-    if: "!contains(github.event.head_commit.message, '[maven-release-plugin]')"
+    # NOTE: do not run this on release commits and on PR
+    if: "!contains(github.event.head_commit.message, '[maven-release-plugin]') && ((github.repository == 'finos/legend-sdlc') || (github.ref == 'refs/heads/master'))"
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
@@ -57,23 +58,11 @@ jobs:
     - name: Download deps and plugins
       run: mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
     - name: Build + Test
-      if: (github.repository != 'finos/legend-sdlc') || (github.ref != 'refs/heads/master')
-      run: mvn install javadoc:javadoc -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSSZ -Dmaven.test.failure.ignore=true
+      if: ((github.repository != 'finos/legend-sdlc') && (github.ref == 'refs/heads/master')) || ((github.repository != 'finos/legend-sdlc') && (github.ref == 'refs/heads/master'))
+      run: mvn install javadoc:javadoc -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSSZ
     - name: Build + Test + Maven Deploy + Sonar + Docker Snapshot
       if: (github.repository == 'finos/legend-sdlc') && (github.ref == 'refs/heads/master')
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      run: mvn javadoc:javadoc deploy -P sonar,docker-snapshot -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSSZ -Dmaven.test.failure.ignore=true
-    - name: Upload Test Results
-      if: always()
-      uses: actions/upload-artifact@v3
-      with:
-        name: test-results
-        path: test-reports/surefire-reports-aggregate/*.xml
-    - name: Upload CI Event
-      if: always()
-      uses: actions/upload-artifact@v3
-      with:
-        name: event-file
-        path: ${{ github.event_path }}
+      run: mvn javadoc:javadoc deploy -P sonar,docker-snapshot -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSSZ

--- a/.github/workflows/test-result.yml
+++ b/.github/workflows/test-result.yml
@@ -16,7 +16,7 @@ name: Publish Test Results
 
 on:
   workflow_run:
-    workflows: ["Build CI"]
+    workflows: ["Pull Request CI"]
     types:
       - completed
 permissions: {}
@@ -32,8 +32,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Debug Only
-        run: echo ${{ github.event.workflow_run.conclusion }}
       - name: Download and Extract Artifacts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Incubating)
-![Build CI](https://github.com/finos/legend-sdlc/workflows/Build%20CI/badge.svg)
+![Build CI](https://github.com/finos/legend-sdlc/workflows/CI/badge.svg)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=legend-sdlc&metric=security_rating&token=69394360757d5e1356312ddfee658a6b205e2c97)](https://sonarcloud.io/dashboard?id=legend-sdlc)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=legend-sdlc&metric=bugs&token=69394360757d5e1356312ddfee658a6b205e2c97)](https://sonarcloud.io/dashboard?id=legend-sdlc)
 


### PR DESCRIPTION
Split the build workflow into PR and `non-PR` builds, only publish test result for `PR` build