### PR TITLE
[WIP] Improve test coverage of ReviewsResource 

### DIFF
--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/AbstractLegendSDLCServerResourceTest.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/AbstractLegendSDLCServerResourceTest.java
@@ -16,6 +16,7 @@ package org.finos.legend.sdlc.server.resources;
 
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.apache.http.client.HttpResponseException;
 import org.finos.legend.sdlc.server.LegendSDLCServerForTest;
 import org.finos.legend.sdlc.server.config.LegendSDLCServerConfiguration;
 import org.finos.legend.sdlc.server.inmemory.backend.InMemoryBackend;
@@ -26,6 +27,7 @@ import org.junit.Rule;
 import java.util.Optional;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
 
 public abstract class AbstractLegendSDLCServerResourceTest
 {
@@ -68,4 +70,13 @@ public abstract class AbstractLegendSDLCServerResourceTest
     {
         return "http://localhost:" + APP_RULE.getLocalPort() + Optional.ofNullable(path).orElse("");
     }
+
+    protected Response getSuccessfulOrThrow(String url) throws HttpResponseException{
+        javax.ws.rs.core.Response response = this.clientFor(url).request().get();
+        if (response.getStatusInfo().getFamily() == javax.ws.rs.core.Response.Status.Family.SUCCESSFUL) {
+            throw new HttpResponseException(response.getStatus(), "Error during http call with status: " + response.getStatus() + " , entity: " + response.readEntity(String.class));
+        }
+        return response;
+    }
+
 }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/AbstractLegendSDLCServerResourceTest.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/AbstractLegendSDLCServerResourceTest.java
@@ -16,7 +16,9 @@ package org.finos.legend.sdlc.server.resources;
 
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpResponseException;
+import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.finos.legend.sdlc.server.LegendSDLCServerForTest;
 import org.finos.legend.sdlc.server.config.LegendSDLCServerConfiguration;
 import org.finos.legend.sdlc.server.inmemory.backend.InMemoryBackend;
@@ -24,9 +26,14 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Request;
 import javax.ws.rs.core.Response;
 
 public abstract class AbstractLegendSDLCServerResourceTest
@@ -70,13 +77,47 @@ public abstract class AbstractLegendSDLCServerResourceTest
     {
         return "http://localhost:" + APP_RULE.getLocalPort() + Optional.ofNullable(path).orElse("");
     }
-
-    protected Response getSuccessfulOrThrow(String url) throws HttpResponseException{
-        javax.ws.rs.core.Response response = this.clientFor(url).request().get();
-        if (response.getStatusInfo().getFamily() == javax.ws.rs.core.Response.Status.Family.SUCCESSFUL) {
-            throw new HttpResponseException(response.getStatus(), "Error during http call with status: " + response.getStatus() + " , entity: " + response.readEntity(String.class));
-        }
-        return response;
+    public RequestHelper requestHelperFor(String url){
+        return new RequestHelper(this.clientFor(url));
     }
+
+    static class RequestHelper {
+
+        private Optional<Set<Response.Status.Family>> acceptableResponseStatuses = Optional.empty();
+        private final WebTarget webTarget;
+
+        private RequestHelper(WebTarget webTarget){
+            this.webTarget = webTarget;
+        }
+
+        public RequestHelper withAcceptableResponseStatuses(Set<javax.ws.rs.core.Response.Status.Family> acceptableResponseStatuses){
+            this.acceptableResponseStatuses = Optional.of(new HashSet<>(acceptableResponseStatuses));
+            return this;
+        }
+
+        private Invocation.Builder request(){
+            return null;
+        }
+
+        private void checkResponseIsAcceptable(Response response) throws HttpResponseException{
+            if(this.acceptableResponseStatuses.isPresent()) {
+                Set<javax.ws.rs.core.Response.Status.Family> acceptableResponseStatuses = this.acceptableResponseStatuses.get();
+                if (!acceptableResponseStatuses.contains(response.getStatusInfo().getFamily())) {
+                    throw new HttpResponseException(response.getStatus(), "Error during http call with status: " + response.getStatus() + " , entity: " + response.readEntity(String.class));
+                }
+            }
+        }
+
+        public Response get() throws HttpResponseException{
+            Response response = this.request().get();
+            checkResponseIsAcceptable(response);
+            return response;
+        }
+        public <T> T getTyped() throws HttpResponseException{
+            Response response = this.get();
+            return response.readEntity(new GenericType<T>(){});
+        }
+    }
+
 
 }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestProjectsResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestProjectsResource.java
