### PR TITLE
remove source information on Pure parsing to optimize storage size

### DIFF
--- a/legend-sdlc-entity-maven-plugin/pom.xml
+++ b/legend-sdlc-entity-maven-plugin/pom.xml
@@ -51,6 +51,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/legend-sdlc-entity-maven-plugin/src/test/java/org/finos/legend/sdlc/entities/PureDomainDeserializer.java
+++ b/legend-sdlc-entity-maven-plugin/src/test/java/org/finos/legend/sdlc/entities/PureDomainDeserializer.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.sdlc.entities;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.language.pure.grammar.from.PureGrammarParser;
@@ -38,7 +39,7 @@ import java.util.Map;
 public class PureDomainDeserializer implements EntityTextSerializer
 {
     private final PureGrammarParser pureParser = PureGrammarParser.newInstance();
-    private final ObjectMapper jsonMapper = PureProtocolObjectMapperFactory.getNewObjectMapper();
+    private final ObjectMapper jsonMapper = PureProtocolObjectMapperFactory.getNewObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
     @Override
     public String getName()
@@ -83,7 +84,11 @@ public class PureDomainDeserializer implements EntityTextSerializer
         PureModelContextData pureModelContextData;
         try
         {
-            pureModelContextData = this.pureParser.parseModel(content);
+            pureModelContextData = this.pureParser.parseModel(
+                    content,
+                    // NOTE: remove source information to optimize model size for storage
+                    false
+            );
         }
         catch (EngineException e)
         {
@@ -97,7 +102,7 @@ public class PureDomainDeserializer implements EntityTextSerializer
         PackageableElement element = elements.get((elements.get(0) instanceof SectionIndex) ? 1 : 0);
         String classifierPath = getClassifierPath(element);
         String intermediateJson = this.jsonMapper.writeValueAsString(element);
-        Map<String, Object> entityContent =  this.jsonMapper.readValue(intermediateJson, this.jsonMapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class));
+        Map<String, Object> entityContent = this.jsonMapper.readValue(intermediateJson, this.jsonMapper.getTypeFactory().constructMapType(Map.class, String.class, Object.class));
         return Entity.newEntity(element.getPath(), classifierPath, entityContent);
     }
 

--- a/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/associations/Employment.json
+++ b/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/associations/Employment.json
@@ -7,64 +7,25 @@
     "package": "model::domain::associations",
     "properties": [
       {
-        "defaultValue": null,
         "multiplicity": {
-          "lowerBound": 0,
-          "upperBound": null
+          "lowerBound": 0
         },
         "name": "employer",
-        "propertyTypeSourceInformation": {
-          "endColumn": 31,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 13,
-          "startLine": 3
-        },
-        "sourceInformation": {
-          "endColumn": 35,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 3
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "model::domain::Firm"
       },
       {
-        "defaultValue": null,
         "multiplicity": {
-          "lowerBound": 0,
-          "upperBound": null
+          "lowerBound": 0
         },
         "name": "employees",
-        "propertyTypeSourceInformation": {
-          "endColumn": 34,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 14,
-          "startLine": 4
-        },
-        "sourceInformation": {
-          "endColumn": 38,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 4
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "model::domain::Person"
       }
     ],
     "qualifiedProperties": [],
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 5,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 1
-    },
     "stereotypes": [],
     "taggedValues": []
   }

