### PR TITLE
Update test assertion to accommodate change in parser error listener …

### DIFF
--- a/legend-sdlc-protocol-pure/src/test/java/org/finos/legend/sdlc/protocol/pure/v1/TestPureEntitySerializer.java
+++ b/legend-sdlc-protocol-pure/src/test/java/org/finos/legend/sdlc/protocol/pure/v1/TestPureEntitySerializer.java
@@ -65,7 +65,7 @@ public class TestPureEntitySerializer
     public void testSerializeClass()
     {
         testSerialize("class", "TestClass");
-        testPureSyntaxError("PARSER error at [5:3]: Unexpected token", "class", "TestBadClass");
+        testPureSyntaxError("PARSER error at [5:3]: Unexpected token '{'", "class", "TestBadClass");
     }
 
     @Test


### PR DESCRIPTION
…(unexpected token is now displayed in error message when available).

Corresponding engine PR (merged):
https://github.com/finos/legend-engine/pull/763