### PR TITLE
handle ArtifactGenerationExtensions 

### DIFF
--- a/legend-sdlc-generation-file-maven-plugin/pom.xml
+++ b/legend-sdlc-generation-file-maven-plugin/pom.xml
@@ -28,6 +28,13 @@
 
     <dependencies>
 
+        <!-- PURE -->
+        <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+        </dependency>
+        <!-- PURE -->
+
         <!-- SDLC -->
         <dependency>
             <groupId>org.finos.legend.sdlc</groupId>

--- a/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/FileGenerationMojo.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/FileGenerationMojo.java
@@ -27,11 +27,14 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.fileGeneration.FileGenerationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.generationSpecification.GenerationSpecification;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.generation.artifact.ArtifactGenerationFactory;
+import org.finos.legend.sdlc.generation.artifact.ArtifactGenerationResult;
 import org.finos.legend.sdlc.language.pure.compiler.toPureGraph.PureModelBuilder;
 import org.finos.legend.sdlc.serialization.EntityLoader;
 
@@ -54,13 +57,12 @@ import java.util.stream.Collectors;
 @Mojo(name = "generate-file-generations", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class FileGenerationMojo extends AbstractMojo
 {
-    private static final String GENERATION_SPECIFICATION_CLASSIFIER_PATH = "meta::pure::generation::metamodel::GenerationSpecification";
 
     @Parameter
-    private GenerationSpecificationFilter inclusions;
+    private PackageableElementFilter inclusions;
 
     @Parameter
-    private GenerationSpecificationFilter exclusions;
+    private PackageableElementFilter exclusions;
 
     @Parameter(defaultValue = "${project.build.outputDirectory}")
     private File outputDirectory;
@@ -110,9 +112,12 @@ public class FileGenerationMojo extends AbstractMojo
         PureModel pureModel = pureModelWithContextData.getPureModel();
         long modelEnd = System.nanoTime();
         getLog().info(String.format("Finished loading and compiling model (%.9fs)", (modelEnd - modelStart) / 1_000_000_000.0));
+
+        Set<String> fileOutputPaths = Sets.mutable.empty();
+        // Generation Specification
         Map<String, GenerationSpecification> generationSpecificationMap = LazyIterate.selectInstancesOf(pureModelContextData.getElements(), GenerationSpecification.class).groupByUniqueKey(PackageableElement::getPath, Maps.mutable.empty());
-        filterGenerationSpecsByIncludes(generationSpecificationMap);
-        filterGenerationSpecsByExcludes(generationSpecificationMap);
+        filterPackageableElementsByIncludes(generationSpecificationMap);
+        filterPackageableElementsByExcludes(generationSpecificationMap);
         if (generationSpecificationMap.isEmpty())
         {
             getLog().info("No generation specification found, nothing to generate");
@@ -130,7 +135,23 @@ public class FileGenerationMojo extends AbstractMojo
             getLog().info(String.format("Start generating file generations for generation specification '%s', %,d file generations found", generationSpecification.getPath(), generationSpecification.fileGenerations.size()));
             FileGenerationFactory fileGenerationFactory = FileGenerationFactory.newFactory(generationSpecification, pureModelContextData, pureModel);
             MutableMap<FileGenerationSpecification, List<GenerationOutput>> outputs = fileGenerationFactory.generateFiles();
-            serializeOutput(outputs);
+            serializeOutput(outputs, fileOutputPaths);
+            getLog().info(String.format("Done (%.9fs)", (System.nanoTime() - generateStart) / 1_000_000_000.0));
+        }
+        catch (Exception e)
+        {
+            throw new MojoExecutionException("Error generating files: " + e.getMessage(), e);
+        }
+        // Artifact Generations
+        Map<String, PackageableElement> elementsMap = LazyIterate.adapt(pureModelContextData.getElements()).groupByUniqueKey(PackageableElement::getPath, Maps.mutable.empty());
+        filterPackageableElementsByIncludes(elementsMap);
+        filterPackageableElementsByExcludes(elementsMap);
+        try
+        {
+            List<PackageableElement> elements = Lists.mutable.withAll(elementsMap.values());
+            ArtifactGenerationFactory factory = ArtifactGenerationFactory.newFactory(pureModel, pureModelContextData, elements);
+            MutableMap<ArtifactGenerationExtension, List<ArtifactGenerationResult>> results = factory.generate();
+            serializeArtifacts(results, fileOutputPaths);
             getLog().info(String.format("Done (%.9fs)", (System.nanoTime() - generateStart) / 1_000_000_000.0));
         }
         catch (Exception e)
@@ -139,11 +160,12 @@ public class FileGenerationMojo extends AbstractMojo
         }
     }
 