--- a/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/classes/Address.json
+++ b/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/classes/Address.json
@@ -8,64 +8,27 @@
     "package": "model::domain::classes",
     "properties": [
       {
-        "defaultValue": null,
         "multiplicity": {
           "lowerBound": 1,
           "upperBound": 1
         },
         "name": "type",
-        "propertyTypeSourceInformation": {
-          "endColumn": 41,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 9,
-          "startLine": 3
-        },
-        "sourceInformation": {
-          "endColumn": 45,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 3
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "model::domain::enums::AddressType"
       },
       {
-        "defaultValue": null,
         "multiplicity": {
           "lowerBound": 1,
           "upperBound": 1
         },
         "name": "address",
-        "propertyTypeSourceInformation": {
-          "endColumn": 17,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 12,
-          "startLine": 4
-        },
-        "sourceInformation": {
-          "endColumn": 21,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 4
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "String"
       }
     ],
     "qualifiedProperties": [],
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 5,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 1
-    },
     "stereotypes": [],
     "superTypes": [],
     "taggedValues": []

--- a/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/classes/EntityWithAddresses.json
+++ b/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/classes/EntityWithAddresses.json
@@ -8,39 +8,16 @@
     "package": "model::domain::classes",
     "properties": [
       {
-        "defaultValue": null,
         "multiplicity": {
-          "lowerBound": 0,
-          "upperBound": null
+          "lowerBound": 0
         },
         "name": "addresses",
-        "propertyTypeSourceInformation": {
-          "endColumn": 44,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 14,
-          "startLine": 3
-        },
-        "sourceInformation": {
-          "endColumn": 48,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 3
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "model::domain::classes::Address"
       }
     ],
     "qualifiedProperties": [],
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 4,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 1
-    },
     "stereotypes": [],
     "superTypes": [],
     "taggedValues": []

--- a/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/classes/Firm.json
+++ b/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/classes/Firm.json
@@ -8,89 +8,37 @@
     "package": "model::domain::classes",
     "properties": [
       {
-        "defaultValue": null,
         "multiplicity": {
           "lowerBound": 1,
           "upperBound": 1
         },
         "name": "legalName",
-        "propertyTypeSourceInformation": {
-          "endColumn": 19,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 14,
-          "startLine": 3
-        },
-        "sourceInformation": {
-          "endColumn": 23,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 3
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "String"
       },
       {
-        "defaultValue": null,
         "multiplicity": {
           "lowerBound": 0,
           "upperBound": 1
         },
         "name": "commonName",
-        "propertyTypeSourceInformation": {
-          "endColumn": 20,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 15,
-          "startLine": 4
-        },
-        "sourceInformation": {
-          "endColumn": 27,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 4
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "String"
       },
       {
-        "defaultValue": null,
         "multiplicity": {
           "lowerBound": 0,
           "upperBound": 1
         },
         "name": "founded",
-        "propertyTypeSourceInformation": {
-          "endColumn": 21,
-          "endLine": 5,
-          "sourceId": "",
-          "startColumn": 12,
-          "startLine": 5
-        },
-        "sourceInformation": {
-          "endColumn": 28,
-          "endLine": 5,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 5
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "StrictDate"
       }
     ],
     "qualifiedProperties": [],
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 6,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 1
-    },
     "stereotypes": [],
     "superTypes": [
       "model::domain::classes::EntityWithAddresses"

--- a/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/classes/Person.json
+++ b/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/classes/Person.json
@@ -8,64 +8,27 @@
     "package": "model::domain::classes",
     "properties": [
       {
-        "defaultValue": null,
         "multiplicity": {
           "lowerBound": 1,
           "upperBound": 1
         },
         "name": "firstName",
-        "propertyTypeSourceInformation": {
-          "endColumn": 19,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 14,
-          "startLine": 3
-        },
-        "sourceInformation": {
-          "endColumn": 23,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 3
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "String"
       },
       {
-        "defaultValue": null,
         "multiplicity": {
           "lowerBound": 1,
           "upperBound": 1
         },
         "name": "lastName",
-        "propertyTypeSourceInformation": {
-          "endColumn": 18,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 13,
-          "startLine": 4
-        },
-        "sourceInformation": {
-          "endColumn": 22,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 4
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "String"
       }
     ],
     "qualifiedProperties": [],
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 5,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 1
-    },
     "stereotypes": [],
     "superTypes": [
       "model::domain::classes::EntityWithAddresses"

--- a/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/enums/AddressType.json
+++ b/legend-sdlc-entity-maven-plugin/src/test/resources/simple-json-model/entities/model/domain/enums/AddressType.json
@@ -1,51 +1,27 @@
 {
-  "classifierPath" : "meta::pure::metamodel::type::Enumeration",
-  "content" : {
-    "_type" : "Enumeration",
-    "name" : "AddressType",
-    "package" : "model::domain::enums",
-    "sourceInformation" : {
-      "endColumn" : 1,
-      "endLine" : 4,
-      "sourceId" : "",
-      "startColumn" : 1,
-      "startLine" : 1
-    },
-    "stereotypes" : [ ],
-    "taggedValues" : [ ],
-    "values" : [ {
-      "sourceInformation" : {
-        "endColumn" : 8,
-        "endLine" : 3,
-        "sourceId" : "",
-        "startColumn" : 3,
-        "startLine" : 3
+  "classifierPath": "meta::pure::metamodel::type::Enumeration",
+  "content": {
+    "_type": "Enumeration",
+    "name": "AddressType",
+    "package": "model::domain::enums",
+    "stereotypes": [],
+    "taggedValues": [],
+    "values": [
+      {
+        "stereotypes": [],
+        "taggedValues": [],
+        "value": "STREET"
       },
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "value" : "STREET"
-    }, {
-      "sourceInformation" : {
-        "endColumn" : 14,
-        "endLine" : 3,
-        "sourceId" : "",
-        "startColumn" : 11,
-        "startLine" : 3
+      {
+        "stereotypes": [],
+        "taggedValues": [],
+        "value": "CITY"
       },
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "value" : "CITY"
-    }, {
-      "sourceInformation" : {
-        "endColumn" : 23,
-        "endLine" : 3,
-        "sourceId" : "",
-        "startColumn" : 17,
-        "startLine" : 3
-      },
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "value" : "COUNTRY"
-    } ]
+      {
+        "stereotypes": [],
+        "taggedValues": [],
+        "value": "COUNTRY"
+      }
+    ]
   }
 }

--- a/legend-sdlc-entity-maven-plugin/src/test/resources/simple-mixed-model/model/domain/classes/EntityWithAddresses.json
+++ b/legend-sdlc-entity-maven-plugin/src/test/resources/simple-mixed-model/model/domain/classes/EntityWithAddresses.json
@@ -8,39 +8,16 @@
     "package": "model::domain::classes",
     "properties": [
       {
-        "defaultValue": null,
         "multiplicity": {
-          "lowerBound": 0,
-          "upperBound": null
+          "lowerBound": 0
         },
         "name": "addresses",
-        "propertyTypeSourceInformation": {
-          "endColumn": 44,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 14,
-          "startLine": 3
-        },
-        "sourceInformation": {
-          "endColumn": 48,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 3
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "model::domain::classes::Address"
       }
     ],
     "qualifiedProperties": [],
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 4,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 1
-    },
     "stereotypes": [],
     "superTypes": [],
     "taggedValues": []

--- a/legend-sdlc-entity-maven-plugin/src/test/resources/simple-mixed-model/model/domain/classes/Firm.json
+++ b/legend-sdlc-entity-maven-plugin/src/test/resources/simple-mixed-model/model/domain/classes/Firm.json
@@ -8,89 +8,37 @@
     "package": "model::domain::classes",
     "properties": [
       {
-        "defaultValue": null,
         "multiplicity": {
           "lowerBound": 1,
           "upperBound": 1
         },
         "name": "legalName",
-        "propertyTypeSourceInformation": {
-          "endColumn": 19,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 14,
-          "startLine": 3
-        },
-        "sourceInformation": {
-          "endColumn": 23,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 3
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "String"
       },
       {
-        "defaultValue": null,
         "multiplicity": {
           "lowerBound": 0,
           "upperBound": 1
         },
         "name": "commonName",
-        "propertyTypeSourceInformation": {
-          "endColumn": 20,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 15,
-          "startLine": 4
-        },
-        "sourceInformation": {
-          "endColumn": 27,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 4
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "String"
       },
       {
-        "defaultValue": null,
         "multiplicity": {
           "lowerBound": 0,
           "upperBound": 1
         },
         "name": "founded",
-        "propertyTypeSourceInformation": {
-          "endColumn": 21,
-          "endLine": 5,
-          "sourceId": "",
-          "startColumn": 12,
-          "startLine": 5
-        },
-        "sourceInformation": {
-          "endColumn": 28,
-          "endLine": 5,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 5
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "StrictDate"
       }
     ],
     "qualifiedProperties": [],
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 6,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 1
-    },
     "stereotypes": [],
     "superTypes": [
       "model::domain::classes::EntityWithAddresses"

--- a/legend-sdlc-entity-maven-plugin/src/test/resources/simple-mixed-model/model/domain/enums/AddressType.json
+++ b/legend-sdlc-entity-maven-plugin/src/test/resources/simple-mixed-model/model/domain/enums/AddressType.json
@@ -1,51 +1,27 @@
 {
-  "classifierPath" : "meta::pure::metamodel::type::Enumeration",
-  "content" : {
-    "_type" : "Enumeration",
-    "name" : "AddressType",
-    "package" : "model::domain::enums",
-    "sourceInformation" : {
-      "endColumn" : 1,
-      "endLine" : 4,
-      "sourceId" : "",
-      "startColumn" : 1,
-      "startLine" : 1
-    },
-    "stereotypes" : [ ],
-    "taggedValues" : [ ],
-    "values" : [ {
-      "sourceInformation" : {
-        "endColumn" : 8,
-        "endLine" : 3,
-        "sourceId" : "",
-        "startColumn" : 3,
-        "startLine" : 3
+  "classifierPath": "meta::pure::metamodel::type::Enumeration",
+  "content": {
+    "_type": "Enumeration",
+    "name": "AddressType",
+    "package": "model::domain::enums",
+    "stereotypes": [],
+    "taggedValues": [],
+    "values": [
+      {
+        "stereotypes": [],
+        "taggedValues": [],
+        "value": "STREET"
       },
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "value" : "STREET"
-    }, {
-      "sourceInformation" : {
-        "endColumn" : 14,
-        "endLine" : 3,
-        "sourceId" : "",
-        "startColumn" : 11,
-        "startLine" : 3
+      {
+        "stereotypes": [],
+        "taggedValues": [],
+        "value": "CITY"
       },
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "value" : "CITY"
-    }, {
-      "sourceInformation" : {
-        "endColumn" : 23,
-        "endLine" : 3,
-        "sourceId" : "",
-        "startColumn" : 17,
-        "startLine" : 3
-      },
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "value" : "COUNTRY"
-    } ]
+      {
+        "stereotypes": [],
+        "taggedValues": [],
+        "value": "COUNTRY"
+      }
+    ]
   }
 }

--- a/legend-sdlc-protocol-pure/src/main/java/org/finos/legend/sdlc/protocol/pure/v1/PureEntitySerializer.java
+++ b/legend-sdlc-protocol-pure/src/main/java/org/finos/legend/sdlc/protocol/pure/v1/PureEntitySerializer.java
@@ -156,7 +156,11 @@ public class PureEntitySerializer implements EntityTextSerializer
 
     private PackageableElement deserializeToElement(String content)
     {
-        PureModelContextData pureModelContextData = this.pureParser.parseModel(content);
+        PureModelContextData pureModelContextData = this.pureParser.parseModel(
+                content,
+                // NOTE: remove source information to optimize model size for storage
+                false
+        );
         List<PackageableElement> elements = pureModelContextData.getElements();
         switch (elements.size())
         {

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/association/TestAssociation_full.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/association/TestAssociation_full.json
@@ -11,20 +11,6 @@
           "lowerBound": 0
         },
         "name": "employees",
-        "propertyTypeSourceInformation": {
-          "endColumn": 34,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 14,
-          "startLine": 3
-        },
-        "sourceInformation": {
-          "endColumn": 38,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 3
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "model::domain::Person"
@@ -35,50 +21,15 @@
           "upperBound": 1
         },
         "name": "employer",
-        "propertyTypeSourceInformation": {
-          "endColumn": 31,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 13,
-          "startLine": 4
-        },
-        "sourceInformation": {
-          "endColumn": 38,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 4
-        },
         "stereotypes": [],
         "taggedValues": [],
         "type": "model::domain::Firm"
       }
     ],
     "qualifiedProperties": [],
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 5,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 1
-    },
     "stereotypes": [
       {
         "profile": "model::domain::TestProfile",
-        "profileSourceInformation": {
-          "endColumn": 40,
-          "endLine": 1,
-          "sourceId": "",
-          "startColumn": 15,
-          "startLine": 1
-        },
-        "sourceInformation": {
-          "endColumn": 52,
-          "endLine": 1,
-          "sourceId": "",
-          "startColumn": 15,
-          "startLine": 1
-        },
         "value": "stereotype1"
       }
     ],

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/class/TestClass_full.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/class/TestClass_full.json
@@ -1,291 +1,112 @@
 {
-  "classifierPath" : "meta::pure::metamodel::type::Class",
-  "content" : {
-    "_type" : "class",
-    "constraints" : [ ],
-    "name" : "TestClass",
-    "originalMilestonedProperties" : [ ],
-    "package" : "model::domain",
-    "properties" : [ {
-      "multiplicity" : {
-        "lowerBound" : 1,
-        "upperBound" : 1
-      },
-      "name" : "oneName",
-      "propertyTypeSourceInformation" : {
-        "endColumn" : 162,
-        "endLine" : 3,
-        "sourceId" : "",
-        "startColumn" : 157,
-        "startLine" : 3
-      },
-      "sourceInformation" : {
-        "endColumn" : 166,
-        "endLine" : 3,
-        "sourceId" : "",
-        "startColumn" : 3,
-        "startLine" : 3
-      },
-      "stereotypes" : [ {
-        "profile" : "model::domain::TestProfile",
-        "profileSourceInformation" : {
-          "endColumn" : 30,
-          "endLine" : 3,
-          "sourceId" : "",
-          "startColumn" : 5,
-          "startLine" : 3
+  "classifierPath": "meta::pure::metamodel::type::Class",
+  "content": {
+    "_type": "class",
+    "constraints": [],
+    "name": "TestClass",
+    "originalMilestonedProperties": [],
+    "package": "model::domain",
+    "properties": [
+      {
+        "multiplicity": {
+          "lowerBound": 1,
+          "upperBound": 1
         },
-        "sourceInformation" : {
-          "endColumn" : 41,
-          "endLine" : 3,
-          "sourceId" : "",
-          "startColumn" : 5,
-          "startLine" : 3
-        },
-        "value" : "identifier"
-      } ],
-      "taggedValues" : [ {
-        "sourceInformation" : {
-          "endColumn" : 91,
-          "endLine" : 3,
-          "sourceId" : "",
-          "startColumn" : 46,
-          "startLine" : 3
-        },
-        "tag" : {
-          "profile" : "model::domain::TestProfile",
-          "profileSourceInformation" : {
-            "endColumn" : 71,
-            "endLine" : 3,
-            "sourceId" : "",
-            "startColumn" : 46,
-            "startLine" : 3
+        "name": "oneName",
+        "stereotypes": [
+          {
+            "profile": "model::domain::TestProfile",
+            "value": "identifier"
+          }
+        ],
+        "taggedValues": [
+          {
+            "tag": {
+              "profile": "model::domain::TestProfile",
+              "value": "tag1"
+            },
+            "value": "some value"
           },
-          "sourceInformation" : {
-            "endColumn" : 76,
-            "endLine" : 3,
-            "sourceId" : "",
-            "startColumn" : 73,
-            "startLine" : 3
+          {
+            "tag": {
+              "profile": "model::domain::TestProfile",
+              "value": "tag2"
+            },
+            "value": "some other value"
+          }
+        ],
+        "type": "String"
+      },
+      {
+        "multiplicity": {
+          "lowerBound": 0,
+          "upperBound": 1
+        },
+        "name": "anotherName",
+        "stereotypes": [],
+        "taggedValues": [],
+        "type": "String"
+      },
+      {
+        "multiplicity": {
+          "lowerBound": 0,
+          "upperBound": 1
+        },
+        "name": "oneDate",
+        "stereotypes": [],
+        "taggedValues": [
+          {
+            "tag": {
+              "profile": "model::domain::TestProfile",
+              "value": "tag1"
+            },
+            "value": "some kind of date"
+          }
+        ],
+        "type": "StrictDate"
+      },
+      {
+        "multiplicity": {
+          "lowerBound": 0,
+          "upperBound": 1
+        },
+        "name": "anotherDate",
+        "stereotypes": [],
+        "taggedValues": [],
+        "type": "DateTime"
+      },
+      {
+        "multiplicity": {
+          "lowerBound": 1,
+          "upperBound": 1
+        },
+        "name": "oneNumber",
+        "stereotypes": [
+          {
+            "profile": "model::domain::TestProfile",
+            "value": "stereotype1"
           },
-          "value" : "tag1"
+          {
+            "profile": "model::domain::TestProfile",
+            "value": "stereotype2"
+          }
+        ],
+        "taggedValues": [],
+        "type": "Integer"
+      },
+      {
+        "multiplicity": {
+          "lowerBound": 0
         },
-        "value" : "some value"
-      }, {
-        "sourceInformation" : {
-          "endColumn" : 145,
-          "endLine" : 3,
-          "sourceId" : "",
-          "startColumn" : 94,
-          "startLine" : 3
-        },
-        "tag" : {
-          "profile" : "model::domain::TestProfile",
-          "profileSourceInformation" : {
-            "endColumn" : 119,
-            "endLine" : 3,
-            "sourceId" : "",
-            "startColumn" : 94,
-            "startLine" : 3
-          },
-          "sourceInformation" : {
-            "endColumn" : 124,
-            "endLine" : 3,
-            "sourceId" : "",
-            "startColumn" : 121,
-            "startLine" : 3
-          },
-          "value" : "tag2"
-        },
-        "value" : "some other value"
-      } ],
-      "type" : "String"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 0,
-        "upperBound" : 1
-      },
-      "name" : "anotherName",
-      "propertyTypeSourceInformation" : {
-        "endColumn" : 21,
-        "endLine" : 4,
-        "sourceId" : "",
-        "startColumn" : 16,
-        "startLine" : 4
-      },
-      "sourceInformation" : {
-        "endColumn" : 28,
-        "endLine" : 4,
-        "sourceId" : "",
-        "startColumn" : 3,
-        "startLine" : 4
-      },
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "type" : "String"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 0,
-        "upperBound" : 1
-      },
-      "name" : "oneDate",
-      "propertyTypeSourceInformation" : {
-        "endColumn" : 77,
-        "endLine" : 5,
-        "sourceId" : "",
-        "startColumn" : 68,
-        "startLine" : 5
-      },
-      "sourceInformation" : {
-        "endColumn" : 84,
-        "endLine" : 5,
-        "sourceId" : "",
-        "startColumn" : 3,
-        "startLine" : 5
-      },
-      "stereotypes" : [ ],
-      "taggedValues" : [ {
-        "sourceInformation" : {
-          "endColumn" : 56,
-          "endLine" : 5,
-          "sourceId" : "",
-          "startColumn" : 4,
-          "startLine" : 5
-        },
-        "tag" : {
-          "profile" : "model::domain::TestProfile",
-          "profileSourceInformation" : {
-            "endColumn" : 29,
-            "endLine" : 5,
-            "sourceId" : "",
-            "startColumn" : 4,
-            "startLine" : 5
-          },
-          "sourceInformation" : {
-            "endColumn" : 34,
-            "endLine" : 5,
-            "sourceId" : "",
-            "startColumn" : 31,
-            "startLine" : 5
-          },
-          "value" : "tag1"
-        },
-        "value" : "some kind of date"
-      } ],
-      "type" : "StrictDate"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 0,
-        "upperBound" : 1
-      },
-      "name" : "anotherDate",
-      "propertyTypeSourceInformation" : {
-        "endColumn" : 23,
-        "endLine" : 6,
-        "sourceId" : "",
-        "startColumn" : 16,
-        "startLine" : 6
-      },
-      "sourceInformation" : {
-        "endColumn" : 30,
-        "endLine" : 6,
-        "sourceId" : "",
-        "startColumn" : 3,
-        "startLine" : 6
-      },
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "type" : "DateTime"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 1,
-        "upperBound" : 1
-      },
-      "name" : "oneNumber",
-      "propertyTypeSourceInformation" : {
-        "endColumn" : 103,
-        "endLine" : 7,
-        "sourceId" : "",
-        "startColumn" : 97,
-        "startLine" : 7
-      },
-      "sourceInformation" : {
-        "endColumn" : 107,
-        "endLine" : 7,
-        "sourceId" : "",
-        "startColumn" : 3,
-        "startLine" : 7
-      },
-      "stereotypes" : [ {
-        "profile" : "model::domain::TestProfile",
-        "profileSourceInformation" : {
-          "endColumn" : 30,
-          "endLine" : 7,
-          "sourceId" : "",
-          "startColumn" : 5,
-          "startLine" : 7
-        },
-        "sourceInformation" : {
-          "endColumn" : 42,
-          "endLine" : 7,
-          "sourceId" : "",
-          "startColumn" : 5,
-          "startLine" : 7
-        },
-        "value" : "stereotype1"
-      }, {
-        "profile" : "model::domain::TestProfile",
-        "profileSourceInformation" : {
-          "endColumn" : 70,
-          "endLine" : 7,
-          "sourceId" : "",
-          "startColumn" : 45,
-          "startLine" : 7
-        },
-        "sourceInformation" : {
-          "endColumn" : 82,
-          "endLine" : 7,
-          "sourceId" : "",
-          "startColumn" : 45,
-          "startLine" : 7
-        },
-        "value" : "stereotype2"
-      } ],
-      "taggedValues" : [ ],
-      "type" : "Integer"
-    }, {
-      "multiplicity" : {
-        "lowerBound" : 0
-      },
-      "name" : "moreNumbers",
-      "propertyTypeSourceInformation" : {
-        "endColumn" : 20,
-        "endLine" : 8,
-        "sourceId" : "",
-        "startColumn" : 16,
-        "startLine" : 8
-      },
-      "sourceInformation" : {
-        "endColumn" : 24,
-        "endLine" : 8,
-        "sourceId" : "",
-        "startColumn" : 3,
-        "startLine" : 8
-      },
-      "stereotypes" : [ ],
-      "taggedValues" : [ ],
-      "type" : "Float"
-    } ],
-    "qualifiedProperties" : [ ],
-    "sourceInformation" : {
-      "endColumn" : 1,
-      "endLine" : 9,
-      "sourceId" : "",
-      "startColumn" : 1,
-      "startLine" : 1
-    },
-    "stereotypes" : [ ],
-    "superTypes" : [ ],
-    "taggedValues" : [ ]
+        "name": "moreNumbers",
+        "stereotypes": [],
+        "taggedValues": [],
+        "type": "Float"
+      }
+    ],
+    "qualifiedProperties": [],
+    "stereotypes": [],
+    "superTypes": [],
+    "taggedValues": []
   }
 }

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/class/TestClass_reduced.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/class/TestClass_reduced.json
@@ -14,20 +14,6 @@
         "stereotypes": [
           {
             "profile": "model::domain::TestProfile",
-            "profileSourceInformation": {
-              "endColumn": 30,
-              "endLine": 3,
-              "sourceId": "",
-              "startColumn": 5,
-              "startLine": 3
-            },
-            "sourceInformation": {
-              "endColumn": 41,
-              "endLine": 3,
-              "sourceId": "",
-              "startColumn": 5,
-              "startLine": 3
-            },
             "value": "identifier"
           }
         ],

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/enumeration/TestEnumeration_full.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/enumeration/TestEnumeration_full.json
@@ -4,41 +4,13 @@
     "_type": "Enumeration",
     "name": "TestEnumeration",
     "package": "model::domain",
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 7,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 1
-    },
     "stereotypes": [],
     "taggedValues": [],
     "values": [
       {
-        "sourceInformation": {
-          "endColumn": 51,
-          "endLine": 3,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 3
-        },
         "stereotypes": [
           {
             "profile": "model::domain::TestProfile",
-            "profileSourceInformation": {
-              "endColumn": 30,
-              "endLine": 3,
-              "sourceId": "",
-              "startColumn": 5,
-              "startLine": 3
-            },
-            "sourceInformation": {
-              "endColumn": 42,
-              "endLine": 3,
-              "sourceId": "",
-              "startColumn": 5,
-              "startLine": 3
-            },
             "value": "stereotype1"
           }
         ],
@@ -46,39 +18,11 @@
         "value": "VALUE1"
       },
       {
-        "sourceInformation": {
-          "endColumn": 57,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 4
-        },
         "stereotypes": [],
         "taggedValues": [
           {
-            "sourceInformation": {
-              "endColumn": 49,
-              "endLine": 4,
-              "sourceId": "",
-              "startColumn": 4,
-              "startLine": 4
-            },
             "tag": {
               "profile": "model::domain::TestProfile",
-              "profileSourceInformation": {
-                "endColumn": 29,
-                "endLine": 4,
-                "sourceId": "",
-                "startColumn": 4,
-                "startLine": 4
-              },
-              "sourceInformation": {
-                "endColumn": 34,
-                "endLine": 4,
-                "sourceId": "",
-                "startColumn": 31,
-                "startLine": 4
-              },
               "value": "tag1"
             },
             "value": "some value"
@@ -87,104 +31,27 @@
         "value": "VALUE2"
       },
       {
-        "sourceInformation": {
-          "endColumn": 201,
-          "endLine": 5,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 5
-        },
         "stereotypes": [
           {
             "profile": "model::domain::TestProfile",
-            "profileSourceInformation": {
-              "endColumn": 30,
-              "endLine": 5,
-              "sourceId": "",
-              "startColumn": 5,
-              "startLine": 5
-            },
-            "sourceInformation": {
-              "endColumn": 42,
-              "endLine": 5,
-              "sourceId": "",
-              "startColumn": 5,
-              "startLine": 5
-            },
             "value": "stereotype1"
           },
           {
             "profile": "model::domain::TestProfile",
-            "profileSourceInformation": {
-              "endColumn": 70,
-              "endLine": 5,
-              "sourceId": "",
-              "startColumn": 45,
-              "startLine": 5
-            },
-            "sourceInformation": {
-              "endColumn": 82,
-              "endLine": 5,
-              "sourceId": "",
-              "startColumn": 45,
-              "startLine": 5
-            },
             "value": "stereotype2"
           }
         ],
         "taggedValues": [
           {
-            "sourceInformation": {
-              "endColumn": 138,
-              "endLine": 5,
-              "sourceId": "",
-              "startColumn": 87,
-              "startLine": 5
-            },
             "tag": {
               "profile": "model::domain::TestProfile",
-              "profileSourceInformation": {
-                "endColumn": 112,
-                "endLine": 5,
-                "sourceId": "",
-                "startColumn": 87,
-                "startLine": 5
-              },
-              "sourceInformation": {
-                "endColumn": 117,
-                "endLine": 5,
-                "sourceId": "",
-                "startColumn": 114,
-                "startLine": 5
-              },
               "value": "tag1"
             },
             "value": "some other value"
           },
           {
-            "sourceInformation": {
-              "endColumn": 193,
-              "endLine": 5,
-              "sourceId": "",
-              "startColumn": 141,
-              "startLine": 5
-            },
             "tag": {
               "profile": "model::domain::TestProfile",
-              "profileSourceInformation": {
-                "endColumn": 166,
-                "endLine": 5,
-                "sourceId": "",
-                "startColumn": 141,
-                "startLine": 5
-              },
-              "sourceInformation": {
-                "endColumn": 171,
-                "endLine": 5,
-                "sourceId": "",
-                "startColumn": 168,
-                "startLine": 5
-              },
               "value": "tag2"
             },
             "value": "yet another value"
@@ -193,13 +60,6 @@
         "value": "VALUE3"
       },
       {
-        "sourceInformation": {
-          "endColumn": 8,
-          "endLine": 6,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 6
-        },
         "stereotypes": [],
         "taggedValues": [],
         "value": "VALUE4"

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/m2m/TestMapping_full.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/m2m/TestMapping_full.json
@@ -7,13 +7,6 @@
       {
         "_type": "pureInstance",
         "class": "model::domain::TargetClass1",
-        "classSourceInformation": {
-          "endColumn": 29,
-          "endLine": 6,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 6
-        },
         "id": "tc1",
         "propertyMappings": [
           {
@@ -21,23 +14,9 @@
             "explodeProperty": false,
             "property": {
               "class": "model::domain::TargetClass1",
-              "property": "id",
-              "sourceInformation": {
-                "endColumn": 6,
-                "endLine": 9,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 9
-              }
+              "property": "id"
             },
             "source": "tc1",
-            "sourceInformation": {
-              "endColumn": 15,
-              "endLine": 9,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 5,
-              "startLine": 9
-            },
             "transform": {
               "_type": "lambda",
               "body": [
@@ -46,24 +25,10 @@
                   "parameters": [
                     {
                       "_type": "var",
-                      "name": "src",
-                      "sourceInformation": {
-                        "endColumn": 12,
-                        "endLine": 9,
-                        "sourceId": "model::mapping::TestMapping",
-                        "startColumn": 9,
-                        "startLine": 9
-                      }
+                      "name": "src"
                     }
                   ],
-                  "property": "id",
-                  "sourceInformation": {
-                    "endColumn": 15,
-                    "endLine": 9,
-                    "sourceId": "model::mapping::TestMapping",
-                    "startColumn": 14,
-                    "startLine": 9
-                  }
+                  "property": "id"
                 }
               ],
               "parameters": []
@@ -75,23 +40,9 @@
             "explodeProperty": false,
             "property": {
               "class": "model::domain::TargetClass1",
-              "property": "type",
-              "sourceInformation": {
-                "endColumn": 8,
-                "endLine": 10,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 10
-              }
+              "property": "type"
             },
             "source": "tc1",
-            "sourceInformation": {
-              "endColumn": 65,
-              "endLine": 10,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 5,
-              "startLine": 10
-            },
             "transform": {
               "_type": "lambda",
               "body": [
@@ -100,24 +51,10 @@
                   "parameters": [
                     {
                       "_type": "var",
-                      "name": "src",
-                      "sourceInformation": {
-                        "endColumn": 60,
-                        "endLine": 10,
-                        "sourceId": "model::mapping::TestMapping",
-                        "startColumn": 57,
-                        "startLine": 10
-                      }
+                      "name": "src"
                     }
                   ],
-                  "property": "type",
-                  "sourceInformation": {
-                    "endColumn": 65,
-                    "endLine": 10,
-                    "sourceId": "model::mapping::TestMapping",
-                    "startColumn": 62,
-                    "startLine": 10
-                  }
+                  "property": "type"
                 }
               ],
               "parameters": []
@@ -129,23 +66,9 @@
             "explodeProperty": false,
             "property": {
               "class": "model::domain::TargetClass1",
-              "property": "otherType",
-              "sourceInformation": {
-                "endColumn": 13,
-                "endLine": 11,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 11
-              }
+              "property": "otherType"
             },
             "source": "tc1",
-            "sourceInformation": {
-              "endColumn": 78,
-              "endLine": 11,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 5,
-              "startLine": 11
-            },
             "transform": {
               "_type": "lambda",
               "body": [
@@ -154,24 +77,10 @@
                   "parameters": [
                     {
                       "_type": "var",
-                      "name": "src",
-                      "sourceInformation": {
-                        "endColumn": 68,
-                        "endLine": 11,
-                        "sourceId": "model::mapping::TestMapping",
-                        "startColumn": 65,
-                        "startLine": 11
-                      }
+                      "name": "src"
                     }
                   ],
-                  "property": "otherType",
-                  "sourceInformation": {
-                    "endColumn": 78,
-                    "endLine": 11,
-                    "sourceId": "model::mapping::TestMapping",
-                    "startColumn": 70,
-                    "startLine": 11
-                  }
+                  "property": "otherType"
                 }
               ],
               "parameters": []
@@ -182,23 +91,9 @@
             "explodeProperty": false,
             "property": {
               "class": "model::domain::TargetClass1",
-              "property": "other",
-              "sourceInformation": {
-                "endColumn": 9,
-                "endLine": 12,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 12
-              }
+              "property": "other"
             },
             "source": "tc1",
-            "sourceInformation": {
-              "endColumn": 26,
-              "endLine": 12,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 5,
-              "startLine": 12
-            },
             "target": "tc2",
             "transform": {
               "_type": "lambda",
@@ -208,24 +103,10 @@
                   "parameters": [
                     {
                       "_type": "var",
-                      "name": "src",
-                      "sourceInformation": {
-                        "endColumn": 20,
-                        "endLine": 12,
-                        "sourceId": "model::mapping::TestMapping",
-                        "startColumn": 17,
-                        "startLine": 12
-                      }
+                      "name": "src"
                     }
                   ],
-                  "property": "other",
-                  "sourceInformation": {
-                    "endColumn": 26,
-                    "endLine": 12,
-                    "sourceId": "model::mapping::TestMapping",
-                    "startColumn": 22,
-                    "startLine": 12
-                  }
+                  "property": "other"
                 }
               ],
               "parameters": []
@@ -233,32 +114,11 @@
           }
         ],
         "root": false,
-        "sourceClassSourceInformation": {
-          "endColumn": 36,
-          "endLine": 8,
-          "sourceId": "model::mapping::TestMapping",
-          "startColumn": 10,
-          "startLine": 8
-        },
-        "sourceInformation": {
-          "endColumn": 3,
-          "endLine": 13,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 6
-        },
         "srcClass": "model::domain::SourceClass1"
       },
       {
         "_type": "pureInstance",
         "class": "model::domain::TargetClass2",
-        "classSourceInformation": {
-          "endColumn": 29,
-          "endLine": 14,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 14
-        },
         "id": "tc2",
         "propertyMappings": [
           {
@@ -266,23 +126,9 @@
             "explodeProperty": false,
             "property": {
               "class": "model::domain::TargetClass2",
-              "property": "id",
-              "sourceInformation": {
-                "endColumn": 6,
-                "endLine": 17,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 17
-              }
+              "property": "id"
             },
             "source": "tc2",
-            "sourceInformation": {
-              "endColumn": 15,
-              "endLine": 17,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 5,
-              "startLine": 17
-            },
             "transform": {
               "_type": "lambda",
               "body": [
@@ -291,24 +137,10 @@
                   "parameters": [
                     {
                       "_type": "var",
-                      "name": "src",
-                      "sourceInformation": {
-                        "endColumn": 12,
-                        "endLine": 17,
-                        "sourceId": "model::mapping::TestMapping",
-                        "startColumn": 9,
-                        "startLine": 17
-                      }
+                      "name": "src"
                     }
                   ],
-                  "property": "id",
-                  "sourceInformation": {
-                    "endColumn": 15,
-                    "endLine": 17,
-                    "sourceId": "model::mapping::TestMapping",
-                    "startColumn": 14,
-                    "startLine": 17
-                  }
+                  "property": "id"
                 }
               ],
               "parameters": []
@@ -319,23 +151,9 @@
             "explodeProperty": false,
             "property": {
               "class": "model::domain::TargetClass2",
-              "property": "name",
-              "sourceInformation": {
-                "endColumn": 8,
-                "endLine": 18,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 18
-              }
+              "property": "name"
             },
             "source": "tc2",
-            "sourceInformation": {
-              "endColumn": 34,
-              "endLine": 18,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 5,
-              "startLine": 18
-            },
             "transform": {
               "_type": "lambda",
               "body": [
@@ -348,33 +166,12 @@
                       "parameters": [
                         {
                           "_type": "var",
-                          "name": "src",
-                          "sourceInformation": {
-                            "endColumn": 14,
-                            "endLine": 18,
-                            "sourceId": "model::mapping::TestMapping",
-                            "startColumn": 11,
-                            "startLine": 18
-                          }
+                          "name": "src"
                         }
                       ],
-                      "property": "name",
-                      "sourceInformation": {
-                        "endColumn": 19,
-                        "endLine": 18,
-                        "sourceId": "model::mapping::TestMapping",
-                        "startColumn": 16,
-                        "startLine": 18
-                      }
+                      "property": "name"
                     }
-                  ],
-                  "sourceInformation": {
-                    "endColumn": 32,
-                    "endLine": 18,
-                    "sourceId": "model::mapping::TestMapping",
-                    "startColumn": 22,
-                    "startLine": 18
-                  }
+                  ]
                 }
               ],
               "parameters": []
@@ -382,20 +179,6 @@
           }
         ],
         "root": false,
-        "sourceClassSourceInformation": {
-          "endColumn": 36,
-          "endLine": 16,
-          "sourceId": "model::mapping::TestMapping",
-          "startColumn": 10,
-          "startLine": 16
-        },
-        "sourceInformation": {
-          "endColumn": 3,
-          "endLine": 19,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 14
-        },
         "srcClass": "model::domain::SourceClass2"
       }
     ],
@@ -435,14 +218,7 @@
           }
         ],
         "enumeration": "model::domain::TestEnumeration",
-        "id": "TestEnumerationMappingInt",
-        "sourceInformation": {
-          "endColumn": 3,
-          "endLine": 26,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 21
-        }
+        "id": "TestEnumerationMappingInt"
       },
       {
         "enumValueMappings": [
@@ -479,37 +255,16 @@
           }
         ],
         "enumeration": "model::domain::TestEnumeration",
-        "id": "TestEnumerationMappingString",
-        "sourceInformation": {
-          "endColumn": 3,
-          "endLine": 32,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 27
-        }
+        "id": "TestEnumerationMappingString"
       }
     ],
     "includedMappings": [
       {
-        "includedMapping": "model::mapping::OtherMapping",
-        "sourceInformation": {
-          "endColumn": 38,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 4
-        }
+        "includedMapping": "model::mapping::OtherMapping"
       }
     ],
     "name": "TestMapping",
     "package": "model::mapping",
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 33,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 2
-    },
     "tests": []
   }
 }

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/relational/TestMapping_full.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/relational/TestMapping_full.json
@@ -7,13 +7,6 @@
       {
         "_type": "relational",
         "class": "model::domain::TargetClass1",
-        "classSourceInformation": {
-          "endColumn": 29,
-          "endLine": 6,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 6
-        },
         "distinct": false,
         "groupBy": [],
         "id": "tc1",
@@ -23,214 +16,88 @@
             "_type": "relationalPropertyMapping",
             "property": {
               "class": "model::domain::TargetClass1",
-              "property": "id",
-              "sourceInformation": {
-                "endColumn": 6,
-                "endLine": 8,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 8
-              }
+              "property": "id"
             },
             "relationalOperation": {
               "_type": "column",
               "column": "id",
-              "sourceInformation": {
-                "endColumn": 46,
-                "endLine": 8,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 9,
-                "startLine": 8
-              },
               "table": {
                 "_type": "Table",
                 "database": "model::domain::TestDatabase",
                 "mainTableDb": "model::domain::TestDatabase",
                 "schema": "default",
-                "sourceInformation": {
-                  "endColumn": 43,
-                  "endLine": 8,
-                  "sourceId": "model::mapping::TestMapping",
-                  "startColumn": 38,
-                  "startLine": 8
-                },
                 "table": "Table1"
               },
               "tableAlias": "Table1"
             },
-            "source": "tc1",
-            "sourceInformation": {
-              "endColumn": 46,
-              "endLine": 8,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 7,
-              "startLine": 8
-            }
+            "source": "tc1"
           },
           {
             "_type": "relationalPropertyMapping",
             "enumMappingId": "TestEnumerationMappingInt",
             "property": {
               "class": "model::domain::TargetClass1",
-              "property": "type",
-              "sourceInformation": {
-                "endColumn": 8,
-                "endLine": 9,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 9
-              }
+              "property": "type"
             },
             "relationalOperation": {
               "_type": "column",
               "column": "type",
-              "sourceInformation": {
-                "endColumn": 96,
-                "endLine": 9,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 57,
-                "startLine": 9
-              },
               "table": {
                 "_type": "Table",
                 "database": "model::domain::TestDatabase",
                 "mainTableDb": "model::domain::TestDatabase",
                 "schema": "default",
-                "sourceInformation": {
-                  "endColumn": 91,
-                  "endLine": 9,
-                  "sourceId": "model::mapping::TestMapping",
-                  "startColumn": 86,
-                  "startLine": 9
-                },
                 "table": "Table1"
               },
               "tableAlias": "Table1"
             },
-            "source": "tc1",
-            "sourceInformation": {
-              "endColumn": 96,
-              "endLine": 9,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 9,
-              "startLine": 9
-            }
+            "source": "tc1"
           },
           {
             "_type": "relationalPropertyMapping",
             "enumMappingId": "TestEnumerationMappingString",
             "property": {
               "class": "model::domain::TargetClass1",
-              "property": "otherType",
-              "sourceInformation": {
-                "endColumn": 13,
-                "endLine": 10,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 10
-              }
+              "property": "otherType"
             },
             "relationalOperation": {
               "_type": "column",
               "column": "otherType",
-              "sourceInformation": {
-                "endColumn": 109,
-                "endLine": 10,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 65,
-                "startLine": 10
-              },
               "table": {
                 "_type": "Table",
                 "database": "model::domain::TestDatabase",
                 "mainTableDb": "model::domain::TestDatabase",
                 "schema": "default",
-                "sourceInformation": {
-                  "endColumn": 99,
-                  "endLine": 10,
-                  "sourceId": "model::mapping::TestMapping",
-                  "startColumn": 94,
-                  "startLine": 10
-                },
                 "table": "Table1"
               },
               "tableAlias": "Table1"
             },
-            "source": "tc1",
-            "sourceInformation": {
-              "endColumn": 109,
-              "endLine": 10,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 14,
-              "startLine": 10
-            }
+            "source": "tc1"
           },
           {
             "_type": "relationalPropertyMapping",
             "property": {
               "class": "model::domain::TargetClass1",
-              "property": "other",
-              "sourceInformation": {
-                "endColumn": 9,
-                "endLine": 11,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 11
-              }
+              "property": "other"
             },
             "relationalOperation": {
               "_type": "elemtWithJoins",
               "joins": [
                 {
                   "db": "model::domain::TestDatabase",
-                  "name": "Table1_Table2",
-                  "sourceInformation": {
-                    "endColumn": 59,
-                    "endLine": 11,
-                    "sourceId": "model::mapping::TestMapping",
-                    "startColumn": 46,
-                    "startLine": 11
-                  }
+                  "name": "Table1_Table2"
                 }
-              ],
-              "sourceInformation": {
-                "endColumn": 59,
-                "endLine": 11,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 17,
-                "startLine": 11
-              }
+              ]
             },
             "source": "tc1",
-            "sourceInformation": {
-              "endColumn": 59,
-              "endLine": 11,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 15,
-              "startLine": 11
-            },
             "target": "tc2"
           }
         ],
-        "root": false,
-        "sourceInformation": {
-          "endColumn": 3,
-          "endLine": 12,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 6
-        }
+        "root": false
       },
       {
         "_type": "relational",
         "class": "model::domain::TargetClass2",
-        "classSourceInformation": {
-          "endColumn": 29,
-          "endLine": 13,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 13
-        },
         "distinct": false,
         "groupBy": [],
         "id": "tc2",
@@ -240,62 +107,27 @@
             "_type": "relationalPropertyMapping",
             "property": {
               "class": "model::domain::TargetClass2",
-              "property": "id",
-              "sourceInformation": {
-                "endColumn": 6,
-                "endLine": 15,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 15
-              }
+              "property": "id"
             },
             "relationalOperation": {
               "_type": "column",
               "column": "id",
-              "sourceInformation": {
-                "endColumn": 46,
-                "endLine": 15,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 9,
-                "startLine": 15
-              },
               "table": {
                 "_type": "Table",
                 "database": "model::domain::TestDatabase",
                 "mainTableDb": "model::domain::TestDatabase",
                 "schema": "default",
-                "sourceInformation": {
-                  "endColumn": 43,
-                  "endLine": 15,
-                  "sourceId": "model::mapping::TestMapping",
-                  "startColumn": 38,
-                  "startLine": 15
-                },
                 "table": "Table2"
               },
               "tableAlias": "Table2"
             },
-            "source": "tc2",
-            "sourceInformation": {
-              "endColumn": 46,
-              "endLine": 15,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 7,
-              "startLine": 15
-            }
+            "source": "tc2"
           },
           {
             "_type": "relationalPropertyMapping",
             "property": {
               "class": "model::domain::TargetClass2",
-              "property": "name",
-              "sourceInformation": {
-                "endColumn": 8,
-                "endLine": 16,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 5,
-                "startLine": 16
-              }
+              "property": "name"
             },
             "relationalOperation": {
               "_type": "dynaFunc",
@@ -304,56 +136,21 @@
                 {
                   "_type": "column",
                   "column": "name",
-                  "sourceInformation": {
-                    "endColumn": 56,
-                    "endLine": 16,
-                    "sourceId": "model::mapping::TestMapping",
-                    "startColumn": 17,
-                    "startLine": 16
-                  },
                   "table": {
                     "_type": "Table",
                     "database": "model::domain::TestDatabase",
                     "mainTableDb": "model::domain::TestDatabase",
                     "schema": "default",
-                    "sourceInformation": {
-                      "endColumn": 51,
-                      "endLine": 16,
-                      "sourceId": "model::mapping::TestMapping",
-                      "startColumn": 46,
-                      "startLine": 16
-                    },
                     "table": "Table2"
                   },
                   "tableAlias": "Table2"
                 }
-              ],
-              "sourceInformation": {
-                "endColumn": 57,
-                "endLine": 16,
-                "sourceId": "model::mapping::TestMapping",
-                "startColumn": 11,
-                "startLine": 16
-              }
+              ]
             },
-            "source": "tc2",
-            "sourceInformation": {
-              "endColumn": 57,
-              "endLine": 16,
-              "sourceId": "model::mapping::TestMapping",
-              "startColumn": 9,
-              "startLine": 16
-            }
+            "source": "tc2"
           }
         ],