@@ -16,9 +16,11 @@ package org.finos.legend.sdlc.server.resources;
 
 import org.apache.http.client.HttpResponseException;
 import org.finos.legend.sdlc.domain.model.project.Project;
+import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
@@ -33,11 +35,9 @@ public class TestProjectsResource extends AbstractLegendSDLCServerResourceTest
         this.backend.project("C").addVersionedClasses("1.0.0", "c1", "c2");
         this.backend.project("B").addDependency("C:1.0.0");
 
-        Response response = this.getSuccessfulOrThrow("/api/projects");
-
-        List<Project> projects = response.readEntity(new GenericType<List<Project>>()
-        {
-        });
+        List<Project> projects = this.requestHelperFor("/api/projects")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertEquals(3, projects.size());
         Assert.assertEquals("project-A", findProject(projects, "A").getName());

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestProjectsResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestProjectsResource.java
@@ -33,12 +33,7 @@ public class TestProjectsResource extends AbstractLegendSDLCServerResourceTest
         this.backend.project("C").addVersionedClasses("1.0.0", "c1", "c2");
         this.backend.project("B").addDependency("C:1.0.0");
 
-        Response response = this.clientFor("/api/projects").request().get();
-
-        if (response.getStatus() != 200)
-        {
-            throw new HttpResponseException(response.getStatus(), "Error during http call with status: " + response.getStatus() + " , entity: " + response.readEntity(String.class));
-        }
+        Response response = this.getSuccessfulOrThrow("/api/projects");
 
         List<Project> projects = response.readEntity(new GenericType<List<Project>>()
         {

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestReviewsResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestReviewsResource.java
@@ -1,0 +1,83 @@
+// Copyright 2021 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.server.resources;
+
+import org.apache.http.client.HttpResponseException;
+import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+
+public class TestReviewsResource extends AbstractLegendSDLCServerResourceTest
+{
+
+    @Test
+    public void testGetReviews() {
+
+    }
+
+    @Test
+    public void testGetReview() {
+    }
+
+    @Test
+    public void testIsReviewOutdated() {
+    }
+
+    @Test
+    public void testCreateReview() {
+    }
+
+    @Test
+    public void testCloseReview() {
+    }
+
+    @Test
+    public void testReopenReview() {
+    }
+
+    @Test
+    public void testApproveReview() {
+    }
+
+    @Test
+    public void testRevokeReviewApproval() {
+    }
+
+    @Test
+    public void testRejectReview() {
+    }
+
+    @Test
+    public void testCommitReview() {
+    }
+
+    @Test
+    public void testGetReviewUpdateStatus() {
+    }
+
+    @Test
+    public void testUpdateReview() {
+    }
+
+    @Test
+    public void testEditReview() {
+    }
+
+}

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestWorkspaceEntitiesResource.java
@@ -24,7 +24,9 @@ import org.finos.legend.sdlc.server.inmemory.domain.api.InMemoryEntity;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -42,31 +44,17 @@ public class TestWorkspaceEntitiesResource extends AbstractLegendSDLCServerResou
 
         this.backend.project(projectId).addEntities(workspaceOneId, InMemoryEntity.newEntity(entityOneName, entityPackageName), InMemoryEntity.newEntity(entityTwoName, entityPackageName));
 
-        Response responseOne = this.clientFor("/api/projects/A/workspaces/entityw1").request().get();
-
-        if (responseOne.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseOne.getStatus(), "Error during getting user workspace with status: " + responseOne.getStatus() + ", entity: " + responseOne.readEntity(String.class));
-        }
-
-        Workspace workspace = responseOne.readEntity(new GenericType<Workspace>()
-        {
-        });
+        Workspace workspace = this.requestHelperFor("/api/projects/A/workspaces/entityw1")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(workspace);
         Assert.assertEquals(workspaceOneId, workspace.getWorkspaceId());
         Assert.assertEquals(projectId, workspace.getProjectId());
 
-        Response responseTwo = this.clientFor("/api/projects/A/workspaces/entityw1/entities").request().get();
-
-        if (responseTwo.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseTwo.getStatus(), "Error during getting entities in user workspace with status: " + responseTwo.getStatus() + ", entity: " + responseTwo.readEntity(String.class));
-        }
-
-        List<Entity> entities = responseTwo.readEntity(new GenericType<List<Entity>>()
-        {
-        });
+        List<Entity> entities = this.requestHelperFor("/api/projects/A/workspaces/entityw1/entities")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(entities);
         Assert.assertEquals(2, entities.size());