-    protected void serializeOutput(MutableMap<FileGenerationSpecification, List<GenerationOutput>> generationGenerationOutputMap) throws IOException
+    protected void serializeOutput(MutableMap<FileGenerationSpecification, List<GenerationOutput>> generationGenerationOutputMap, Set<String> fileOutputPaths) throws MojoExecutionException, IOException
     {
         long serializeStart = System.nanoTime();
         getLog().info("Start serializing file generations");
         Path outputDirPath = this.outputDirectory.toPath();
+        String fileSeparator = outputDirPath.getFileSystem().getSeparator();
         Pattern pkgSepPattern = Pattern.compile("::", Pattern.LITERAL);
         String replacement = Matcher.quoteReplacement(outputDirPath.getFileSystem().getSeparator());
         for (Map.Entry<FileGenerationSpecification, List<GenerationOutput>> fileOutputPair : generationGenerationOutputMap.entrySet())
@@ -155,7 +177,11 @@ public class FileGenerationMojo extends AbstractMojo
             getLog().info(String.format("Serializing %,d files for '%s'", generationOutputs.size(), fileGenerationSpecification.getPath()));
             for (GenerationOutput output : generationOutputs)
             {
-                String fileName = rootFolder + '/' + output.getFileName();
+                String fileName = rootFolder + fileSeparator + output.getFileName();
+                if (!fileOutputPaths.add(fileName))
+                {
+                    throw new MojoExecutionException("Duplicate file paths found when serializing file generations outputs : '" + fileName + "'");
+                }
                 String resolver = pkgSepPattern.matcher(fileName).replaceAll(replacement);
                 Path entityFilePath = outputDirPath.resolve(resolver);
                 Files.createDirectories(entityFilePath.getParent());
@@ -169,84 +195,120 @@ public class FileGenerationMojo extends AbstractMojo
         getLog().info(String.format("Done serializing %,d file generations' output to %s (%.9fs)", generationGenerationOutputMap.size(), this.outputDirectory, (System.nanoTime() - serializeStart) / 1_000_000_000.0));
     }
 
-    private void filterGenerationSpecsByIncludes(Map<String, GenerationSpecification> generationSpecsByPath) throws MojoExecutionException
+
+    protected void serializeArtifacts(MutableMap<ArtifactGenerationExtension, List<ArtifactGenerationResult>> results, Set<String> fileOutputPaths) throws IOException, MojoExecutionException
+    {
+        long serializeStart = System.nanoTime();
+        getLog().info("Start serializing artifact extension generations");
+        Path outputDirPath = this.outputDirectory.toPath();
+        String fileSeparator = outputDirPath.getFileSystem().getSeparator();
+        Pattern pkgSepPattern = Pattern.compile("::", Pattern.LITERAL);
+        String replacement = Matcher.quoteReplacement(fileSeparator);
+        for (Map.Entry<ArtifactGenerationExtension, List<ArtifactGenerationResult>> resultByExtension : results.entrySet())
+        {
+            ArtifactGenerationExtension extension = resultByExtension.getKey();
+            List<ArtifactGenerationResult> extensionResults = resultByExtension.getValue();
+            for (ArtifactGenerationResult result : extensionResults)
+            {
+                org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement generator = result.getElement();
+                String elementFolder = org.finos.legend.pure.m3.navigation.PackageableElement.PackageableElement.getUserPathForPackageableElement(generator, fileSeparator);
+                List<GenerationOutput> generatorOutputs = result.getResults();
+                String rootExtensionFolder = extension.getKey();
+                for (GenerationOutput output : generatorOutputs)
+                {
+                    String fileName = elementFolder + fileSeparator + rootExtensionFolder + fileSeparator + output.getFileName();
+                    if (!fileOutputPaths.add(fileName))
+                    {
+                        throw new MojoExecutionException("Duplicate file path found when serializing artifact generation extension  '" + extension.getClass() + "' output: '" + fileName + "'");
+                    }
+                    String resolver = pkgSepPattern.matcher(fileName).replaceAll(replacement);
+                    Path entityFilePath = outputDirPath.resolve(resolver);
+                    Files.createDirectories(entityFilePath.getParent());
+                    try (OutputStream stream = Files.newOutputStream(entityFilePath))
+                    {
+                        stream.write(output.extractFileContent().getBytes(StandardCharsets.UTF_8));
+                    }
+                }
+            }
+            getLog().info("Done serializing files for extension: '" + extension.getClass() + "'");
+        }
+        getLog().info(String.format("Done serializing %,d artifact generation extension results to %s (%.9fs)", results.size(), this.outputDirectory, (System.nanoTime() - serializeStart) / 1_000_000_000.0));
+    }
+
+    private <T extends PackageableElement> void filterPackageableElementsByIncludes(Map<String, T> elementsByPath) throws MojoExecutionException
     {
         if (this.inclusions != null)
         {
-            ResolvedGenerationSpecificationFilter filter;
+            ResolvedPackageableElementFilter filter;
             try
             {
-                filter = resolveGenerationSpecFilter(this.inclusions);
+                filter = resolvePackageableElementFilter(this.inclusions, elementsByPath.keySet());
             }
             catch (Exception e)
             {
-                throw new MojoExecutionException("Error resolving included GenerationSpecifications", e);
+                throw new MojoExecutionException("Error resolving included PackageableElements", e);
             }
-            generationSpecsByPath.keySet().removeIf(filter.negate());
-            if ((filter.generationSpecPaths != null) && Iterate.anySatisfy(filter.generationSpecPaths, p -> !generationSpecsByPath.containsKey(p)))
-            {
-                throw new MojoExecutionException(LazyIterate.reject(filter.generationSpecPaths, generationSpecsByPath::containsKey).makeString("Could not find included GenerationSpecifications: ", ", ", ""));
-            }
+            elementsByPath.keySet().removeIf(filter.negate());
         }
     }
 
-    private void filterGenerationSpecsByExcludes(Map<String, GenerationSpecification> generationSpecsByPath) throws MojoExecutionException
+    private <T extends PackageableElement> void filterPackageableElementsByExcludes(Map<String, T> elementsByPath) throws MojoExecutionException
     {
-        if ((this.exclusions != null) && !generationSpecsByPath.isEmpty())
+        if ((this.exclusions != null) && !elementsByPath.isEmpty())
         {
-            ResolvedGenerationSpecificationFilter filter;
+            ResolvedPackageableElementFilter filter;
             try
             {
-                filter = resolveGenerationSpecFilter(this.exclusions);
+                filter = resolvePackageableElementFilter(this.exclusions, elementsByPath.keySet());
             }
             catch (Exception e)
             {
-                throw new MojoExecutionException("Error resolving excluded GenerationSpecifications", e);
+                throw new MojoExecutionException("Error resolving excluded PackageableElements", e);
             }
-            generationSpecsByPath.keySet().removeIf(filter);
+            elementsByPath.keySet().removeIf(filter);
         }
     }
 
-    private static ResolvedGenerationSpecificationFilter resolveGenerationSpecFilter(GenerationSpecificationFilter generationSpec) throws Exception
+    private static ResolvedPackageableElementFilter resolvePackageableElementFilter(PackageableElementFilter elementFilter, Set<String> elementsByPath) throws Exception
     {
-        Set<String> generationSpecPaths;
-        if (generationSpec.directories != null)
+        Set<String> resolvedElementsByPath;
+        if (elementFilter.directories != null)
         {
-            try (EntityLoader directoriesLoader = EntityLoader.newEntityLoader(generationSpec.directories))
+            try (EntityLoader directoriesLoader = EntityLoader.newEntityLoader(elementFilter.directories))
             {
-                generationSpecPaths = directoriesLoader.getAllEntities()
-                        .filter(e -> GENERATION_SPECIFICATION_CLASSIFIER_PATH.equals(e.getClassifierPath()))
-                        .map(Entity::getPath)
-                        .collect(Collectors.toCollection(Sets.mutable::empty));
+
+                resolvedElementsByPath = directoriesLoader.getAllEntities().filter(e -> elementsByPath.contains(e.getPath())).map(Entity::getPath).collect(Collectors.toCollection(Sets.mutable::empty));
             }
-            if (generationSpec.paths != null)
+            if (elementFilter.paths != null)
             {
-                generationSpecPaths.addAll(generationSpec.paths);
+                resolvedElementsByPath.addAll(elementFilter.paths);
             }
         }
         else
         {
-            generationSpecPaths = generationSpec.paths;
+            resolvedElementsByPath = elementFilter.paths;
         }
-
-        return new ResolvedGenerationSpecificationFilter(generationSpecPaths, generationSpec.packages);
+        return new ResolvedPackageableElementFilter(resolvedElementsByPath, elementFilter.packages);
     }
 
-    public static class GenerationSpecificationFilter
+
+    public static class PackageableElementFilter
     {
+
         public File[] directories;
         public Set<String> paths;
         public Set<String> packages;
     }
 
-    private static class ResolvedGenerationSpecificationFilter implements Predicate<String>
+    private static class ResolvedPackageableElementFilter implements Predicate<String>
     {
-        private final Set<String> generationSpecPaths;
+
+        private final Set<String> elementPaths;
         private final ListIterable<String> packages;
 
-        private ResolvedGenerationSpecificationFilter(Set<String> generationSpecPaths, Set<String> packages)
+        private ResolvedPackageableElementFilter(Set<String> elementPaths, Set<String> packages)
         {
-            this.generationSpecPaths = generationSpecPaths;
+            this.elementPaths = elementPaths;
             if (packages == null)
             {
                 this.packages = null;
@@ -259,19 +321,19 @@ public class FileGenerationMojo extends AbstractMojo
         }
 
         @Override
-        public boolean test(String generationSpecPath)
+        public boolean test(String elementPath)
         {
-            if (this.generationSpecPaths == null)
+            if (this.elementPaths == null)
             {
-                return (this.packages == null) || inSomePackage(generationSpecPath);
+                return (this.packages == null) || inSomePackage(elementPath);
             }
 
-            if (this.generationSpecPaths.contains(generationSpecPath))
+            if (this.elementPaths.contains(elementPath))
             {
                 return true;
             }
 
-            return (this.packages != null) && inSomePackage(generationSpecPath);
+            return (this.packages != null) && inSomePackage(elementPath);
         }
 
         private boolean inSomePackage(String path)

--- a/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestFileGenerationMojo.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestFileGenerationMojo.java
@@ -139,7 +139,7 @@ public class TestFileGenerationMojo
         assertDirectoryEmpty(outputDir);
         executeMojo(projectDir, entitiesDir);
         Set<String> actualGeneratedSourceFiles = getFileStream(generatedSourceDir, true).map(Path::toString).collect(Collectors.toSet());
-        Assert.assertEquals(20, actualGeneratedSourceFiles.size());
+        Assert.assertEquals(23, actualGeneratedSourceFiles.size());
         // Temporary disable because of ordering issue in the Protobuf generation
         verifyDirsAreEqual(generatedSourceDir, expectedPath);
     }
@@ -235,7 +235,7 @@ public class TestFileGenerationMojo
         assertDirectoryEmpty(outputDir);
         executeMojo(projectDir, entitySourceDirectories);
         Set<String> actualGeneratedSourceFiles = getFileStream(generatedSourceDir, true).map(Path::toString).collect(Collectors.toSet());
-        Assert.assertEquals(20, actualGeneratedSourceFiles.size());
+        Assert.assertEquals(23, actualGeneratedSourceFiles.size());
     }
 
     private Model buildMavenModel(String groupId, String artifactId, String version, String packaging)

--- a/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestSimpleEnumArtifactGenerationExtension.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestSimpleEnumArtifactGenerationExtension.java
@@ -1,0 +1,49 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.generation.file;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.Artifact;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration;
+
+import java.util.List;
+
+public class TestSimpleEnumArtifactGenerationExtension implements ArtifactGenerationExtension
+{
+
+    @Override
+    public String getKey()
+    {
+        return "test-enumeration-generation";
+    }
+
+    @Override
+    public boolean canGenerate(PackageableElement packageableElement)
+    {
+        return packageableElement instanceof Enumeration;
+    }
+
+    @Override
+    public List<Artifact> generate(PackageableElement packageableElement, PureModel pureModel, PureModelContextData pureModelContextData, String s)
+    {
+        String content = "Some output for enumeration '" + packageableElement._name() + "'";
+        Artifact artifact = new Artifact(content, "SomeTestOutput.txt", "txt");
+        return Lists.mutable.with(artifact);
+    }
+}

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension
@@ -1,0 +1,1 @@
+org.finos.legend.sdlc.generation.file.TestSimpleEnumArtifactGenerationExtension

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/City/test-enumeration-generation/SomeTestOutput.txt
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/City/test-enumeration-generation/SomeTestOutput.txt
@@ -1,0 +1,1 @@
+Some output for enumeration 'City'

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/Country/test-enumeration-generation/SomeTestOutput.txt
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/Country/test-enumeration-generation/SomeTestOutput.txt
@@ -1,0 +1,1 @@
+Some output for enumeration 'Country'

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/IncType/test-enumeration-generation/SomeTestOutput.txt
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/IncType/test-enumeration-generation/SomeTestOutput.txt
@@ -1,0 +1,1 @@
+Some output for enumeration 'IncType'

--- a/legend-sdlc-generation-file/pom.xml
+++ b/legend-sdlc-generation-file/pom.xml
@@ -31,6 +31,10 @@
 
         <!-- PURE -->
         <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m3-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-pure-code-compiled-core</artifactId>
         </dependency>

--- a/legend-sdlc-generation-file/src/main/java/org/finos/legend/sdlc/generation/artifact/ArtifactGenerationFactory.java
+++ b/legend-sdlc-generation-file/src/main/java/org/finos/legend/sdlc/generation/artifact/ArtifactGenerationFactory.java
@@ -1,0 +1,101 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package org.finos.legend.sdlc.generation.artifact;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.Artifact;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtensionLoader;
+import org.finos.legend.engine.protocol.pure.PureClientVersions;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
+import org.finos.legend.sdlc.generation.file.GenerationOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class ArtifactGenerationFactory
+{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactGenerationFactory.class);
+    private final PureModel pureModel;
+    private final List<ArtifactGenerationExtension> extensions;
+    private final List<PackageableElement> elements;
+    private final PureModelContextData data;
+
+    ArtifactGenerationFactory(PureModel pureModel, PureModelContextData data, List<PackageableElement> elements)
+    {
+        if (pureModel == null || elements == null)
+        {
+            throw new RuntimeException("Pure model and elements required for artifact generation factory");
+        }
+        this.data = data;
+        this.pureModel = pureModel;
+        this.elements = elements;
+        this.extensions = ArtifactGenerationExtensionLoader.extensions();
+    }
+
+    public static ArtifactGenerationFactory newFactory(PureModel pureModel, PureModelContextData data, List<PackageableElement> elements)
+    {
+        return new ArtifactGenerationFactory(pureModel, data, elements);
+    }
+
+    public MutableMap<ArtifactGenerationExtension, List<ArtifactGenerationResult>> generate()
+    {
+        if (this.extensions.isEmpty() || this.elements.isEmpty())
+        {
+            return Maps.mutable.empty();
+        }
+        MutableMap<ArtifactGenerationExtension, List<ArtifactGenerationResult>> results = Maps.mutable.empty();
+        for (PackageableElement element : this.elements)
+        {
+            org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement packageableElement = pureModel.getPackageableElement(element.getPath());
+            for (ArtifactGenerationExtension extension : this.extensions)
+            {
+                if (extension.canGenerate(packageableElement))
+                {
+                    List<Artifact> artifacts = this.generateArtifacts(packageableElement, element, extension);
+                    List<GenerationOutput> outputs = ListIterate.collect(artifacts, artifact -> new GenerationOutput(artifact.content, artifact.path, artifact.format));
+                    ArtifactGenerationResult result = new ArtifactGenerationResult(packageableElement, outputs, extension);
+                    results.getIfAbsentPut(result.getGenerator(), Lists.mutable::empty).add(result);
+                }
+            }
+        }
+        return results;
+    }
+
+    private List<Artifact> generateArtifacts(org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement packageableElement, PackageableElement element, ArtifactGenerationExtension extension)
+    {
+        try
+        {
+            LOGGER.info("Start generating artifact extension '{}' for element '{}'", extension.getClass(), element.getPath());
+            List<Artifact> outputs = extension.generate(packageableElement, this.pureModel, this.data, PureClientVersions.production);
+            LOGGER.info("Done generating artifacts, {} artifacts generated", outputs.size());
+            return outputs;
+        }
+        catch (Exception exception)
+        {
+            LOGGER.error("Error generating artifacts for extension '{}':", extension.getClass(), exception);
+            throw exception;
+        }
+    }
+
+}

