### PR TITLE
Fix how platform properties are set by project structures

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructureV11Factory.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructureV11Factory.java
@@ -93,11 +93,11 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
         private static final String DEFAULT_EXECUTION_EXTENSION_ARTIFACT_ID = "legend-engine-extensions-collection-execution";
         private static final String DEFAULT_SERIALIZER_EXTENSION_ARTIFACT_ID = "legend-sdlc-extensions-collection-entity-serializer";
 
-        private static final Map<String, MavenCoordinates> DEFAULT_EXTENSIONS_COLLECTION =
-                Maps.immutable.with(GENERATION_EXTENSIONS_COLLECTION_KEY, new MavenCoordinates(LEGEND_ENGINE_GROUP_ID, DEFAULT_GENERATION_EXTENSION_ARTIFACT_ID, LEGEND_ENGINE_PROPERTY_REFERENCE),
-                        EXECUTION_EXTENSIONS_COLLECTION_KEY, new MavenCoordinates(LEGEND_ENGINE_GROUP_ID, DEFAULT_EXECUTION_EXTENSION_ARTIFACT_ID, LEGEND_ENGINE_PROPERTY_REFERENCE),
-                        SERIALIZER_EXTENSIONS_COLLECTION_KEY, new MavenCoordinates(LEGEND_SDLC_GROUP_ID, DEFAULT_SERIALIZER_EXTENSION_ARTIFACT_ID, LEGEND_SDLC_PROPERTY_REFERENCE))
-                        .toMap();
+        private static final ImmutableMap<String, MavenCoordinates> DEFAULT_EXTENSIONS_COLLECTION = Maps.immutable.with(
+                GENERATION_EXTENSIONS_COLLECTION_KEY, new MavenCoordinates(LEGEND_ENGINE_GROUP_ID, DEFAULT_GENERATION_EXTENSION_ARTIFACT_ID, LEGEND_ENGINE_PROPERTY_REFERENCE),
+                EXECUTION_EXTENSIONS_COLLECTION_KEY, new MavenCoordinates(LEGEND_ENGINE_GROUP_ID, DEFAULT_EXECUTION_EXTENSION_ARTIFACT_ID, LEGEND_ENGINE_PROPERTY_REFERENCE),
+                SERIALIZER_EXTENSIONS_COLLECTION_KEY, new MavenCoordinates(LEGEND_SDLC_GROUP_ID, DEFAULT_SERIALIZER_EXTENSION_ARTIFACT_ID, LEGEND_SDLC_PROPERTY_REFERENCE)
+        );
 
         // Plugin Helpers
         private final LegendEntityPluginMavenHelper legendEntityPluginMavenHelper;
@@ -220,7 +220,9 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
                     break;
                 }
                 default:
-                    break;
+                {
+                    // do nothing
+                }
             }
         }
 
@@ -258,13 +260,14 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
             super.addMavenProjectProperties(propertySetter);
             propertySetter.accept(LEGEND_SDLC_PROPERTY, LEGEND_SDLC_VERSION);
             propertySetter.accept(LEGEND_ENGINE_PROPERTY, LEGEND_ENGINE_VERSION);
-            if (this.getPlatforms() != null)
+            getPlatforms().forEach(platform ->
             {
-                this.getPlatforms().forEach((platform) ->
+                String version = platform.getPublicStructureVersion(this.version);
+                if (version != null)
                 {
-                    propertySetter.accept(this.getPlatformPropertyName(platform.getName()), platform.getPublicStructureVersion(this.version));
-                });
-            }
+                    propertySetter.accept(getPlatformPropertyName(platform.getName()), version);
+                }
+            });
         }
 
         private Dependency getLegendTestUtilsDependencyWithExclusion()
@@ -365,10 +368,9 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
 
         private static class MavenCoordinates
         {
-            private String groupId;
-            private String artifactId;
-            private String version;
-
+            private final String groupId;
+            private final String artifactId;
+            private final String version;
 
             public MavenCoordinates(String groupdId, String artifactId, String version)
             {
@@ -392,6 +394,5 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
                 return groupId;
             }
         }
-
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructureV12Factory.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructureV12Factory.java
@@ -93,11 +93,11 @@ public class ProjectStructureV12Factory extends ProjectStructureVersionFactory
         private static final String DEFAULT_EXECUTION_EXTENSION_ARTIFACT_ID = "legend-engine-extensions-collection-execution";
         private static final String DEFAULT_SERIALIZER_EXTENSION_ARTIFACT_ID = "legend-sdlc-extensions-collection-entity-serializer";
 