@@ -87,31 +75,17 @@ public class TestWorkspaceEntitiesResource extends AbstractLegendSDLCServerResou
 
         this.backend.project(projectId).addEntities(workspaceOneId, WorkspaceType.GROUP, InMemoryEntity.newEntity(entityOneName, entityPackageName), InMemoryEntity.newEntity(entityTwoName, entityPackageName));
 
-        Response responseOne = this.clientFor("/api/projects/A/groupWorkspaces/entityw2").request().get();
-
-        if (responseOne.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseOne.getStatus(), "Error during getting group workspace with status: " + responseOne.getStatus() + ", entity: " + responseOne.readEntity(String.class));
-        }
-
-        Workspace workspace = responseOne.readEntity(new GenericType<Workspace>()
-        {
-        });
+        Workspace workspace = this.requestHelperFor("/api/projects/A/groupWorkspaces/entityw2")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(workspace);
         Assert.assertEquals(workspaceOneId, workspace.getWorkspaceId());
         Assert.assertEquals(projectId, workspace.getProjectId());
 
-        Response responseTwo = this.clientFor("/api/projects/A/groupWorkspaces/entityw2/entities").request().get();
-
-        if (responseTwo.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseTwo.getStatus(), "Error during getting entities in group workspace with status: " + responseTwo.getStatus() + ", entity: " + responseTwo.readEntity(String.class));
-        }
-
-        List<Entity> entities = responseTwo.readEntity(new GenericType<List<Entity>>()
-        {
-        });
+        List<Entity> entities = this.requestHelperFor("/api/projects/A/groupWorkspaces/entityw2/entities")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(entities);
         Assert.assertEquals(2, entities.size());
@@ -130,32 +104,17 @@ public class TestWorkspaceEntitiesResource extends AbstractLegendSDLCServerResou
         String entityPackageName = "testpkg";
 
         this.backend.project(projectId).addEntities(workspaceOneId, InMemoryEntity.newEntity(entityOneName, entityPackageName));
-
-        Response responseOne = this.clientFor("/api/projects/A/workspaces/entityw3").request().get();
-
-        if (responseOne.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseOne.getStatus(), "Error during getting user workspace with status: " + responseOne.getStatus() + ", entity: " + responseOne.readEntity(String.class));
-        }
-
-        Workspace workspace = responseOne.readEntity(new GenericType<Workspace>()
-        {
-        });
+        Workspace workspace  = this.requestHelperFor("/api/projects/A/workspaces/entityw3")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(workspace);
         Assert.assertEquals(workspaceOneId, workspace.getWorkspaceId());
         Assert.assertEquals(projectId, workspace.getProjectId());
 
