### PR TITLE
Upgrade Dockerfile to use openjdk:11.0.16

### DIFF
--- a/legend-sdlc-server/Dockerfile
+++ b/legend-sdlc-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.15-bullseye
+FROM openjdk:11.0.16
 COPY target/legend-sdlc-server-*-shaded.jar /app/bin/
 CMD java -cp /app/bin/*.jar \
 -XX:+ExitOnOutOfMemoryError \


### PR DESCRIPTION
Upgrade Dockerfile to use openjdk:11.0.16