### PR TITLE
A comprehensive error handling strategy of pulling entities -- part I

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/entity/EntityAccessContext.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/entity/EntityAccessContext.java
@@ -24,7 +24,11 @@ public interface EntityAccessContext
 {
     Entity getEntity(String path);
 
+    Entity getEntity(String path, Boolean excludeInvalid);
+
     List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate);
+
+    List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate, Boolean excludeInvalid);
 
     List<String> getEntityPaths(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate);
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/entity/EntityAccessContext.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/entity/EntityAccessContext.java
@@ -24,11 +24,12 @@ public interface EntityAccessContext
 {
     Entity getEntity(String path);
 
-    Entity getEntity(String path, Boolean excludeInvalid);
+    default List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate)
+    {
+        return getEntities(entityPathPredicate, classifierPathPredicate, entityContentPredicate, false);
+    }
 
-    List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate);
-
-    List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate, Boolean excludeInvalid);
+    List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate, boolean excludeInvalid);
 
     List<String> getEntityPaths(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate);
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApi.java
@@ -736,28 +736,32 @@ public class GitLabEntityApi extends GitLabApiWithFileAccess implements EntityAp
         {
             stream = stream.filter(excludeInvalid ? epf ->
             {
+                Entity entity;
                 try
                 {
-                    return classifierPathPredicate.test(epf.getEntity().getClassifierPath());
+                    entity =  epf.getEntity();
                 }
                 catch (Exception ignore)
                 {
                     return false;
                 }
+                return classifierPathPredicate.test(entity.getClassifierPath());
             } : epf -> classifierPathPredicate.test(epf.getEntity().getClassifierPath()));
         }
         if (contentPredicate != null)
         {
             stream = stream.filter(excludeInvalid ? epf ->
             {
+                Entity entity;
                 try
                 {
-                    return contentPredicate.test(epf.getEntity().getContent());
+                    entity =  epf.getEntity();
                 }
                 catch (Exception ignore)
                 {
                     return false;
                 }
+                return contentPredicate.test(entity.getContent());
             } : epf -> contentPredicate.test(epf.getEntity().getContent()));
         }
         return stream;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceEntitiesResource.java
@@ -65,7 +65,7 @@ public class BackupWorkspaceEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in backup user workspace " + workspaceId + " for project " + projectId,
@@ -81,7 +81,7 @@ public class BackupWorkspaceEntitiesResource extends EntityAccessResource
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in backup user workspace " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceEntitiesResource.java
@@ -76,16 +76,11 @@ public class BackupWorkspaceEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the backup user workspace by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in backup user workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getBackupUserWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getBackupUserWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceEntitiesResource.java
@@ -65,7 +65,7 @@ public class BackupWorkspaceEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in backup user workspace " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceEntitiesResource.java
@@ -62,22 +62,30 @@ public class BackupWorkspaceEntitiesResource extends EntityAccessResource
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in backup user workspace " + workspaceId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getBackupUserWorkspaceEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getBackupUserWorkspaceEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the backup user workspace by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in backup user workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getBackupUserWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path)
+                () -> this.entityApi.getBackupUserWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceRevisionEntitiesResource.java
@@ -66,7 +66,7 @@ public class BackupWorkspaceRevisionEntitiesResource extends EntityAccessResourc
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId,
@@ -77,17 +77,11 @@ public class BackupWorkspaceRevisionEntitiesResource extends EntityAccessResourc
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the backup user workspace at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("revisionId") String revisionId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") String revisionId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getBackupUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getBackupUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceRevisionEntitiesResource.java
@@ -66,7 +66,7 @@ public class BackupWorkspaceRevisionEntitiesResource extends EntityAccessResourc
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId,
@@ -83,7 +83,7 @@ public class BackupWorkspaceRevisionEntitiesResource extends EntityAccessResourc
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/BackupWorkspaceRevisionEntitiesResource.java
@@ -63,22 +63,31 @@ public class BackupWorkspaceRevisionEntitiesResource extends EntityAccessResourc
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getBackupUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getBackupUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the backup user workspace at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") String revisionId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("revisionId") String revisionId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getBackupUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
+                () -> this.entityApi.getBackupUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ComparisonReviewEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ComparisonReviewEntitiesResource.java
@@ -63,11 +63,14 @@ public class ComparisonReviewEntitiesResource extends EntityAccessResource
                                               @QueryParam("stereotype")
                                               @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                               @QueryParam("taggedValue")
-                                              @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                              @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                              @QueryParam("excludeInvalid")
+                                              @DefaultValue("false")
+                                              @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting [from] entities in review " + reviewId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getReviewFromEntityAccessContext(projectId, reviewId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getReviewFromEntityAccessContext(projectId, reviewId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -87,33 +90,46 @@ public class ComparisonReviewEntitiesResource extends EntityAccessResource
                                             @QueryParam("stereotype")
                                             @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                             @QueryParam("taggedValue")
-                                            @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                            @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                            @QueryParam("excludeInvalid")
+                                            @DefaultValue("false")
+                                            @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting [to] entities in review " + reviewId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getReviewToEntityAccessContext(projectId, reviewId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getReviewToEntityAccessContext(projectId, reviewId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
     @GET
     @Path("from/entities/{entityPath}")
     @ApiOperation("Get [from] entity for a given review")
