### PR TITLE
Include default configuration files in Docker image

### DIFF
--- a/legend-sdlc-server/Dockerfile
+++ b/legend-sdlc-server/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11.0.16-bullseye
 COPY target/legend-sdlc-server-*-shaded.jar /app/bin/
-COPY target/classes/docker/config /config
+COPY src/main/resources/docker/config /config
 CMD java -cp /app/bin/*.jar \
 -XX:+ExitOnOutOfMemoryError \
 -XX:MaxRAMPercentage=60 \

--- a/legend-sdlc-server/Dockerfile
+++ b/legend-sdlc-server/Dockerfile
@@ -1,5 +1,6 @@
 FROM openjdk:11.0.16-bullseye
 COPY target/legend-sdlc-server-*-shaded.jar /app/bin/
+COPY target/classes/docker/config /config
 CMD java -cp /app/bin/*.jar \
 -XX:+ExitOnOutOfMemoryError \
 -XX:MaxRAMPercentage=60 \

--- a/legend-sdlc-server/src/main/resources/docker/config/config.json
+++ b/legend-sdlc-server/src/main/resources/docker/config/config.json
@@ -1,0 +1,106 @@
+{
+  "applicationName": "Legend SDLC",
+  "server": {
+    "adminContextPath": "/admin",
+    "applicationConnectors": [
+      {
+        "type": "http",
+        "port": ${SDLC_PORT},
+        "maxRequestHeaderSize": "128KiB"
+      }
+    ],
+    "adminConnectors": [
+      {
+        "type": "http",
+        "port": 7071
+      }
+    ],
+    "gzip": {
+      "includedMethods": [
+        "GET",
+        "POST"
+      ]
+    },
+    "requestLog": {
+      "type": "classic",
+      "level": "OFF",
+      "appenders": [
+        {
+          "type": "console",
+          "logFormat": "OFF"
+        }
+      ]
+    },
+    "rootPath": "/api"
+  },
+  "projectStructure": {
+    "projectCreation": {
+      "groupIdPattern": "^org\\.finos\\.legend\\..+"
+    },
+    "extensionProvider": {
+      "org.finos.legend.sdlc.server.gitlab.finos.FinosGitlabProjectStructureExtensionProvider": {}
+    }
+  },
+  "filterPriorities": {
+    "GitLab": 1,
+    "org.pac4j.j2e.filter.CallbackFilter": 2,
+    "org.pac4j.j2e.filter.SecurityFilter": 3,
+    "CORS": 4
+  },
+  "pac4j": {
+    "callbackPrefix": "/api/pac4j/login",
+    "mongoUri": "${MONGODB_URI}",
+    "mongoDb": "${MONGODB_NAME}",
+    "clients": [
+      {
+        "org.finos.legend.server.pac4j.gitlab.GitlabClient": {
+          "name": "gitlab",
+          "clientId": "${GITLAB_APP_ID}",
+          "secret": "${GITLAB_APP_SECRET}",
+          "discoveryUri": "https://${GITLAB_HOST}/.well-known/openid-configuration",
+          "scope": "openid profile api"
+        }
+      }
+    ],
+    "mongoSession": {
+      "enabled": "${MONGO_SESSION_ENABLED}",
+      "collection": "userSessions"
+    },
+    "bypassPaths": [
+      "/api/info"
+    ]
+  },
+  "features": {
+    "canCreateProject": true,
+    "canCreateVersion": true
+  },
+  "gitLab": {
+    "newProjectVisibility": "public",
+    "projectTag": "pure",
+    "projectIdPrefix": "UAT",
+    "server": {
+      "scheme": "https",
+      "host": "${GITLAB_HOST}"
+    },
+    "app": {
+      "id": "${GITLAB_APP_ID}",
+      "secret": "${GITLAB_APP_SECRET}",
+      "redirectURI": "http://localhost:7070/api/auth/callback"
+    }
+  },
+  "logging": {
+    "level": "INFO",
+    "appenders": [
+      {
+        "type": "console",
+        "logFormat": "%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p [%thread] %c - %m%n"
+      }
+    ]
+  },
+  "swagger": {
+    "resourcePackage": "org.finos.legend.sdlc.server.resources",
+    "title": "Legend LEGEND_SDLC",
+    "version": "local-snapshot",
+    "schemes": []
+  }
+}

--- a/legend-sdlc-server/src/main/resources/docker/config/config.json
+++ b/legend-sdlc-server/src/main/resources/docker/config/config.json
@@ -12,7 +12,7 @@
     "adminConnectors": [
       {
         "type": "http",
-        "port": 7071
+        "port": ${SDLC_ADMIN_PORT}
       }
     ],
     "gzip": {
@@ -35,10 +35,23 @@
   },
   "projectStructure": {
     "projectCreation": {
-      "groupIdPattern": "^org\\.finos\\.legend\\..+"
     },
     "extensionProvider": {
       "org.finos.legend.sdlc.server.gitlab.finos.FinosGitlabProjectStructureExtensionProvider": {}
+    },
+    "platforms": {
+       "legend-engine": {
+           "groupId": "org.finos.legend.engine",
+           "platformVersion": {
+              "version": "${ENGINE_MAVEN_VERSION}"
+           }
+       },
+       "legend-sdlc": {
+          "groupId": "org.finos.legend.sdlc",
+          "platformVersion":{
+              "version": "${SDLC_MAVEN_VERSION}"
+          } 
+       }
     }
   },
   "filterPriorities": {
@@ -76,8 +89,7 @@
   },
   "gitLab": {
     "newProjectVisibility": "public",
-    "projectTag": "pure",
-    "projectIdPrefix": "UAT",
+    "projectTag": "${SDLC_PROJECT_TAG}",
     "server": {
       "scheme": "https",
       "host": "${GITLAB_HOST}"
@@ -85,7 +97,7 @@
     "app": {
       "id": "${GITLAB_APP_ID}",
       "secret": "${GITLAB_APP_SECRET}",
-      "redirectURI": "http://localhost:7070/api/auth/callback"
+      "redirectURI": "${SDLC_REDIRECT_URI}"
     }
   },
   "logging": {


### PR DESCRIPTION
This PR adds a set of default configuration files into the server Docker image. 

This simplifies the running of the Docker images. Users can simply run the container by passing configuration values as environment variables instead of having to manage the configuration files. 
