### PR TITLE
support function overloading

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/BaseGitLabApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/BaseGitLabApi.java
@@ -66,7 +66,7 @@ abstract class BaseGitLabApi
     private static final Random RANDOM = new Random();
     private static final Encoder RANDOM_ID_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
-    private static final Pattern PACKAGEABLE_ELEMENT_PATH_PATTERN = Pattern.compile("^\\w++(::\\w++)*+(\\w*+\\$\\w++\\$\\w*+)*+$");
+    private static final Pattern PACKAGEABLE_ELEMENT_PATH_PATTERN = Pattern.compile("^\\w++(::\\w++)*+[\\w$]*+$");
 
     private static final int MAX_RETRIES = 5;
     private static final long INITIAL_RETRY_WAIT_INTERVAL_MILLIS = 1000L;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/BaseGitLabApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/BaseGitLabApi.java
@@ -157,7 +157,7 @@ abstract class BaseGitLabApi
 
     protected static boolean isValidEntityName(String string)
     {
-        return (string != null) && !string.isEmpty() && string.chars().allMatch(c -> (c == '_') || Character.isLetterOrDigit(c));
+        return (string != null) && !string.isEmpty() && string.chars().allMatch(c -> (c == '_')  || (c == '$') || Character.isLetterOrDigit(c));
     }
 
     protected static boolean isValidEntityPath(String string)
@@ -167,7 +167,7 @@ abstract class BaseGitLabApi
 
     protected static boolean isValidPackagePath(String string)
     {
-        return isValidPackageableElementPath(string);
+        return isValidPackageableElementPath(string) && !string.contains("$");
     }
 
     protected static boolean isValidClassifierPath(String string)

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/BaseGitLabApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/BaseGitLabApi.java
@@ -66,7 +66,7 @@ abstract class BaseGitLabApi
     private static final Random RANDOM = new Random();
     private static final Encoder RANDOM_ID_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
-    private static final Pattern PACKAGEABLE_ELEMENT_PATH_PATTERN = Pattern.compile("^\\w++(::\\w++)*+$");
+    private static final Pattern PACKAGEABLE_ELEMENT_PATH_PATTERN = Pattern.compile("^\\w++(::\\w++)*+(\\w*+\\$\\w++\\$\\w*+)*+$");
 
     private static final int MAX_RETRIES = 5;
     private static final long INITIAL_RETRY_WAIT_INTERVAL_MILLIS = 1000L;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