-    public Entity getReviewFromEntity(@PathParam("projectId") String projectId, @PathParam("reviewId") String reviewId, @PathParam("entityPath") String entityPath)
+    public Entity getReviewFromEntity(@PathParam("projectId") String projectId,
+                                      @PathParam("reviewId") String reviewId,
+                                      @PathParam("entityPath") String entityPath,
+                                      @QueryParam("excludeInvalid")
+                                      @DefaultValue("false")
+                                      @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting [from] entity for review " + reviewId + " of project " + projectId,
-                () -> this.entityApi.getReviewFromEntityAccessContext(projectId, reviewId).getEntity(entityPath)
+                () -> this.entityApi.getReviewFromEntityAccessContext(projectId, reviewId).getEntity(entityPath, excludeInvalid)
         );
     }
 
     @GET
     @Path("to/entities/{entityPath}")
     @ApiOperation("Get [to] entity for a given review")
-    public Entity getReviewToEntity(@PathParam("projectId") String projectId, @PathParam("reviewId") String reviewId, @PathParam("entityPath") String entityPath)
+    public Entity getReviewToEntity(@PathParam("projectId") String projectId,
+                                    @PathParam("reviewId") String reviewId,
+                                    @PathParam("entityPath") String entityPath,
+                                    @QueryParam("excludeInvalid")
+                                    @DefaultValue("false")
+                                    @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting [to] entity for review " + reviewId + " of project " + projectId,
-                () -> this.entityApi.getReviewToEntityAccessContext(projectId, reviewId).getEntity(entityPath)
+                () -> this.entityApi.getReviewToEntityAccessContext(projectId, reviewId).getEntity(entityPath, excludeInvalid)
         );
     }
 

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ComparisonReviewEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ComparisonReviewEntitiesResource.java
@@ -66,7 +66,7 @@ public class ComparisonReviewEntitiesResource extends EntityAccessResource
                                               @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                               @QueryParam("excludeInvalid")
                                               @DefaultValue("false")
-                                              @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                              @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting [from] entities in review " + reviewId + " for project " + projectId,
@@ -93,7 +93,7 @@ public class ComparisonReviewEntitiesResource extends EntityAccessResource
                                             @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                             @QueryParam("excludeInvalid")
                                             @DefaultValue("false")
-                                            @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                            @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting [to] entities in review " + reviewId + " for project " + projectId,
@@ -104,32 +104,22 @@ public class ComparisonReviewEntitiesResource extends EntityAccessResource
     @GET
     @Path("from/entities/{entityPath}")
     @ApiOperation("Get [from] entity for a given review")
