### PR TITLE
add `sessionCookie` to test and Docker config to help with development using docker-compose

### DIFF
--- a/legend-sdlc-server/src/main/resources/docker/config/config.json
+++ b/legend-sdlc-server/src/main/resources/docker/config/config.json
@@ -1,5 +1,6 @@
 {
   "applicationName": "Legend SDLC",
+  "sessionCookie": "LEGEND_SDLC_JSESSIONID",
   "server": {
     "adminContextPath": "/admin",
     "applicationConnectors": [

--- a/legend-sdlc-server/src/test/resources/config-test.yaml
+++ b/legend-sdlc-server/src/test/resources/config-test.yaml
@@ -14,6 +14,8 @@
 
 applicationName: Legend SDLC
 
+sessionCookie: LEGEND_SDLC_JSESSIONID
+
 server:
   applicationConnectors:
     - type: http


### PR DESCRIPTION
Specifying session cookie name to help with local development (when we have multiple Legend applications)

See https://stackoverflow.com/questions/16789495/two-applications-on-the-same-server-use-the-same-jsessionid