-        private static final Map<String, ProjectStructureV12Factory.ProjectStructureV12.MavenCoordinates> DEFAULT_EXTENSIONS_COLLECTION =
-                Maps.immutable.with(GENERATION_EXTENSIONS_COLLECTION_KEY, new ProjectStructureV12Factory.ProjectStructureV12.MavenCoordinates(LEGEND_ENGINE_GROUP_ID, DEFAULT_GENERATION_EXTENSION_ARTIFACT_ID, LEGEND_ENGINE_PROPERTY_REFERENCE),
-                        EXECUTION_EXTENSIONS_COLLECTION_KEY, new ProjectStructureV12Factory.ProjectStructureV12.MavenCoordinates(LEGEND_ENGINE_GROUP_ID, DEFAULT_EXECUTION_EXTENSION_ARTIFACT_ID, LEGEND_ENGINE_PROPERTY_REFERENCE),
-                        SERIALIZER_EXTENSIONS_COLLECTION_KEY, new ProjectStructureV12Factory.ProjectStructureV12.MavenCoordinates(LEGEND_SDLC_GROUP_ID, DEFAULT_SERIALIZER_EXTENSION_ARTIFACT_ID, LEGEND_SDLC_PROPERTY_REFERENCE))
-                        .toMap();
+        private static final ImmutableMap<String, ProjectStructureV12Factory.ProjectStructureV12.MavenCoordinates> DEFAULT_EXTENSIONS_COLLECTION = Maps.immutable.with(
+                GENERATION_EXTENSIONS_COLLECTION_KEY, new MavenCoordinates(LEGEND_ENGINE_GROUP_ID, DEFAULT_GENERATION_EXTENSION_ARTIFACT_ID, LEGEND_ENGINE_PROPERTY_REFERENCE),
+                EXECUTION_EXTENSIONS_COLLECTION_KEY, new MavenCoordinates(LEGEND_ENGINE_GROUP_ID, DEFAULT_EXECUTION_EXTENSION_ARTIFACT_ID, LEGEND_ENGINE_PROPERTY_REFERENCE),
+                SERIALIZER_EXTENSIONS_COLLECTION_KEY, new MavenCoordinates(LEGEND_SDLC_GROUP_ID, DEFAULT_SERIALIZER_EXTENSION_ARTIFACT_ID, LEGEND_SDLC_PROPERTY_REFERENCE)
+        );
 
         // Plugin Helpers
         private final LegendEntityPluginMavenHelper legendEntityPluginMavenHelper;
@@ -221,7 +221,9 @@ public class ProjectStructureV12Factory extends ProjectStructureVersionFactory
                     break;
                 }
                 default:
-                    break;
+                {
+                    // do nothing
+                }
             }
         }
 
@@ -259,13 +261,14 @@ public class ProjectStructureV12Factory extends ProjectStructureVersionFactory
             super.addMavenProjectProperties(propertySetter);
             propertySetter.accept(LEGEND_SDLC_PROPERTY, LEGEND_SDLC_VERSION);
             propertySetter.accept(LEGEND_ENGINE_PROPERTY, LEGEND_ENGINE_VERSION);
-            if (this.getPlatforms() != null)
+            getPlatforms().forEach(platform ->
             {
-                this.getPlatforms().forEach((platform) ->
+                String version = platform.getPublicStructureVersion(this.version);
+                if (version != null)
                 {
-                    propertySetter.accept(this.getPlatformPropertyName(platform.getName()), platform.getPublicStructureVersion(this.version));
-                });
-            }
+                    propertySetter.accept(getPlatformPropertyName(platform.getName()), version);
+                }
+            });
         }
 
         private Dependency getLegendTestUtilsDependencyWithExclusion()
@@ -367,10 +370,9 @@ public class ProjectStructureV12Factory extends ProjectStructureVersionFactory
 
         private static class MavenCoordinates
         {
-            private String groupId;
-            private String artifactId;
-            private String version;
-
+            private final String groupId;
+            private final String artifactId;
+            private final String version;
 
             public MavenCoordinates(String groupdId, String artifactId, String version)
             {
@@ -395,5 +397,4 @@ public class ProjectStructureV12Factory extends ProjectStructureVersionFactory
             }
         }
     }
-
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/MultiModuleMavenProjectStructure.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/MultiModuleMavenProjectStructure.java
@@ -47,6 +47,7 @@ import java.lang.reflect.Method;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.SortedMap;
@@ -213,7 +214,9 @@ public abstract class MultiModuleMavenProjectStructure extends MavenProjectStruc
 
     public List<ProjectStructurePlatformExtensions.Platform> getPlatforms()
     {
-        return this.projectStructurePlatformExtensions != null ? this.projectStructurePlatformExtensions.getPlatforms() : null;
+        return Optional.ofNullable(this.projectStructurePlatformExtensions)
+                .map(ProjectStructurePlatformExtensions::getPlatforms)
+                .orElse(Lists.fixedSize.empty());
     }
 
     public String getPlatformPropertyReference(String platform)


### PR DESCRIPTION
Fix how platform properties are set by project structures. Previously, if a mapping from project structure version to platform version was not included in the platform configuration section of the server configuration, the server would throw a NullPointerException during project configuration updates. This fixes that bug, and makes the version setting a bit more robust. Now if there isn't a mapping specifically for the project structure version but there is a general platform version, that will be returned.