### PR TITLE
Fix bug in project import where workspace information is dropped

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabApiWithFileAccess.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabApiWithFileAccess.java
@@ -989,9 +989,9 @@ abstract class GitLabApiWithFileAccess extends BaseGitLabApi
             this.revisionId = revisionId;
             this.workspaceType = workspaceType;
             this.workspaceAccessType = workspaceAccessType;
-            if ((this.workspaceId != null) && (this.workspaceAccessType == null))
+            if ((this.workspaceId != null) && ((this.workspaceType == null) || (this.workspaceAccessType == null)))
             {
-                throw new RuntimeException("workspace access type is required when workspace ID is specified");
+                throw new RuntimeException("workspace type and access type are required when workspace id is specified");
             }
         }
 


### PR DESCRIPTION
Fix bug in project import where workspace information is dropped. In passing, fix a validation that workspace type and access type are present when workspace id is present.