@@ -981,7 +981,7 @@ public class GitLabEntityApi extends GitLabApiWithFileAccess implements EntityAp
                      *  and create corresponding new files for functions. Therefore, gitlab will keep clean and consistent.
                      */
                     if ((localEntity.getPath() != null) && (getEntityPath() != null) &&
-                            localEntity.getPath().contains(getEntityPath()) &&
+                            localEntity.getPath().startsWith(getEntityPath()) &&
                             "meta::pure::metamodel::function::ConcreteFunctionDefinition".equals(localEntity.getClassifierPath()))
                     {
                         // getEntityPath() only contains functionName

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -983,8 +984,12 @@ public class GitLabEntityApi extends GitLabApiWithFileAccess implements EntityAp
                             localEntity.getPath().contains(getEntityPath()) &&
                             "meta::pure::metamodel::function::ConcreteFunctionDefinition".equals(localEntity.getClassifierPath()))
                     {
-                        // getEntityPath() only contains functionName.
-                        this.entity = Entity.newEntity(getEntityPath(), localEntity.getClassifierPath(), localEntity.getContent());
+                        // getEntityPath() only contains functionName
+                        // update content's name to obey the rule that the entity path must equal package + "::" + name.
+                        Map<String, Object> newContent = new HashMap<>(localEntity.getContent().size());
+                        localEntity.getContent().forEach((k, v) -> newContent.put(k, v));
+                        newContent.put("name", getEntityPath().substring(getEntityPath().lastIndexOf(":") + 1));
+                        this.entity = Entity.newEntity(getEntityPath(), localEntity.getClassifierPath(), newContent);
                     }
                     else
                     {

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
@@ -47,7 +47,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -986,8 +985,7 @@ public class GitLabEntityApi extends GitLabApiWithFileAccess implements EntityAp
                     {
                         // getEntityPath() only contains functionName
                         // update content's name to obey the rule that the entity path must equal package + "::" + name.
-                        Map<String, Object> newContent = new HashMap<>(localEntity.getContent().size());
-                        localEntity.getContent().forEach((k, v) -> newContent.put(k, v));
+                        Map<String, Object> newContent = Maps.mutable.ofMap(localEntity.getContent());
                         newContent.put("name", getEntityPath().substring(getEntityPath().lastIndexOf(":") + 1));
                         this.entity = Entity.newEntity(getEntityPath(), localEntity.getClassifierPath(), newContent);
                     }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
@@ -962,29 +962,23 @@ public class GitLabEntityApi extends GitLabApiWithFileAccess implements EntityAp
                 if (!Objects.equals(localEntity.getPath(), getEntityPath()))
                 {
                     /**
-                     *  In gitlab, each entity will be stored as a file of which file name is built upon entity's path.
-                     *  for now, the file name of function is functionName, which doesn't contain function signature.
-                     *  To support function overloading, Engine is updated to store function signature as the name of
-                     *  PackageableElement, which updates PackageableElement's path at the same time since path is
-                     *  built upon PackageableElement's name. Any new function entity will be stored in a file whose
-                     *  name is the full function signature in gitlab. However, existing functions need to be updated
-                     *  to be consistent.
+                     * This is a temporary hack to compensate for a non-backward-compatible change in
+                     * ConcreteFunctionDefinition parsing in legend-engine. Previously, the function name was used as the
+                     * PackageableElement name by the parser. Now, however, a new PackageableElement name is created
+                     * based on the function name and signature (i.e., the same name the Pure compiler would give it)
                      *
-                     *  getEntityPath() is from file name in gitlab
-                     *  localEntity is computed from Engine, once Engine is updated, it will contain the whole function signature.
-                     *  For existing functions in gitlab, localEntity.getPath() and getEntityPath() won't match anymore.
-                     *  However, they are related. localEntity.getPath() must contain getEntityPath() if everything is correct
-                     *  for these cases. If condition below is true, a new entity will be created using the short version
-                     *  of the path (functionName only) as a flag for Studio to trigger a `delete` and `create` actions.
-                     *  Users have to push local changes computed automatically for functions above, which will delete old files
-                     *  and create corresponding new files for functions. Therefore, gitlab will keep clean and consistent.
+                     * Normally, an exception would be thrown when there is a mismatch between the expected entity path
+                     * (based on the file path) and the one computed from the parsed entity (based on the "package" and
+                     * "name" properties). However, to compensate for this non-backward-compatible change, if the entity is a
+                     * ConcreteFunctionDefinition, the entity path and "name" property will be changed to match the expected
+                     * values.
+                     *
+                     * This hack should be removed at the earliest opportunity, and no later than 3/31/2023.
                      */
                     if ((localEntity.getPath() != null) && (getEntityPath() != null) &&
                             localEntity.getPath().startsWith(getEntityPath()) &&
                             "meta::pure::metamodel::function::ConcreteFunctionDefinition".equals(localEntity.getClassifierPath()))
                     {
-                        // getEntityPath() only contains functionName
-                        // update content's name to obey the rule that the entity path must equal package + "::" + name.
                         Map<String, Object> newContent = Maps.mutable.ofMap(localEntity.getContent());
                         newContent.put("name", getEntityPath().substring(getEntityPath().lastIndexOf(":") + 1));
                         this.entity = Entity.newEntity(getEntityPath(), localEntity.getClassifierPath(), newContent);

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/TestBaseGitLabApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/TestBaseGitLabApi.java
@@ -55,6 +55,8 @@ public class TestBaseGitLabApi
     {
         Assert.assertTrue(BaseGitLabApi.isValidPackagePath("model"));
         Assert.assertTrue(BaseGitLabApi.isValidPackagePath("random::entity::path"));
+        Assert.assertTrue(BaseGitLabApi.isValidPackagePath("meta"));
+        Assert.assertTrue(BaseGitLabApi.isValidPackagePath("meta::entity::path"));
 
         Assert.assertFalse(BaseGitLabApi.isValidPackagePath("model::"));
         Assert.assertFalse(BaseGitLabApi.isValidPackagePath("model::*"));
@@ -85,6 +87,8 @@ public class TestBaseGitLabApi
 
         Assert.assertFalse(BaseGitLabApi.isValidClassifierPath("meta::"));
         Assert.assertFalse(BaseGitLabApi.isValidClassifierPath("meta::*"));
+        Assert.assertFalse(BaseGitLabApi.isValidClassifierPath("random"));
+        Assert.assertFalse(BaseGitLabApi.isValidClassifierPath("random::entity::path"));
         Assert.assertFalse(BaseGitLabApi.isValidClassifierPath("meta::$test::$function"));
         Assert.assertFalse(BaseGitLabApi.isValidClassifierPath("meta::has::other::characters::test_String_$1_10$__String_$1_*$_&"));
     }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/TestBaseGitLabApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/TestBaseGitLabApi.java
@@ -1,0 +1,91 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.server.gitlab.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestBaseGitLabApi
+{
+    @Test
+    public void testIsValidEntityName()
+    {
+        Assert.assertTrue(BaseGitLabApi.isValidEntityName("randomEntityName"));
+        Assert.assertTrue(BaseGitLabApi.isValidEntityName("entityNameAllows$"));
+        Assert.assertTrue(BaseGitLabApi.isValidEntityName("entityNameAllows$And_"));
+        Assert.assertTrue(BaseGitLabApi.isValidEntityName("entity_name_only_has_underscore"));
+        Assert.assertTrue(BaseGitLabApi.isValidEntityName("test_String_$1_10$__String_MANY_"));
+        Assert.assertTrue(BaseGitLabApi.isValidEntityName("test_String_$1_10$__String_$1_MANY$_"));
+        Assert.assertTrue(BaseGitLabApi.isValidEntityName("test_String_$1_MANY$__String_1_"));
+
+        Assert.assertFalse(BaseGitLabApi.isValidEntityName("random::entity::path::entityName"));
+        Assert.assertFalse(BaseGitLabApi.isValidEntityName("test_String_$1_10$__String_$1_*$_&"));
+        Assert.assertFalse(BaseGitLabApi.isValidEntityName("entity_name_has_other_characters_*#@"));
+    }
+
+    @Test
+    public void testIsValidEntityPath()
+    {
+        Assert.assertTrue(BaseGitLabApi.isValidEntityPath("random::entity::path"));
+        Assert.assertTrue(BaseGitLabApi.isValidEntityPath("model::test::function::test_String_$1_10$__String_MANY_"));
+        Assert.assertTrue(BaseGitLabApi.isValidEntityPath("model::test::function::test_String_$1_MANY$__String_1_"));
+
+        Assert.assertFalse(BaseGitLabApi.isValidEntityPath("model"));
+        Assert.assertFalse(BaseGitLabApi.isValidEntityPath("model::"));
+        Assert.assertFalse(BaseGitLabApi.isValidEntityPath("model::*"));
+        Assert.assertFalse(BaseGitLabApi.isValidEntityPath("model::$test::$function"));
+        Assert.assertFalse(BaseGitLabApi.isValidEntityPath("meta::test::ValidClassName"));
+        Assert.assertFalse(BaseGitLabApi.isValidEntityPath("model::has::other::characters::test_String_$1_10$__String_$1_*$_&"));
+    }
+
+    @Test
+    public void testIsValidPackagePath()
+    {
+        Assert.assertTrue(BaseGitLabApi.isValidPackagePath("model"));
+        Assert.assertTrue(BaseGitLabApi.isValidPackagePath("random::entity::path"));
+
+        Assert.assertFalse(BaseGitLabApi.isValidPackagePath("model::"));
+        Assert.assertFalse(BaseGitLabApi.isValidPackagePath("model::*"));
+        Assert.assertFalse(BaseGitLabApi.isValidPackagePath("model::$test::$function"));
+        Assert.assertFalse(BaseGitLabApi.isValidPackagePath("model::test::function::test_String_$1_10$__String_MANY_"));
+    }
+
+    @Test
+    public void testIsValidPackageableElementPath()
+    {
+        Assert.assertTrue(BaseGitLabApi.isValidPackageableElementPath("model"));
+        Assert.assertTrue(BaseGitLabApi.isValidPackageableElementPath("meta::entity::path"));
+        Assert.assertTrue(BaseGitLabApi.isValidPackageableElementPath("random::entity::path"));
+        Assert.assertTrue(BaseGitLabApi.isValidPackageableElementPath("model::test::function::test_String_$1_10$__String_MANY_"));
+
+        Assert.assertFalse(BaseGitLabApi.isValidPackageableElementPath("model::"));
+        Assert.assertFalse(BaseGitLabApi.isValidPackageableElementPath("model::*"));
+        Assert.assertFalse(BaseGitLabApi.isValidPackageableElementPath("model::$test::$function"));
+        Assert.assertFalse(BaseGitLabApi.isValidPackageableElementPath("model::has::other::characters::test_String_$1_10$__String_$1_*$_&"));
+    }
+
+    @Test
+    public void testIsValidClassifierPath()
+    {
+        Assert.assertTrue(BaseGitLabApi.isValidClassifierPath("meta::entity::path"));
+        Assert.assertTrue(BaseGitLabApi.isValidClassifierPath("meta::pure::metamodel::function::ConcreteFunctionDefinition"));
+        Assert.assertTrue(BaseGitLabApi.isValidClassifierPath("meta::entity::path::test_String_$1_10$__String_MANY_"));
+
+        Assert.assertFalse(BaseGitLabApi.isValidClassifierPath("meta::"));
+        Assert.assertFalse(BaseGitLabApi.isValidClassifierPath("meta::*"));
+        Assert.assertFalse(BaseGitLabApi.isValidClassifierPath("meta::$test::$function"));
+        Assert.assertFalse(BaseGitLabApi.isValidClassifierPath("meta::has::other::characters::test_String_$1_10$__String_$1_*$_&"));
+    }
+}


### PR DESCRIPTION
**1. Update Engine parser so that the function signature will be used for function.name
2. SDLC identifies the old style (use functionName as the file name) functions, then creates a new entity that has functionName as its path  
  3. Studio will create a ‘Delete’ action to delete this kind of entity above, then do a ‘Create’ operation to correct the gitlab file name**
<img width="1023" alt="Screen Shot 2022-09-22 at 2 16 03 PM" src="https://user-images.githubusercontent.com/73408381/191821666-ac322b53-96b0-4a77-920f-0b1fa145c92b.png">

depends on https://github.com/finos/legend-engine/pull/759