### PR TITLE
Add endpoint to check the project configuration of gitlab project

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/project/ProjectConfigurationApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/project/ProjectConfigurationApi.java
@@ -21,6 +21,7 @@ import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectConfigurationStatusReport;
 
 import java.util.Collections;
 import java.util.List;
@@ -165,4 +166,6 @@ public interface ProjectConfigurationApi
     {
         return Collections.emptyList();
     }
+
+    ProjectConfigurationStatusReport getProjectConfigurationStatus(String projectId);
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabApiWithFileAccess.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabApiWithFileAccess.java
@@ -120,6 +120,11 @@ abstract class GitLabApiWithFileAccess extends BaseGitLabApi
         return config;
     }
 
+    protected ProjectConfiguration getProjectConfiguration(String projectId)
+    {
+        return ProjectStructure.getProjectConfiguration(projectId, null, null, getProjectFileAccessProvider(), null, null);
+    }
+
     protected ProjectConfiguration getProjectConfiguration(String projectId, VersionId versionId)
     {
         ProjectConfiguration config = ProjectStructure.getProjectConfiguration(projectId, versionId, getProjectFileAccessProvider());

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectApi.java
@@ -85,6 +85,8 @@ public class GitLabProjectApi extends GitLabApiWithFileAccess implements Project
     private final ProjectStructureExtensionProvider projectStructureExtensionProvider;
     private final ProjectStructurePlatformExtensions projectStructurePlatformExtensions;
 
+    static final String PROJECT_CONFIGURATION_WORKSPACE_ID_PREFIX = "ProjectConfiguration_";
+
     @Inject
     public GitLabProjectApi(GitLabConfiguration gitLabConfiguration, GitLabUserContext userContext, ProjectStructureConfiguration projectStructureConfig, ProjectStructureExtensionProvider projectStructureExtensionProvider, BackgroundTaskProcessor backgroundTaskProcessor, ProjectStructurePlatformExtensions projectStructurePlatformExtensions)
     {
@@ -367,7 +369,7 @@ public class GitLabProjectApi extends GitLabApiWithFileAccess implements Project
 
         // Create a workspace for project configuration
         RepositoryApi repositoryApi = gitLabApi.getRepositoryApi();
-        String workspaceId = "ProjectConfiguration_" + getRandomIdString();
+        String workspaceId = PROJECT_CONFIGURATION_WORKSPACE_ID_PREFIX + getRandomIdString();
         WorkspaceType workspaceType = WorkspaceType.USER;
         WorkspaceAccessType workspaceAccessType = WorkspaceAccessType.WORKSPACE;
         Branch workspaceBranch;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabWorkspaceApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabWorkspaceApi.java
@@ -312,6 +312,11 @@ public class GitLabWorkspaceApi extends GitLabApiWithFileAccess implements Works
         LegendSDLCServerException.validateNonNull(workspaceId, "workspaceId may not be null");
 
         validateWorkspaceId(workspaceId);
+        if (this.getProjectConfiguration(projectId) ==  null)
+        {
+            throw new LegendSDLCServerException("Project structure has not been set up", Status.CONFLICT);
+        }
+
         GitLabProjectId gitLabProjectId = parseProjectId(projectId);
         RepositoryApi repositoryApi = getGitLabApi().getRepositoryApi();
         // Delete backup workspace with the same name if exists

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectConfigurationStatusReport.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectConfigurationStatusReport.java
@@ -1,0 +1,24 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.server.project;
+
+import java.util.List;
+
+public interface ProjectConfigurationStatusReport
+{
+    boolean isProjectConfigured();
+
+    List<String> getReviewIds();
+}

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectConfigurationResource.java
@@ -19,6 +19,7 @@ import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactTypeGenerationConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
+import org.finos.legend.sdlc.server.project.ProjectConfigurationStatusReport;
 
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -61,6 +62,17 @@ public class ProjectConfigurationResource extends BaseResource
         return executeWithLogging(
                 "getting project " + projectId + " available generations configurations",
                 () -> this.projectConfigurationApi.getProjectAvailableArtifactGenerations(projectId)
+        );
+    }
+
+    @GET
+    @Path("/projectConfigurationStatus")
+    @ApiOperation("Returns the project configuration status report")
+    public ProjectConfigurationStatusReport checkProjectConfigurationStatus(@PathParam("projectId") String projectId)
+    {
+        return executeWithLogging(
+                "checking if project " + projectId + " is configured",
+                () -> this.projectConfigurationApi.getProjectConfigurationStatus(projectId)
         );
     }
 }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryProjectConfigurationApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryProjectConfigurationApi.java
@@ -26,6 +26,7 @@ import org.finos.legend.sdlc.server.inmemory.backend.InMemoryBackend;
 import org.finos.legend.sdlc.server.inmemory.domain.api.InMemoryProject;
 import org.finos.legend.sdlc.server.inmemory.domain.api.InMemoryRevision;
 import org.finos.legend.sdlc.server.inmemory.domain.api.InMemoryVersion;
+import org.finos.legend.sdlc.server.project.ProjectConfigurationStatusReport;
 
 import java.util.List;
 import javax.inject.Inject;
@@ -167,6 +168,12 @@ public class InMemoryProjectConfigurationApi implements ProjectConfigurationApi
 
     @Override
     public ProjectStructureVersion getLatestProjectStructureVersion()
+    {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public ProjectConfigurationStatusReport getProjectConfigurationStatus(String projectId)
     {
         throw new UnsupportedOperationException("Not implemented");
     }


### PR DESCRIPTION
- [x] Create an endpoint in sdlc api/projects/{projectId}/configuration/checkProjectConfigurationStatus which returns the project configuration status of a project (Contains if the project is configured or not, and review Id of the project configuration MR)

Related to finos/legend-studio#1329