### PR TITLE
Validate prefix when parsing project ids

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/GitLabProjectId.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/GitLabProjectId.java
@@ -31,6 +31,11 @@ public final class GitLabProjectId
         this.gitLabId = gitLabId;
     }
 
+    public String getPrefix()
+    {
+        return this.prefix;
+    }
+
     public int getGitLabId()
     {
         return this.gitLabId;
@@ -77,27 +82,33 @@ public final class GitLabProjectId
     {
         if (projectId == null)
         {
-            return null;
+            throw new IllegalArgumentException("Invalid project id: null");
+        }
+        if (projectId.isEmpty())
+        {
+            throw new IllegalArgumentException("Invalid project id: \"\"");
         }
 
         int separatorIndex = projectId.indexOf(DELIMITER);
-        return newProjectId(separatorIndex == -1 ? null : projectId.substring(0, separatorIndex), parseGitLabId(projectId, separatorIndex));
+        String prefix = (separatorIndex == -1) ? null : projectId.substring(0, separatorIndex);
+        int gitLabId = parseGitLabId(projectId, separatorIndex + 1);
+        return newProjectId(prefix, gitLabId);
     }
 
-    private static int parseGitLabId(String projectId, int separatorIndex)
+    private static int parseGitLabId(String projectId, int start)
     {
         try
         {
-            return Integer.parseInt(projectId.substring(separatorIndex + 1));
+            return Integer.parseInt(projectId.substring(start));
         }
         catch (NumberFormatException e)
         {
-            throw new IllegalArgumentException("Invalid project id: " + projectId);
+            throw new IllegalArgumentException("Invalid project id: \"" + projectId + "\"");
         }
     }
 
     private static String getProjectIdString(String prefix, int gitLabId)
     {
-        return (prefix != null ? (prefix + DELIMITER) : "") + gitLabId;
+        return (prefix == null) ? Integer.toString(gitLabId) : (prefix + DELIMITER + gitLabId);
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/BaseGitLabApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/BaseGitLabApi.java
@@ -47,6 +47,7 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.Base64.Encoder;
 import java.util.Date;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.function.Function;
@@ -120,7 +121,11 @@ abstract class BaseGitLabApi
         }
         catch (Exception e)
         {
-            throw new LegendSDLCServerException("Invalid project id: " + projectId, Status.BAD_REQUEST, e);
+            throw new LegendSDLCServerException("Invalid project id: \"" + projectId + "\"", Status.BAD_REQUEST, e);
+        }
+        if (!Objects.equals(this.gitLabConfiguration.getProjectIdPrefix(), gitLabProjectId.getPrefix()))
+        {
+            throw new LegendSDLCServerException("Invalid project id: \"" + projectId + "\"", Status.BAD_REQUEST);
         }
         return gitLabProjectId;
     }


### PR DESCRIPTION
Validate prefix when parsing project ids. Previously, if someone used the wrong prefix in a project id, it would be ignored. The integer part of the id was extracted and used. This can lead to people potentially getting the wrong project in cases where there are multiple servers that use different id prefixes. Now the server will return a 400 if the user uses the wrong id prefix.