-        Response responseTwo = this.clientFor("/api/projects/A/workspaces/entityw3/entities/testpkg::testentityone").request().get();
-
-        if (responseTwo.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseTwo.getStatus(), "Error during getting entity in user workspace with status: " + responseTwo.getStatus() + ", entity: " + responseTwo.readEntity(String.class));
-        }
-
-        Entity entity = responseTwo.readEntity(new GenericType<Entity>()
-        {
-        });
+        Entity entity = this.requestHelperFor("/api/projects/A/workspaces/entityw3/entities/testpkg::testentityone")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(entity);
         Assert.assertEquals(entityPackageName + "::" + entityOneName, entity.getPath());
@@ -189,31 +148,17 @@ public class TestWorkspaceEntitiesResource extends AbstractLegendSDLCServerResou
 
         this.backend.project(projectId).addEntities(workspaceOneId, WorkspaceType.GROUP, InMemoryEntity.newEntity(entityOneName, entityPackageName));
 
-        Response responseOne = this.clientFor("/api/projects/A/groupWorkspaces/entityw4").request().get();
-
-        if (responseOne.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseOne.getStatus(), "Error during getting group workspace with status: " + responseOne.getStatus() + ", entity: " + responseOne.readEntity(String.class));
-        }
-
-        Workspace workspace = responseOne.readEntity(new GenericType<Workspace>()
-        {
-        });
+        Workspace workspace = this.requestHelperFor("/api/projects/A/workspaces/entityw4/")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(workspace);
         Assert.assertEquals(workspaceOneId, workspace.getWorkspaceId());
         Assert.assertEquals(projectId, workspace.getProjectId());
 
-        Response responseTwo = this.clientFor("/api/projects/A/groupWorkspaces/entityw4/entities/testpkg::testentityone").request().get();
-
-        if (responseTwo.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseTwo.getStatus(), "Error during getting entity in group workspace with status: " + responseTwo.getStatus() + ", entity: " + responseTwo.readEntity(String.class));
-        }
-
-        Entity entity = responseTwo.readEntity(new GenericType<Entity>()
-        {
-        });
+        Entity entity = this.requestHelperFor("/api/projects/A/groupWorkspaces/entityw4/entities/testpkg::testentityone")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(entity);
         Assert.assertEquals(entityPackageName + "::" + entityOneName, entity.getPath());

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestWorkspaceRevisionsResource.java
@@ -16,6 +16,7 @@ package org.finos.legend.sdlc.server.resources;
 
 import org.apache.http.client.HttpResponseException;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.Project;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
@@ -23,6 +24,7 @@ import org.finos.legend.sdlc.server.inmemory.domain.api.InMemoryEntity;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
@@ -40,21 +42,17 @@ public class TestWorkspaceRevisionsResource extends AbstractLegendSDLCServerReso
 
         this.backend.project(projectId).addEntities(workspaceOneId, InMemoryEntity.newEntity(entityOneName, entityPackageName), InMemoryEntity.newEntity(entityTwoName, entityPackageName));
 
-        Response responseOne = this.getSuccessfulOrThrow("/api/projects/A/workspaces/revisionw1");
-
-        Workspace workspace = responseOne.readEntity(new GenericType<Workspace>()
-        {
-        });
+        Workspace workspace = this.requestHelperFor("/api/projects/A/workspaces/revisionw1")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(workspace);
         Assert.assertEquals(workspaceOneId, workspace.getWorkspaceId());
         Assert.assertEquals(projectId, workspace.getProjectId());
 
-        Response responseThree = this.getSuccessfulOrThrow("/api/projects/A/workspaces/revisionw1/revisions");
-
-        List<Revision> revisions = responseThree.readEntity(new GenericType<List<Revision>>()
-        {
-        });
+        List<Revision> revisions = this.requestHelperFor("/api/projects/A/workspaces/revisionw1/revisions")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(revisions);
         Assert.assertEquals(1, revisions.size());