-    public Entity getReviewFromEntity(@PathParam("projectId") String projectId,
-                                      @PathParam("reviewId") String reviewId,
-                                      @PathParam("entityPath") String entityPath,
-                                      @QueryParam("excludeInvalid")
-                                      @DefaultValue("false")
-                                      @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getReviewFromEntity(@PathParam("projectId") String projectId, @PathParam("reviewId") String reviewId, @PathParam("entityPath") String entityPath)
     {
         return executeWithLogging(
                 "getting [from] entity for review " + reviewId + " of project " + projectId,
-                () -> this.entityApi.getReviewFromEntityAccessContext(projectId, reviewId).getEntity(entityPath, excludeInvalid)
+                () -> this.entityApi.getReviewFromEntityAccessContext(projectId, reviewId).getEntity(entityPath)
         );
     }
 
     @GET
     @Path("to/entities/{entityPath}")
     @ApiOperation("Get [to] entity for a given review")
-    public Entity getReviewToEntity(@PathParam("projectId") String projectId,
-                                    @PathParam("reviewId") String reviewId,
-                                    @PathParam("entityPath") String entityPath,
-                                    @QueryParam("excludeInvalid")
-                                    @DefaultValue("false")
-                                    @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getReviewToEntity(@PathParam("projectId") String projectId, @PathParam("reviewId") String reviewId, @PathParam("entityPath") String entityPath)
     {
         return executeWithLogging(
                 "getting [to] entity for review " + reviewId + " of project " + projectId,
-                () -> this.entityApi.getReviewToEntityAccessContext(projectId, reviewId).getEntity(entityPath, excludeInvalid)
+                () -> this.entityApi.getReviewToEntityAccessContext(projectId, reviewId).getEntity(entityPath)
         );
     }
 

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ComparisonReviewEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ComparisonReviewEntitiesResource.java
@@ -66,7 +66,7 @@ public class ComparisonReviewEntitiesResource extends EntityAccessResource
                                               @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                               @QueryParam("excludeInvalid")
                                               @DefaultValue("false")
-                                              @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                              @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting [from] entities in review " + reviewId + " for project " + projectId,
@@ -93,7 +93,7 @@ public class ComparisonReviewEntitiesResource extends EntityAccessResource
                                             @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                             @QueryParam("excludeInvalid")
                                             @DefaultValue("false")
-                                            @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                            @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting [to] entities in review " + reviewId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceEntitiesResource.java
@@ -65,7 +65,7 @@ public class ConflictResolutionWorkspaceEntitiesResource extends EntityAccessRes
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in user workspace with conflict resolution " + workspaceId + " for project " + projectId,
@@ -81,7 +81,7 @@ public class ConflictResolutionWorkspaceEntitiesResource extends EntityAccessRes
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in user workspace with conflict resolution " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceEntitiesResource.java
@@ -62,22 +62,30 @@ public class ConflictResolutionWorkspaceEntitiesResource extends EntityAccessRes
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in user workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getUserWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getUserWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the user workspace with conflict resolution by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in user workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getUserWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId).getEntity(path)
+                () -> this.entityApi.getUserWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceEntitiesResource.java
@@ -65,7 +65,7 @@ public class ConflictResolutionWorkspaceEntitiesResource extends EntityAccessRes
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in user workspace with conflict resolution " + workspaceId + " for project " + projectId,
@@ -76,16 +76,11 @@ public class ConflictResolutionWorkspaceEntitiesResource extends EntityAccessRes
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the user workspace with conflict resolution by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in user workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getUserWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getUserWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceRevisionEntitiesResource.java
@@ -78,7 +78,11 @@ public class ConflictResolutionWorkspaceRevisionEntitiesResource extends EntityA
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the user workspace with conflict resolution at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("revisionId")
+                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                  @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceRevisionEntitiesResource.java
@@ -67,7 +67,7 @@ public class ConflictResolutionWorkspaceRevisionEntitiesResource extends EntityA
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId,
@@ -78,18 +78,11 @@ public class ConflictResolutionWorkspaceRevisionEntitiesResource extends EntityA
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the user workspace with conflict resolution at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("revisionId")
-                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getUserWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getUserWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceRevisionEntitiesResource.java
@@ -50,7 +50,8 @@ public class ConflictResolutionWorkspaceRevisionEntitiesResource extends EntityA
     @ApiOperation("Get entities of the user workspace with conflict resolution at the revision")
     public List<Entity> getAllEntities(@PathParam("projectId") String projectId,
                                        @PathParam("workspaceId") String workspaceId,
-                                       @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                       @PathParam("revisionId")
+                                       @ApiParam("Including aliases: head, latest, current, base") String revisionId,
                                        @QueryParam("classifierPath")
                                        @ApiParam("Only include entities with one of these classifier paths.") Set<String> classifierPaths,
                                        @QueryParam("package")
@@ -63,11 +64,14 @@ public class ConflictResolutionWorkspaceRevisionEntitiesResource extends EntityA
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getUserWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getUserWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -76,12 +80,16 @@ public class ConflictResolutionWorkspaceRevisionEntitiesResource extends EntityA
     @ApiOperation("Get an entity of the user workspace with conflict resolution at the revision by its path")
     public Entity getEntityByPath(@PathParam("projectId") String projectId,
                                   @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
-                                  @PathParam("path") String path)
+                                  @PathParam("revisionId")
+                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getUserWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
+                () -> this.entityApi.getUserWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ConflictResolutionWorkspaceRevisionEntitiesResource.java
@@ -67,7 +67,7 @@ public class ConflictResolutionWorkspaceRevisionEntitiesResource extends EntityA
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId,
@@ -85,7 +85,7 @@ public class ConflictResolutionWorkspaceRevisionEntitiesResource extends EntityA
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/EntityAccessResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/EntityAccessResource.java
@@ -37,7 +37,7 @@ abstract class EntityAccessResource extends BaseResource
         return entityAccessContext.getEntityPaths(entityPathPredicate, classifierPathPredicate, contentPredicate);
     }
 
-    protected List<Entity> getEntities(EntityAccessContext entityAccessContext, Set<String> classifierPaths, Set<String> packages, boolean includeSubPackages, String nameRegex, Set<String> stereotypes, Collection<String> taggedValueRegexes, Boolean excludeInvalidEntities)
+    protected List<Entity> getEntities(EntityAccessContext entityAccessContext, Set<String> classifierPaths, Set<String> packages, boolean includeSubPackages, String nameRegex, Set<String> stereotypes, Collection<String> taggedValueRegexes, boolean excludeInvalidEntities)
     {
         Predicate<String> entityPathPredicate = getEntityPathPredicate(packages, includeSubPackages, nameRegex);
         Predicate<String> classifierPathPredicate = getClassifierPathPredicate(classifierPaths);

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/EntityAccessResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/EntityAccessResource.java
@@ -37,12 +37,12 @@ abstract class EntityAccessResource extends BaseResource
         return entityAccessContext.getEntityPaths(entityPathPredicate, classifierPathPredicate, contentPredicate);
     }
 
-    protected List<Entity> getEntities(EntityAccessContext entityAccessContext, Set<String> classifierPaths, Set<String> packages, boolean includeSubPackages, String nameRegex, Set<String> stereotypes, Collection<String> taggedValueRegexes)
+    protected List<Entity> getEntities(EntityAccessContext entityAccessContext, Set<String> classifierPaths, Set<String> packages, boolean includeSubPackages, String nameRegex, Set<String> stereotypes, Collection<String> taggedValueRegexes, Boolean excludeInvalidEntities)
     {
         Predicate<String> entityPathPredicate = getEntityPathPredicate(packages, includeSubPackages, nameRegex);
         Predicate<String> classifierPathPredicate = getClassifierPathPredicate(classifierPaths);
         Predicate<Map<String, ?>> contentPredicate = getContentPredicate(stereotypes, taggedValueRegexes);
-        return entityAccessContext.getEntities(entityPathPredicate, classifierPathPredicate, contentPredicate);
+        return entityAccessContext.getEntities(entityPathPredicate, classifierPathPredicate, contentPredicate, excludeInvalidEntities);
     }
 
     private Predicate<String> getEntityPathPredicate(Set<String> packages, boolean includeSubPackages, String nameRegex)

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceEntitiesResource.java
@@ -62,22 +62,30 @@ public class GroupBackupWorkspaceEntitiesResource extends EntityAccessResource
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in backup group workspace " + workspaceId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getBackupGroupWorkspaceEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getBackupGroupWorkspaceEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the backup group workspace by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in backup group workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getBackupGroupWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path)
+                () -> this.entityApi.getBackupGroupWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceEntitiesResource.java
@@ -65,7 +65,7 @@ public class GroupBackupWorkspaceEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in backup group workspace " + workspaceId + " for project " + projectId,
@@ -76,16 +76,11 @@ public class GroupBackupWorkspaceEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the backup group workspace by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in backup group workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getBackupGroupWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getBackupGroupWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceEntitiesResource.java
@@ -65,7 +65,7 @@ public class GroupBackupWorkspaceEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in backup group workspace " + workspaceId + " for project " + projectId,
@@ -81,7 +81,7 @@ public class GroupBackupWorkspaceEntitiesResource extends EntityAccessResource
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in backup group workspace " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceRevisionEntitiesResource.java
@@ -67,7 +67,7 @@ public class GroupBackupWorkspaceRevisionEntitiesResource extends EntityAccessRe
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of backup group workspace " + workspaceId + " for project " + projectId,
@@ -84,7 +84,7 @@ public class GroupBackupWorkspaceRevisionEntitiesResource extends EntityAccessRe
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of backup group workspace " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceRevisionEntitiesResource.java
@@ -50,7 +50,8 @@ public class GroupBackupWorkspaceRevisionEntitiesResource extends EntityAccessRe
     @ApiOperation("Get entities of the backup group workspace at the revision")
     public List<Entity> getAllEntities(@PathParam("projectId") String projectId,
                                        @PathParam("workspaceId") String workspaceId,
-                                       @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                       @PathParam("revisionId")
+                                       @ApiParam("Including aliases: head, latest, current, base") String revisionId,
                                        @QueryParam("classifierPath")
                                        @ApiParam("Only include entities with one of these classifier paths.") Set<String> classifierPaths,
                                        @QueryParam("package")
@@ -63,22 +64,31 @@ public class GroupBackupWorkspaceRevisionEntitiesResource extends EntityAccessRe
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of backup group workspace " + workspaceId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getBackupGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getBackupGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the backup group workspace at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") String revisionId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("revisionId") String revisionId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of backup group workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getBackupGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
+                () -> this.entityApi.getBackupGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupBackupWorkspaceRevisionEntitiesResource.java
@@ -67,7 +67,7 @@ public class GroupBackupWorkspaceRevisionEntitiesResource extends EntityAccessRe
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of backup group workspace " + workspaceId + " for project " + projectId,
@@ -78,17 +78,11 @@ public class GroupBackupWorkspaceRevisionEntitiesResource extends EntityAccessRe
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the backup group workspace at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("revisionId") String revisionId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") String revisionId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of backup group workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getBackupGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getBackupGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceEntitiesResource.java
@@ -62,22 +62,30 @@ public class GroupConflictResolutionWorkspaceEntitiesResource extends EntityAcce
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in group workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getGroupWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getGroupWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the group workspace with conflict resolution by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in group workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getGroupWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId).getEntity(path)
+                () -> this.entityApi.getGroupWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceEntitiesResource.java
@@ -65,7 +65,7 @@ public class GroupConflictResolutionWorkspaceEntitiesResource extends EntityAcce
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in group workspace with conflict resolution " + workspaceId + " for project " + projectId,
@@ -76,16 +76,11 @@ public class GroupConflictResolutionWorkspaceEntitiesResource extends EntityAcce
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the group workspace with conflict resolution by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in group workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getGroupWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getGroupWorkspaceWithConflictResolutionEntityAccessContext(projectId, workspaceId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceEntitiesResource.java
@@ -65,7 +65,7 @@ public class GroupConflictResolutionWorkspaceEntitiesResource extends EntityAcce
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in group workspace with conflict resolution " + workspaceId + " for project " + projectId,
@@ -81,7 +81,7 @@ public class GroupConflictResolutionWorkspaceEntitiesResource extends EntityAcce
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in group workspace with conflict resolution " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceRevisionEntitiesResource.java
@@ -67,7 +67,7 @@ public class GroupConflictResolutionWorkspaceRevisionEntitiesResource extends En
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId,
@@ -78,18 +78,11 @@ public class GroupConflictResolutionWorkspaceRevisionEntitiesResource extends En
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the group workspace with conflict resolution at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("revisionId")
-                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getGroupWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getGroupWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceRevisionEntitiesResource.java
@@ -50,7 +50,8 @@ public class GroupConflictResolutionWorkspaceRevisionEntitiesResource extends En
     @ApiOperation("Get entities of the group workspace with conflict resolution at the revision")
     public List<Entity> getAllEntities(@PathParam("projectId") String projectId,
                                        @PathParam("workspaceId") String workspaceId,
-                                       @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                       @PathParam("revisionId")
+                                       @ApiParam("Including aliases: head, latest, current, base") String revisionId,
                                        @QueryParam("classifierPath")
                                        @ApiParam("Only include entities with one of these classifier paths.") Set<String> classifierPaths,
                                        @QueryParam("package")
@@ -63,11 +64,14 @@ public class GroupConflictResolutionWorkspaceRevisionEntitiesResource extends En
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getGroupWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getGroupWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -76,12 +80,16 @@ public class GroupConflictResolutionWorkspaceRevisionEntitiesResource extends En
     @ApiOperation("Get an entity of the group workspace with conflict resolution at the revision by its path")
     public Entity getEntityByPath(@PathParam("projectId") String projectId,
                                   @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
-                                  @PathParam("path") String path)
+                                  @PathParam("revisionId")
+                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getGroupWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
+                () -> this.entityApi.getGroupWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceRevisionEntitiesResource.java
@@ -67,7 +67,7 @@ public class GroupConflictResolutionWorkspaceRevisionEntitiesResource extends En
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId,
@@ -85,7 +85,7 @@ public class GroupConflictResolutionWorkspaceRevisionEntitiesResource extends En
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupConflictResolutionWorkspaceRevisionEntitiesResource.java
@@ -78,7 +78,11 @@ public class GroupConflictResolutionWorkspaceRevisionEntitiesResource extends En
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the group workspace with conflict resolution at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("revisionId")
+                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                  @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceEntitiesResource.java
@@ -73,7 +73,7 @@ public class GroupWorkspaceEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid
     )
     {
         return execute(
@@ -114,16 +114,11 @@ public class GroupWorkspaceEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the group workspace by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in group workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getGroupWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getGroupWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path)
         );
     }
 

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceEntitiesResource.java
@@ -73,7 +73,7 @@ public class GroupWorkspaceEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid
     )
     {
         return execute(
@@ -119,7 +119,7 @@ public class GroupWorkspaceEntitiesResource extends EntityAccessResource
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in group workspace " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceEntitiesResource.java
@@ -70,12 +70,16 @@ public class GroupWorkspaceEntitiesResource extends EntityAccessResource
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid
+    )
     {
         return execute(
                 "getting entities in group workspace " + workspaceId + " for project " + projectId,
                 "get entities of the group workspace",
-                () -> getEntities(this.entityApi.getGroupWorkspaceEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getGroupWorkspaceEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -110,11 +114,16 @@ public class GroupWorkspaceEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the group workspace by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in group workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getGroupWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path)
+                () -> this.entityApi.getGroupWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
         );
     }
 

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionEntitiesResource.java
@@ -50,7 +50,8 @@ public class GroupWorkspaceRevisionEntitiesResource extends EntityAccessResource
     @ApiOperation("Get entities of the group workspace at the revision")
     public List<Entity> getAllEntities(@PathParam("projectId") String projectId,
                                        @PathParam("workspaceId") String workspaceId,
-                                       @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                       @PathParam("revisionId")
+                                       @ApiParam("Including aliases: head, latest, current, base") String revisionId,
                                        @QueryParam("classifierPath")
                                        @ApiParam("Only include entities with one of these classifier paths.") Set<String> classifierPaths,
                                        @QueryParam("package")
@@ -63,11 +64,14 @@ public class GroupWorkspaceRevisionEntitiesResource extends EntityAccessResource
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of group workspace " + workspaceId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -76,12 +80,16 @@ public class GroupWorkspaceRevisionEntitiesResource extends EntityAccessResource
     @ApiOperation("Get an entity of the group workspace at the revision by its path")
     public Entity getEntityByPath(@PathParam("projectId") String projectId,
                                   @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
-                                  @PathParam("path") String path)
+                                  @PathParam("revisionId")
+                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
+                () -> this.entityApi.getGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionEntitiesResource.java
@@ -67,7 +67,7 @@ public class GroupWorkspaceRevisionEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of group workspace " + workspaceId + " for project " + projectId,
@@ -78,18 +78,11 @@ public class GroupWorkspaceRevisionEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the group workspace at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("revisionId")
-                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getGroupWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionEntitiesResource.java
@@ -78,7 +78,11 @@ public class GroupWorkspaceRevisionEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the group workspace at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("revisionId")
+                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                  @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/GroupWorkspaceRevisionEntitiesResource.java
@@ -67,7 +67,7 @@ public class GroupWorkspaceRevisionEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of group workspace " + workspaceId + " for project " + projectId,
@@ -85,7 +85,7 @@ public class GroupWorkspaceRevisionEntitiesResource extends EntityAccessResource
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectEntitiesResource.java
@@ -64,7 +64,7 @@ public class ProjectEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities for project " + projectId,
@@ -79,7 +79,7 @@ public class ProjectEntitiesResource extends EntityAccessResource
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectEntitiesResource.java
@@ -75,11 +75,7 @@ public class ProjectEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the project by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectEntitiesResource.java
@@ -61,22 +61,29 @@ public class ProjectEntitiesResource extends EntityAccessResource
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities for project " + projectId,
-                () -> getEntities(this.entityApi.getProjectEntityAccessContext(projectId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getProjectEntityAccessContext(projectId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the project by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " for project " + projectId,
-                () -> this.entityApi.getProjectEntityAccessContext(projectId).getEntity(path)
+                () -> this.entityApi.getProjectEntityAccessContext(projectId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectEntitiesResource.java
@@ -75,7 +75,11 @@ public class ProjectEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the project by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("path") String path, @QueryParam("excludeInvalid") @DefaultValue("false") @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectEntitiesResource.java
@@ -64,7 +64,7 @@ public class ProjectEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities for project " + projectId,
@@ -75,15 +75,11 @@ public class ProjectEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the project by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("path") String path, @QueryParam("excludeInvalid") @DefaultValue("false") @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " for project " + projectId,
-                () -> this.entityApi.getProjectEntityAccessContext(projectId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getProjectEntityAccessContext(projectId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectRevisionEntitiesResource.java
@@ -49,7 +49,8 @@ public class ProjectRevisionEntitiesResource extends EntityAccessResource
     @GET
     @ApiOperation("Get entities of a revision of the project")
     public List<Entity> getAllEntities(@PathParam("projectId") String projectId,
-                                       @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                       @PathParam("revisionId")
+                                       @ApiParam("Including aliases: head, latest, current, base") String revisionId,
                                        @QueryParam("classifierPath")
                                        @ApiParam("Only include entities with one of these classifier paths.") Set<String> classifierPaths,
                                        @QueryParam("package")
@@ -62,11 +63,14 @@ public class ProjectRevisionEntitiesResource extends EntityAccessResource
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities for revision " + revisionId + " of project " + projectId,
-                () -> getEntities(this.entityApi.getProjectRevisionEntityAccessContext(projectId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getProjectRevisionEntityAccessContext(projectId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -74,12 +78,16 @@ public class ProjectRevisionEntitiesResource extends EntityAccessResource
     @Path("{path}")
     @ApiOperation("Get an entity of a revision of the project by its path")
     public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
-                                  @PathParam("path") String path)
+                                  @PathParam("revisionId")
+                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " for revision " + revisionId + " of project " + projectId,
-                () -> this.entityApi.getProjectRevisionEntityAccessContext(projectId, revisionId).getEntity(path)
+                () -> this.entityApi.getProjectRevisionEntityAccessContext(projectId, revisionId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectRevisionEntitiesResource.java
@@ -66,7 +66,7 @@ public class ProjectRevisionEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities for revision " + revisionId + " of project " + projectId,
@@ -77,17 +77,11 @@ public class ProjectRevisionEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of a revision of the project by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("revisionId")
-                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " for revision " + revisionId + " of project " + projectId,
-                () -> this.entityApi.getProjectRevisionEntityAccessContext(projectId, revisionId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getProjectRevisionEntityAccessContext(projectId, revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectRevisionEntitiesResource.java
@@ -66,7 +66,7 @@ public class ProjectRevisionEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities for revision " + revisionId + " of project " + projectId,
@@ -83,7 +83,7 @@ public class ProjectRevisionEntitiesResource extends EntityAccessResource
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " for revision " + revisionId + " of project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/VersionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/VersionEntitiesResource.java
@@ -65,7 +65,7 @@ public class VersionEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in version " + versionId + " for project " + projectId,
@@ -76,16 +76,11 @@ public class VersionEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of a version by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("versionId") String versionId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("versionId") String versionId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in version " + versionId + " for project " + projectId,
-                () -> this.entityApi.getVersionEntityAccessContext(projectId, versionId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getVersionEntityAccessContext(projectId, versionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/VersionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/VersionEntitiesResource.java
@@ -65,7 +65,7 @@ public class VersionEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in version " + versionId + " for project " + projectId,
@@ -81,7 +81,7 @@ public class VersionEntitiesResource extends EntityAccessResource
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in version " + versionId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/VersionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/VersionEntitiesResource.java
@@ -62,22 +62,30 @@ public class VersionEntitiesResource extends EntityAccessResource
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in version " + versionId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getVersionEntityAccessContext(projectId, versionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getVersionEntityAccessContext(projectId, versionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of a version by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("versionId") String versionId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("versionId") String versionId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in version " + versionId + " for project " + projectId,
-                () -> this.entityApi.getVersionEntityAccessContext(projectId, versionId).getEntity(path)
+                () -> this.entityApi.getVersionEntityAccessContext(projectId, versionId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceEntitiesResource.java
@@ -73,7 +73,7 @@ public class WorkspaceEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return execute(
                 "getting entities in user workspace " + workspaceId + " for project " + projectId,
@@ -113,16 +113,11 @@ public class WorkspaceEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the workspace by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in user workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getUserWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getUserWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path)
         );
     }
 

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceEntitiesResource.java
@@ -73,7 +73,7 @@ public class WorkspaceEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return execute(
                 "getting entities in user workspace " + workspaceId + " for project " + projectId,
@@ -118,7 +118,7 @@ public class WorkspaceEntitiesResource extends EntityAccessResource
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in user workspace " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceEntitiesResource.java
@@ -70,12 +70,15 @@ public class WorkspaceEntitiesResource extends EntityAccessResource
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return execute(
                 "getting entities in user workspace " + workspaceId + " for project " + projectId,
                 "get entities of the user workspace",
-                () -> getEntities(this.entityApi.getUserWorkspaceEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getUserWorkspaceEntityAccessContext(projectId, workspaceId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -110,11 +113,16 @@ public class WorkspaceEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the workspace by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("path") String path)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId,
+                                  @PathParam("workspaceId") String workspaceId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in user workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getUserWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path)
+                () -> this.entityApi.getUserWorkspaceEntityAccessContext(projectId, workspaceId).getEntity(path, excludeInvalid)
         );
     }
 

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceRevisionEntitiesResource.java
@@ -50,7 +50,8 @@ public class WorkspaceRevisionEntitiesResource extends EntityAccessResource
     @ApiOperation("Get entities of the user workspace at the revision")
     public List<Entity> getAllEntities(@PathParam("projectId") String projectId,
                                        @PathParam("workspaceId") String workspaceId,
-                                       @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                       @PathParam("revisionId")
+                                       @ApiParam("Including aliases: head, latest, current, base") String revisionId,
                                        @QueryParam("classifierPath")
                                        @ApiParam("Only include entities with one of these classifier paths.") Set<String> classifierPaths,
                                        @QueryParam("package")
@@ -63,11 +64,14 @@ public class WorkspaceRevisionEntitiesResource extends EntityAccessResource
                                        @QueryParam("stereotype")
                                        @ApiParam("Only include entities with one of these stereotypes. The syntax is PROFILE.NAME, where PROFILE is the full path of the Profile that owns the Stereotype.") Set<String> stereotypes,
                                        @QueryParam("taggedValue")
-                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes)
+                                       @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
+                                       @QueryParam("excludeInvalid")
+                                       @DefaultValue("false")
+                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of user workspace " + workspaceId + " for project " + projectId,
-                () -> getEntities(this.entityApi.getUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntities(this.entityApi.getUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -76,12 +80,16 @@ public class WorkspaceRevisionEntitiesResource extends EntityAccessResource
     @ApiOperation("Get an entity of the user workspace at the revision by its path")
     public Entity getEntityByPath(@PathParam("projectId") String projectId,
                                   @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId,
-                                  @PathParam("path") String path)
+                                  @PathParam("revisionId")
+                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
+                                  @PathParam("path") String path,
+                                  @QueryParam("excludeInvalid")
+                                  @DefaultValue("false")
+                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of user workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
+                () -> this.entityApi.getUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceRevisionEntitiesResource.java
@@ -67,7 +67,7 @@ public class WorkspaceRevisionEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of user workspace " + workspaceId + " for project " + projectId,
@@ -78,18 +78,11 @@ public class WorkspaceRevisionEntitiesResource extends EntityAccessResource
     @GET
     @Path("{path}")
     @ApiOperation("Get an entity of the user workspace at the revision by its path")
-    public Entity getEntityByPath(@PathParam("projectId") String projectId,
-                                  @PathParam("workspaceId") String workspaceId,
-                                  @PathParam("revisionId")
-                                  @ApiParam("Including aliases: head, latest, current, base") String revisionId,
-                                  @PathParam("path") String path,
-                                  @QueryParam("excludeInvalid")
-                                  @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+    public Entity getEntityByPath(@PathParam("projectId") String projectId, @PathParam("workspaceId") String workspaceId, @PathParam("revisionId") @ApiParam("Including aliases: head, latest, current, base") String revisionId, @PathParam("path") String path)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of user workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path, excludeInvalid)
+                () -> this.entityApi.getUserWorkspaceRevisionEntityAccessContext(projectId, workspaceId, revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/WorkspaceRevisionEntitiesResource.java
@@ -67,7 +67,7 @@ public class WorkspaceRevisionEntitiesResource extends EntityAccessResource
                                        @ApiParam("Only include entities with a matching tagged value. The syntax is PROFILE.NAME/REGEX, where PROFILE is the full path of the Profile that owns the Tag, NAME is the name of the Tag, and REGEX is a regular expression to match against the value.") List<String> taggedValueRegexes,
                                        @QueryParam("excludeInvalid")
                                        @DefaultValue("false")
-                                       @ApiParam("If true, exclude invalid entities due to Engine grammar changes and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
+                                       @ApiParam("If true, exclude invalid entities and return valid entities only. If false, the endpoint will return an error if there are any invalid entities.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of user workspace " + workspaceId + " for project " + projectId,
@@ -85,7 +85,7 @@ public class WorkspaceRevisionEntitiesResource extends EntityAccessResource
                                   @PathParam("path") String path,
                                   @QueryParam("excludeInvalid")
                                   @DefaultValue("false")
-                                  @ApiParam("If true, exclude the invalid entity due to Engine grammar changes and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
+                                  @ApiParam("If true, exclude the invalid entity and return null. If false, the endpoint will return an error if there is an invalid entity.") Boolean excludeInvalid)
     {
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of user workspace " + workspaceId + " for project " + projectId,

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryEntityApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryEntityApi.java
@@ -147,13 +147,7 @@ public class InMemoryEntityApi implements EntityApi
         @Override
         public Entity getEntity(String path)
         {
-            return getEntity(path, false);
-        }
-
-        @Override
-        public Entity getEntity(String path, Boolean excludeInvalid)
-        {
-            List<Entity> matches = this.getEntities((p) -> p.equals(path), null, null, excludeInvalid);
+            List<Entity> matches = this.getEntities((p) -> p.equals(path), null, null, false);
             if (matches.size() > 1)
             {
                 throw new IllegalStateException(String.format("Found %d instead of 1 matches for entity with path %s", matches.size(), path));
@@ -166,13 +160,7 @@ public class InMemoryEntityApi implements EntityApi
         }
 
         @Override
-        public List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate)
-        {
-            return getEntities(entityPathPredicate, classifierPathPredicate, entityContentPredicate, false);
-        }
-
-        @Override
-        public List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate,  Boolean excludeInvalid)
+        public List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate,  boolean excludeInvalid)
         {
             Stream<Entity> stream = StreamSupport.stream(this.entities.spliterator(), false);
             if (entityPathPredicate != null)

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryEntityApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryEntityApi.java
@@ -160,7 +160,7 @@ public class InMemoryEntityApi implements EntityApi
         }
 
         @Override
-        public List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate,  boolean excludeInvalid)
+        public List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate, boolean excludeInvalid)
         {
             Stream<Entity> stream = StreamSupport.stream(this.entities.spliterator(), false);
             if (entityPathPredicate != null)

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryEntityApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryEntityApi.java
@@ -147,7 +147,13 @@ public class InMemoryEntityApi implements EntityApi
         @Override
         public Entity getEntity(String path)
         {
-            List<Entity> matches = this.getEntities((p) -> p.equals(path), null, null);
+            return getEntity(path, false);
+        }
+
+        @Override
+        public Entity getEntity(String path, Boolean excludeInvalid)
+        {
+            List<Entity> matches = this.getEntities((p) -> p.equals(path), null, null, excludeInvalid);
             if (matches.size() > 1)
             {
                 throw new IllegalStateException(String.format("Found %d instead of 1 matches for entity with path %s", matches.size(), path));
@@ -161,6 +167,12 @@ public class InMemoryEntityApi implements EntityApi
 
         @Override
         public List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate)
+        {
+            return getEntities(entityPathPredicate, classifierPathPredicate, entityContentPredicate, false);
+        }
+
+        @Override
+        public List<Entity> getEntities(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate,  Boolean excludeInvalid)
         {
             Stream<Entity> stream = StreamSupport.stream(this.entities.spliterator(), false);
             if (entityPathPredicate != null)
@@ -184,7 +196,7 @@ public class InMemoryEntityApi implements EntityApi
         @Override
         public List<String> getEntityPaths(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate)
         {
-            List<Entity> entities = this.getEntities(entityPathPredicate, classifierPathPredicate, entityContentPredicate);
+            List<Entity> entities = this.getEntities(entityPathPredicate, classifierPathPredicate, entityContentPredicate, false);
             return entities.stream().map(Entity::getPath).collect(Collectors.toList());
         }
     }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryEntityApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryEntityApi.java
@@ -147,7 +147,7 @@ public class InMemoryEntityApi implements EntityApi
         @Override
         public Entity getEntity(String path)
         {
-            List<Entity> matches = this.getEntities((p) -> p.equals(path), null, null, false);
+            List<Entity> matches = this.getEntities((p) -> p.equals(path), null, null);
             if (matches.size() > 1)
             {
                 throw new IllegalStateException(String.format("Found %d instead of 1 matches for entity with path %s", matches.size(), path));
@@ -184,7 +184,7 @@ public class InMemoryEntityApi implements EntityApi
         @Override
         public List<String> getEntityPaths(Predicate<String> entityPathPredicate, Predicate<String> classifierPathPredicate, Predicate<? super Map<String, ?>> entityContentPredicate)
         {
-            List<Entity> entities = this.getEntities(entityPathPredicate, classifierPathPredicate, entityContentPredicate, false);
+            List<Entity> entities = this.getEntities(entityPathPredicate, classifierPathPredicate, entityContentPredicate);
             return entities.stream().map(Entity::getPath).collect(Collectors.toList());
         }
     }


### PR DESCRIPTION
Improve endpoints for pulling entities by adding one more parameter whose default value is false to suppress errors from entity validations and only return the valid entities.
If value is true, it means that invalid entities are excluded.
If value is false, it means that endpoints will return an error if there are any invalid entities as before.

https://user-images.githubusercontent.com/73408381/193902405-4da6e9f6-f7ab-4afa-8468-9929ae18dbe6.mov