--- a/legend-sdlc-generation-file/src/main/java/org/finos/legend/sdlc/generation/artifact/ArtifactGenerationResult.java
+++ b/legend-sdlc-generation-file/src/main/java/org/finos/legend/sdlc/generation/artifact/ArtifactGenerationResult.java
@@ -1,0 +1,52 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.generation.artifact;
+
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.sdlc.generation.file.GenerationOutput;
+
+import java.util.List;
+
+
+public class ArtifactGenerationResult
+{
+
+    private final PackageableElement element;
+    private final List<GenerationOutput> results;
+    private final ArtifactGenerationExtension generator;
+
+    public ArtifactGenerationResult(PackageableElement element, List<GenerationOutput> results, ArtifactGenerationExtension generator)
+    {
+        this.element = element;
+        this.results = results;
+        this.generator = generator;
+    }
+
+    public ArtifactGenerationExtension getGenerator()
+    {
+        return this.generator;
+    }
+
+    public List<GenerationOutput> getResults()
+    {
+        return this.results;
+    }
+
+    public PackageableElement getElement()
+    {
+        return this.element;
+    }
+}


### PR DESCRIPTION
- Related to https://github.com/finos/legend-sdlc/issues/504
- `BREAKING` depends on https://github.com/finos/legend-engine/pull/833 and https://github.com/finos/legend-engine/pull/900
- handles ArtifactGenerationExtensions and serializes the result to the output directory as part of the file maven plugin 