@@ -72,29 +70,21 @@ public class TestWorkspaceRevisionsResource extends AbstractLegendSDLCServerReso
 
         this.backend.project(projectId).addEntities(workspaceOneId, WorkspaceType.GROUP, InMemoryEntity.newEntity(entityOneName, entityPackageName), InMemoryEntity.newEntity(entityTwoName, entityPackageName));
 
-        Response responseOne = this.getSuccessfulOrThrow("/api/projects/A/groupWorkspaces/revisionw2");
-
-        Workspace workspace = responseOne.readEntity(new GenericType<Workspace>()
-        {
-        });
+        Workspace workspace = this.requestHelperFor("/api/projects/A/groupWorkspaces/revisionw2")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(workspace);
         Assert.assertEquals(workspaceOneId, workspace.getWorkspaceId());
         Assert.assertEquals(projectId, workspace.getProjectId());
 
-        Response responseThree = this.getSuccessfulOrThrow("/api/projects/A/groupWorkspaces/revisionw2/revisions");
-
-        List<Revision> revisions = responseThree.readEntity(new GenericType<List<Revision>>()
-        {
-        });
+        List<Revision> revisions = this.requestHelperFor("/api/projects/A/groupWorkspaces/revisionw2/revisions")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(revisions);
         Assert.assertEquals(1, revisions.size());
         Assert.assertNotNull(revisions.get(0).getId());
     }
 
-    private Entity findEntity(List<Entity> entities, String entityName, String entityPackageName)
-    {
-        return entities.stream().filter(entity -> entity.getContent().get("name").equals(entityName) && entity.getContent().get("package").equals(entityPackageName)).findFirst().get();
-    }
 }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestWorkspaceRevisionsResource.java
@@ -40,12 +40,7 @@ public class TestWorkspaceRevisionsResource extends AbstractLegendSDLCServerReso
 
         this.backend.project(projectId).addEntities(workspaceOneId, InMemoryEntity.newEntity(entityOneName, entityPackageName), InMemoryEntity.newEntity(entityTwoName, entityPackageName));
 
