### PR TITLE
Deprecate (old style) artifact generations

### DIFF
--- a/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ArtifactGeneration.java
+++ b/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ArtifactGeneration.java
@@ -16,6 +16,7 @@ package org.finos.legend.sdlc.domain.model.project.configuration;
 
 import java.util.Map;
 
+@Deprecated
 public interface ArtifactGeneration
 {
     String getName();

--- a/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ArtifactType.java
+++ b/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ArtifactType.java
@@ -16,12 +16,25 @@ package org.finos.legend.sdlc.domain.model.project.configuration;
 
 public enum ArtifactType
 {
+    @Deprecated
     avro("Avro"),
+
+    @Deprecated
     java("Java"),
+
+    @Deprecated
     jsonSchema("JSON Schema"),
+
+    @Deprecated
     protobuf("Protobuf"),
+
+    @Deprecated
     slang("Slang"),
+
+    @Deprecated
     javaCode("Java Code"),
+
+    @Deprecated
     cdm("Rosetta"),
 
     entities("Entity"),

--- a/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ProjectConfiguration.java
+++ b/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ProjectConfiguration.java
@@ -16,6 +16,7 @@ package org.finos.legend.sdlc.domain.model.project.configuration;
 
 import org.finos.legend.sdlc.domain.model.project.ProjectType;
 
+import java.util.Collections;
 import java.util.List;
 
 public interface ProjectConfiguration
@@ -23,7 +24,10 @@ public interface ProjectConfiguration
     String getProjectId();
 
     @Deprecated
-    ProjectType getProjectType();
+    default ProjectType getProjectType()
+    {
+        return null;
+    }
 
     ProjectStructureVersion getProjectStructureVersion();
 
@@ -35,5 +39,9 @@ public interface ProjectConfiguration
 
     List<MetamodelDependency> getMetamodelDependencies();
 
-    List<ArtifactGeneration> getArtifactGenerations();
+    @Deprecated
+    default List<ArtifactGeneration> getArtifactGenerations()
+    {
+        return Collections.emptyList();
+    }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/project/ProjectConfigurationApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/project/ProjectConfigurationApi.java
@@ -19,13 +19,14 @@ import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactTypeGene
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectStructureVersion;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
-import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 
-import javax.ws.rs.core.Response;
+import java.util.Collections;
 import java.util.List;
+import javax.ws.rs.core.Response;
 
 public interface ProjectConfigurationApi
 {
@@ -171,6 +172,9 @@ public interface ProjectConfigurationApi
 
     ProjectStructureVersion getLatestProjectStructureVersion();
 
-    List<ArtifactTypeGenerationConfiguration> getLatestAvailableArtifactGenerations();
-
+    @Deprecated
+    default List<ArtifactTypeGenerationConfiguration> getLatestAvailableArtifactGenerations()
+    {
+        return Collections.emptyList();
+    }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectConfigurationApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectConfigurationApi.java
@@ -14,8 +14,6 @@
 
 package org.finos.legend.sdlc.server.gitlab.api;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactGeneration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactTypeGenerationConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.MetamodelDependency;
@@ -40,10 +38,10 @@ import org.finos.legend.sdlc.server.tools.BackgroundTaskProcessor;
 import org.gitlab4j.api.models.DiffRef;
 import org.gitlab4j.api.models.MergeRequest;
 
-import javax.inject.Inject;
-import javax.ws.rs.core.Response.Status;
 import java.util.Collections;
 import java.util.List;
+import javax.inject.Inject;
+import javax.ws.rs.core.Response.Status;
 
 public class GitLabProjectConfigurationApi extends GitLabApiWithFileAccess implements ProjectConfigurationApi
 {
@@ -395,12 +393,6 @@ public class GitLabProjectConfigurationApi extends GitLabApiWithFileAccess imple
             }
 
             @Override
-            public ProjectType getProjectType()
-            {
-                return null;
-            }
-
-            @Override
             public ProjectStructureVersion getProjectStructureVersion()
             {
                 return getLatestProjectStructureVersion();
@@ -426,12 +418,6 @@ public class GitLabProjectConfigurationApi extends GitLabApiWithFileAccess imple
 
             @Override
             public List<MetamodelDependency> getMetamodelDependencies()
-            {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public List<ArtifactGeneration> getArtifactGenerations()
             {
                 return Collections.emptyList();
             }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectConfigurationUpdateBuilder.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectConfigurationUpdateBuilder.java
@@ -385,35 +385,41 @@ public class ProjectConfigurationUpdateBuilder
         return this;
     }
 
+    @Deprecated
     public ProjectConfigurationUpdateBuilder withArtifactGenerationToAdd(ArtifactGeneration generation)
     {
         addArtifactGenerationToAdd(generation);
         return this;
     }
 
+    @Deprecated
     public ProjectConfigurationUpdateBuilder withArtifactGenerationsToAdd(Iterable<? extends ArtifactGeneration> generations)
     {
         addArtifactGenerationsToAdd(generations);
         return this;
     }
 
+    @Deprecated
     public ProjectConfigurationUpdateBuilder withArtifactGenerationToRemove(String generationName)
     {
         addArtifactGenerationToRemove(generationName);
         return this;
     }
 
+    @Deprecated
     public ProjectConfigurationUpdateBuilder withArtifactGenerationsToRemove(Iterable<String> generationName)
     {
         addArtifactGenerationsToRemove(generationName);
         return this;
     }
 
+    @Deprecated
     public void addArtifactGenerationToAdd(ArtifactGeneration generation)
     {
         this.generationsToAdd.add(generation);
     }
 
+    @Deprecated
     public void addArtifactGenerationsToAdd(Iterable<? extends ArtifactGeneration> generations)
     {
         if (generations != null)
@@ -422,11 +428,13 @@ public class ProjectConfigurationUpdateBuilder
         }
     }
 
+    @Deprecated
     public void addArtifactGenerationToRemove(String generationName)
     {
         this.generationNamesToRemove.add(generationName);
     }
 
+    @Deprecated
     public void addArtifactGenerationsToRemove(Iterable<String> generationNames)
     {
         if (generationNames != null)
@@ -435,16 +443,19 @@ public class ProjectConfigurationUpdateBuilder
         }
     }
 
+    @Deprecated
     public List<ArtifactGeneration> getArtifactGenerationToAdd()
     {
         return this.generationsToAdd;
     }
 
+    @Deprecated
     public boolean hasArtifactGenerationsToAdd()
     {
         return !this.generationsToAdd.isEmpty();
     }
 
+    @Deprecated
     public Set<String> getArtifactGenerationToRemove()
     {
         return this.generationNamesToRemove;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/SimpleProjectConfiguration.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/SimpleProjectConfiguration.java
@@ -62,12 +62,6 @@ public class SimpleProjectConfiguration implements ProjectConfiguration
     }
 
     @Override
-    public ProjectType getProjectType()
-    {
-        return null;
-    }
-
-    @Override
     public ProjectStructureVersion getProjectStructureVersion()
     {
         return this.projectStructureVersion;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/MultiModuleMavenProjectStructure.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/MultiModuleMavenProjectStructure.java
@@ -58,7 +58,6 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-
 public abstract class MultiModuleMavenProjectStructure extends MavenProjectStructure
 {
     private static final Pattern VALID_MODULE_NAME = Pattern.compile("\\w++(-\\w++)*+");
@@ -94,6 +93,7 @@ public abstract class MultiModuleMavenProjectStructure extends MavenProjectStruc
         this(projectConfiguration, entitiesModuleName, sourceDirectories, otherModules, useDependencyManagement, null);
     }
 
+    @Deprecated
     protected Stream<String> getGenerationModuleNames(ArtifactType type)
     {
         return getProjectConfiguration().getArtifactGenerations().stream().filter(art -> type == art.getType()).map(ArtifactGeneration::getName);
@@ -296,7 +296,7 @@ public abstract class MultiModuleMavenProjectStructure extends MavenProjectStruc
     {
         Model mavenModel = createMavenModuleModel(otherModuleName);
 
-        ArtifactType typeForConfig = otherModules.get(otherModuleName);
+        ArtifactType typeForConfig = this.otherModules.get(otherModuleName);
         Map<ModuleConfigType, Method> otherModuleConfigMethods = this.moduleConfigMethods.get(getModuleConfigName(typeForConfig));
         if (otherModuleConfigMethods != null)
         {

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConfigurationResource.java
@@ -20,13 +20,13 @@ import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactTypeGene
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectStructureVersion;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 
+import java.util.List;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.List;
 
 @Api("Project Configuration")
 @Path("/configuration")
@@ -53,6 +53,7 @@ public class ConfigurationResource extends BaseResource
     @GET
     @Path("/latestAvailableGenerations")
     @ApiOperation("Get available generations for the latest version")
+    @Deprecated
     public List<ArtifactTypeGenerationConfiguration> getLatestAvailableGenerations()
     {
         return this.projectConfigurationApi.getLatestAvailableArtifactGenerations();

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryProjectConfigurationApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryProjectConfigurationApi.java
@@ -28,8 +28,8 @@ import org.finos.legend.sdlc.server.inmemory.domain.api.InMemoryProject;
 import org.finos.legend.sdlc.server.inmemory.domain.api.InMemoryRevision;
 import org.finos.legend.sdlc.server.inmemory.domain.api.InMemoryVersion;
 
-import javax.inject.Inject;
 import java.util.List;
+import javax.inject.Inject;
 
 public class InMemoryProjectConfigurationApi implements ProjectConfigurationApi
 {
@@ -168,12 +168,6 @@ public class InMemoryProjectConfigurationApi implements ProjectConfigurationApi
 
     @Override
     public ProjectStructureVersion getLatestProjectStructureVersion()
-    {
-        throw new UnsupportedOperationException("Not implemented");
-    }
-
-    @Override
-    public List<ArtifactTypeGenerationConfiguration> getLatestAvailableArtifactGenerations()
     {
         throw new UnsupportedOperationException("Not implemented");
     }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/domain/api/InMemoryProjectConfiguration.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/domain/api/InMemoryProjectConfiguration.java
@@ -16,8 +16,6 @@ package org.finos.legend.sdlc.server.inmemory.domain.api;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
-import org.finos.legend.sdlc.domain.model.project.ProjectType;
-import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactGeneration;
 import org.finos.legend.sdlc.domain.model.project.configuration.MetamodelDependency;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
@@ -39,12 +37,6 @@ public class InMemoryProjectConfiguration implements ProjectConfiguration
 
     @Override
     public String getProjectId()
-    {
-        return null;
-    }
-
-    @Override
-    public ProjectType getProjectType()
     {
         return null;
     }
@@ -84,12 +76,6 @@ public class InMemoryProjectConfiguration implements ProjectConfiguration
 
     @Override
     public List<MetamodelDependency> getMetamodelDependencies()
-    {
-        return null;
-    }
-
-    @Override
-    public List<ArtifactGeneration> getArtifactGenerations()
     {
         return null;
     }


### PR DESCRIPTION
Deprecate old style artifact generations. These have been replaced by a new framework for generations.