### PR TITLE
Fix testSuite test with correct serializationFormat

### DIFF
--- a/legend-sdlc-test-utils/src/test/resources/legend-sdlc-test-service-with-testSuites/entities/testTestSuites/TestService.json
+++ b/legend-sdlc-test-utils/src/test/resources/legend-sdlc-test-service-with-testSuites/entities/testTestSuites/TestService.json
@@ -314,6 +314,7 @@
               "endLine": 50,
               "endColumn": 9
             },
+            "serializationFormat": "PURE",
             "assertions": [
               {
                 "_type": "equalToJson",

--- a/legend-sdlc-test-utils/src/test/resources/legend-sdlc-test-service-with-testSuites/entities/testTestSuites/TestService2.json
+++ b/legend-sdlc-test-utils/src/test/resources/legend-sdlc-test-service-with-testSuites/entities/testTestSuites/TestService2.json
@@ -314,6 +314,7 @@
               "endLine": 50,
               "endColumn": 9
             },
+            "serializationFormat": "PURE",
             "assertions": [
               {
                 "_type": "equalToJson",


### PR DESCRIPTION
We added ability for users to use a serializationFormat with their service test.
Unfortunately we missed using the format for graphfetch queries and hence could go ahead without making this change. We are fixing that here (https://github.com/finos/legend-engine/pull/799) and to support that will need this change.
This change here uses that ability (uses PURE serializationFormat)