-        Response responseOne = this.clientFor("/api/projects/A/workspaces/revisionw1").request().get();
-
-        if (responseOne.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseOne.getStatus(), "Error during getting user workspace with status: " + responseOne.getStatus() + ", entity: " + responseOne.readEntity(String.class));
-        }
+        Response responseOne = this.getSuccessfulOrThrow("/api/projects/A/workspaces/revisionw1");
 
         Workspace workspace = responseOne.readEntity(new GenericType<Workspace>()
         {
@@ -55,12 +50,7 @@ public class TestWorkspaceRevisionsResource extends AbstractLegendSDLCServerReso
         Assert.assertEquals(workspaceOneId, workspace.getWorkspaceId());
         Assert.assertEquals(projectId, workspace.getProjectId());
 
-        Response responseThree = this.clientFor("/api/projects/A/workspaces/revisionw1/revisions").request().get();
-
-        if (responseThree.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseThree.getStatus(), "Error during getting revisions in user workspace with status: " + responseThree.getStatus() + ", entity: " + responseThree.readEntity(String.class));
-        }
+        Response responseThree = this.getSuccessfulOrThrow("/api/projects/A/workspaces/revisionw1/revisions");
 
         List<Revision> revisions = responseThree.readEntity(new GenericType<List<Revision>>()
         {
@@ -82,12 +72,7 @@ public class TestWorkspaceRevisionsResource extends AbstractLegendSDLCServerReso
 
         this.backend.project(projectId).addEntities(workspaceOneId, WorkspaceType.GROUP, InMemoryEntity.newEntity(entityOneName, entityPackageName), InMemoryEntity.newEntity(entityTwoName, entityPackageName));
 
-        Response responseOne = this.clientFor("/api/projects/A/groupWorkspaces/revisionw2").request().get();
-
-        if (responseOne.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseOne.getStatus(), "Error during getting group workspace with status: " + responseOne.getStatus() + ", entity: " + responseOne.readEntity(String.class));
-        }
+        Response responseOne = this.getSuccessfulOrThrow("/api/projects/A/groupWorkspaces/revisionw2");
 
         Workspace workspace = responseOne.readEntity(new GenericType<Workspace>()
         {
@@ -97,12 +82,7 @@ public class TestWorkspaceRevisionsResource extends AbstractLegendSDLCServerReso
         Assert.assertEquals(workspaceOneId, workspace.getWorkspaceId());
         Assert.assertEquals(projectId, workspace.getProjectId());
 
-        Response responseThree = this.clientFor("/api/projects/A/groupWorkspaces/revisionw2/revisions").request().get();
-
-        if (responseThree.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseThree.getStatus(), "Error during getting revisions in group workspace with status: " + responseThree.getStatus() + ", entity: " + responseThree.readEntity(String.class));
-        }
+        Response responseThree = this.getSuccessfulOrThrow("/api/projects/A/groupWorkspaces/revisionw2/revisions");
 
         List<Revision> revisions = responseThree.readEntity(new GenericType<List<Revision>>()
         {

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestWorkspacesResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestWorkspacesResource.java
@@ -38,12 +38,7 @@ public class TestWorkspacesResource extends AbstractLegendSDLCServerResourceTest
         this.backend.project(projectId).addWorkspace(workspaceTwoId, WorkspaceType.USER);
         this.backend.project(projectId).addWorkspace(workspaceThreeId, WorkspaceType.GROUP);
 
-        Response responseOne = this.clientFor("/api/projects/A/workspaces").request().get();
-
-        if (responseOne.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseOne.getStatus(), "Error during getting user workspaces with status: " + responseOne.getStatus() + ", entity: " + responseOne.readEntity(String.class));
-        }
+        Response responseOne = this.getSuccessfulOrThrow("/api/projects/A/workspaces");
 
         List<Workspace> allUserWorkspaces = responseOne.readEntity(new GenericType<List<Workspace>>()
         {
@@ -56,12 +51,8 @@ public class TestWorkspacesResource extends AbstractLegendSDLCServerResourceTest
         Assert.assertEquals(workspaceTwoId, findWorkspace(allUserWorkspaces, workspaceTwoId).getWorkspaceId());
         Assert.assertEquals(projectId, findWorkspace(allUserWorkspaces, workspaceTwoId).getProjectId());
 
-        Response responseTwo = this.clientFor("/api/projects/A/groupWorkspaces").request().get();
+        Response responseTwo = this.getSuccessfulOrThrow("/api/projects/A/groupWorkspaces");
 
-        if (responseTwo.getStatus() != 200)
-        {
-            throw new HttpResponseException(responseTwo.getStatus(), "Error during getting group workspaces with status: " + responseTwo.getStatus() + " , entity: " + responseTwo.readEntity(String.class));
-        }
 
         List<Workspace> allGroupWorkspaces = responseTwo.readEntity(new GenericType<List<Workspace>>()
         {
@@ -101,12 +92,7 @@ public class TestWorkspacesResource extends AbstractLegendSDLCServerResourceTest
 
         this.backend.project(projectId).addWorkspace(workspaceId, WorkspaceType.USER);
 
-        Response response = this.clientFor("/api/projects/A/workspaces/userw1").request().get();
-
-        if (response.getStatus() != 200)
-        {
-            throw new HttpResponseException(response.getStatus(), "Error during getting user workspace with status: " + response.getStatus() + ", entity: " + response.readEntity(String.class));
-        }
+        Response response = this.getSuccessfulOrThrow("/api/projects/A/workspaces/userw1");
 
         Workspace workspace = response.readEntity(new GenericType<Workspace>()
         {
@@ -133,12 +119,7 @@ public class TestWorkspacesResource extends AbstractLegendSDLCServerResourceTest
 
         this.backend.project(projectId).addWorkspace(workspaceId, WorkspaceType.GROUP);
 
-        Response response = this.clientFor("/api/projects/A/groupWorkspaces/groupw1").request().get();
-
-        if (response.getStatus() != 200)
-        {
-            throw new HttpResponseException(response.getStatus(), "Error during getting group workspace with status: " + response.getStatus() + ", entity: " + response.readEntity(String.class));
-        }
+        Response response = this.getSuccessfulOrThrow("/api/projects/A/groupWorkspaces/groupw1");
 
         Workspace workspace = response.readEntity(new GenericType<Workspace>()
         {

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestWorkspacesResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestWorkspacesResource.java
@@ -17,9 +17,11 @@ package org.finos.legend.sdlc.server.resources;
 import org.apache.http.client.HttpResponseException;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
+import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
@@ -38,11 +40,9 @@ public class TestWorkspacesResource extends AbstractLegendSDLCServerResourceTest
         this.backend.project(projectId).addWorkspace(workspaceTwoId, WorkspaceType.USER);
         this.backend.project(projectId).addWorkspace(workspaceThreeId, WorkspaceType.GROUP);
 
-        Response responseOne = this.getSuccessfulOrThrow("/api/projects/A/workspaces");
-
-        List<Workspace> allUserWorkspaces = responseOne.readEntity(new GenericType<List<Workspace>>()
-        {
-        });
+        List<Workspace> allUserWorkspaces = this.requestHelperFor("/api/projects/A/workspaces")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(allUserWorkspaces);
         Assert.assertEquals(2, allUserWorkspaces.size());
@@ -51,12 +51,10 @@ public class TestWorkspacesResource extends AbstractLegendSDLCServerResourceTest
         Assert.assertEquals(workspaceTwoId, findWorkspace(allUserWorkspaces, workspaceTwoId).getWorkspaceId());
         Assert.assertEquals(projectId, findWorkspace(allUserWorkspaces, workspaceTwoId).getProjectId());
 
-        Response responseTwo = this.getSuccessfulOrThrow("/api/projects/A/groupWorkspaces");
+        List<Workspace> allGroupWorkspaces = this.requestHelperFor("/api/projects/A/groupWorkspaces")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
-
-        List<Workspace> allGroupWorkspaces = responseTwo.readEntity(new GenericType<List<Workspace>>()
-        {
-        });
 
         Assert.assertNotNull(allGroupWorkspaces);
         Assert.assertEquals(1, allGroupWorkspaces.size());
@@ -92,11 +90,9 @@ public class TestWorkspacesResource extends AbstractLegendSDLCServerResourceTest
 
         this.backend.project(projectId).addWorkspace(workspaceId, WorkspaceType.USER);
 
-        Response response = this.getSuccessfulOrThrow("/api/projects/A/workspaces/userw1");
-
-        Workspace workspace = response.readEntity(new GenericType<Workspace>()
-        {
-        });
+        Workspace workspace = this.requestHelperFor("/api/projects/A/workspaces/userw1")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(workspace);
         Assert.assertEquals(workspaceId, workspace.getWorkspaceId());
@@ -119,11 +115,9 @@ public class TestWorkspacesResource extends AbstractLegendSDLCServerResourceTest
 
         this.backend.project(projectId).addWorkspace(workspaceId, WorkspaceType.GROUP);
 
-        Response response = this.getSuccessfulOrThrow("/api/projects/A/groupWorkspaces/groupw1");
-
-        Workspace workspace = response.readEntity(new GenericType<Workspace>()
-        {
-        });
+        Workspace workspace = this.requestHelperFor("/api/projects/A/groupWorkspaces/groupw1")
+                .withAcceptableResponseStatuses(Collections.singleton(Response.Status.Family.SUCCESSFUL))
+                .getTyped();
 
         Assert.assertNotNull(workspace);
         Assert.assertEquals(workspaceId, workspace.getWorkspaceId());


### PR DESCRIPTION
This pr addresses #128 trying to add test coverage for review resource. 

The current proposal is to introduce a request builder that provides a fluent API to the backend, or even a typed client and reduce the excessive boilerplate and copy-paste in the tests of the Rest port. 