-        "root": false,
-        "sourceInformation": {
-          "endColumn": 3,
-          "endLine": 17,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 13
-        }
+        "root": false
       }
     ],
     "enumerationMappings": [
@@ -392,14 +189,7 @@
           }
         ],
         "enumeration": "model::domain::TestEnumeration",
-        "id": "TestEnumerationMappingInt",
-        "sourceInformation": {
-          "endColumn": 3,
-          "endLine": 24,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 19
-        }
+        "id": "TestEnumerationMappingInt"
       },
       {
         "enumValueMappings": [
@@ -436,37 +226,16 @@
           }
         ],
         "enumeration": "model::domain::TestEnumeration",
-        "id": "TestEnumerationMappingString",
-        "sourceInformation": {
-          "endColumn": 3,
-          "endLine": 30,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 25
-        }
+        "id": "TestEnumerationMappingString"
       }
     ],
     "includedMappings": [
       {
-        "includedMapping": "model::mapping::OtherMapping",
-        "sourceInformation": {
-          "endColumn": 38,
-          "endLine": 4,
-          "sourceId": "",
-          "startColumn": 3,
-          "startLine": 4
-        }
+        "includedMapping": "model::mapping::OtherMapping"
       }
     ],
     "name": "TestMapping",
     "package": "model::mapping",
-    "sourceInformation": {
-      "endColumn": 1,
-      "endLine": 31,
-      "sourceId": "",
-      "startColumn": 1,
-      "startLine": 2
-    },
     "tests": []
   }
 }


### PR DESCRIPTION
I believe we have properly fixed the problem in `engine` with `returnSourceInformation=false` flag in https://github.com/finos/legend-engine/pull/692 so it should be safe to make use of this to:
- reduce entity size
- improve SDLC response time due to lower traffic load