### PR TITLE
Restrict the maven enforcer rules that apply in legend-sdlc-test-reports

### DIFF
--- a/legend-sdlc-test-reports/pom.xml
+++ b/legend-sdlc-test-reports/pom.xml
@@ -30,6 +30,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <configuration>
+                    <rules combine.self="override">
+                        <requireJavaVersion>
+                            <version>${java.version.range}</version>
+                        </requireJavaVersion>
+                    </rules>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <extensions>true</extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <maven.compiler.release>8</maven.compiler.release>
+        <java.version.range>[11.0.10,12)</java.version.range>
 
         <!-- Legend dependency versions -->
         <legend.engine.version>3.2.0</legend.engine.version>
@@ -310,7 +311,7 @@
                 <configuration>
                     <rules>
                         <requireJavaVersion>
-                            <version>[11.0.10,12)</version>
+                            <version>${java.version.range}</version>
                         </requireJavaVersion>
                         <dependencyConvergence />
                         <bannedDependencies>


### PR DESCRIPTION
Restrict the maven enforcer rules that apply in legend-sdlc-test-reports. The enforcer rules have little to no value in that module, since its sole purpose is to aggregate test results from other (substantive) modules. And the dependency convergence rule, in particular, was causing the build to fail in maven 3.6.