### PR TITLE
Add `sourceWorkspace` path parameter to reviews endpoint

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/review/ReviewApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/review/ReviewApi.java
@@ -23,6 +23,7 @@ import org.finos.legend.sdlc.domain.model.review.ReviewState;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiPredicate;
 
 public interface ReviewApi
 {
@@ -46,12 +47,19 @@ public interface ReviewApi
      * @param projectId   project id
      * @param state       review state
      * @param revisionIds a set of revision IDs, with each we will get the reviews are associated
+     * @param workspaceIdAndTypePredicate workspace Id and type predicate with which review is associated
      * @param since       this time limit is interpreted based on the chosen state, for example: if only committed reviews are fetched, 'since' will concern the committed time
      * @param until       this time limit is interpreted based on the chosen state, for example: if only committed reviews are fetched, 'since' will concern the committed time
      * @param limit       maximum number of reviews to get
      * @return reviews
      */
-    List<Review> getReviews(String projectId, ReviewState state, Iterable<String> revisionIds, Instant since, Instant until, Integer limit);
+    List<Review> getReviews(String projectId, ReviewState state, Iterable<String> revisionIds, BiPredicate<String, WorkspaceType> workspaceIdAndTypePredicate, Instant since, Instant until, Integer limit);
+
+    @Deprecated
+    default List<Review> getReviews(String projectId, ReviewState state, Iterable<String> revisionIds, Instant since, Instant until, Integer limit)
+    {
+        return this.getReviews(projectId, state, revisionIds, null, since, until, limit);
+    }
 
     /**
      * Get reviews across all projects with the given state and labels.
@@ -66,18 +74,19 @@ public interface ReviewApi
      * @param assignedToMe whether to return only reviews assigned to me
      * @param authoredByMe whether to return only reviews authored by me
      * @param labels       labels to apply, return only reviews that match all the labels
+     * @param workspaceIdAndTypePredicate workspace Id and type predicate with which review is associated
      * @param state        review state
      * @param since        this time limit is interpreted based on the chosen state, for example: if only committed reviews are fetched, 'since' will concern the committed time
      * @param until        this time limit is interpreted based on the chosen state, for example: if only committed reviews are fetched, 'since' will concern the committed time
      * @param limit        maximum number of reviews to get
      * @return reviews
      */
-    List<Review> getReviews(boolean assignedToMe, boolean authoredByMe, List<String> labels, ReviewState state, Instant since, Instant until, Integer limit);
+    List<Review> getReviews(boolean assignedToMe, boolean authoredByMe, List<String> labels, BiPredicate<String, WorkspaceType> workspaceIdAndTypePredicate, ReviewState state, Instant since, Instant until, Integer limit);
 
     @Deprecated
     default List<Review> getReviews(Set<ProjectType> projectTypes, boolean assignedToMe, boolean authoredByMe, List<String> labels, ReviewState state, Instant since, Instant until, Integer limit)
     {
-        return this.getReviews(assignedToMe, authoredByMe, labels, state, since, until, limit);
+        return this.getReviews(assignedToMe, authoredByMe, labels, null, state, since, until, limit);
     }
 
     /**

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ReviewFilterResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ReviewFilterResource.java
@@ -1,0 +1,46 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.server.resources;
+
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
+
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.regex.Pattern;
+
+public class ReviewFilterResource extends BaseResource
+{
+    protected static BiPredicate<String, WorkspaceType> getWorkspaceIdAndTypePredicate(String workspaceIdRegex, Set<WorkspaceType> workspaceTypes)
+    {
+        if (workspaceIdRegex == null)
+        {
+            return ((workspaceTypes == null) || workspaceTypes.isEmpty()) ? null : (id, type) -> workspaceTypes.contains(type);
+        }
+
+        Pattern workspaceIdPattern;
+        try
+        {
+            workspaceIdPattern = Pattern.compile(workspaceIdRegex, Pattern.CASE_INSENSITIVE);
+        }
+        catch (Exception ignore)
+        {
+            workspaceIdPattern = Pattern.compile(workspaceIdRegex, Pattern.CASE_INSENSITIVE | Pattern.LITERAL);
+        }
+        Pattern finalWorkspaceIdPattern = workspaceIdPattern;
+        return ((workspaceTypes == null) || workspaceTypes.isEmpty()) ?
+                (id, type) -> finalWorkspaceIdPattern.matcher(id).find() :
+                (id, type) -> workspaceTypes.contains(type) && finalWorkspaceIdPattern.matcher(id).find();
+    }
+}

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ReviewsOnlyResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ReviewsOnlyResource.java
@@ -18,6 +18,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.ProjectType;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.review.Review;
 import org.finos.legend.sdlc.domain.model.review.ReviewState;
 import org.finos.legend.sdlc.server.domain.api.review.ReviewApi;
@@ -40,7 +41,7 @@ import java.util.Set;
 @Api("Reviews")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-public class ReviewsOnlyResource extends BaseResource
+public class ReviewsOnlyResource extends ReviewFilterResource
 {
     private final ReviewApi reviewApi;
 
@@ -60,6 +61,8 @@ public class ReviewsOnlyResource extends BaseResource
                                    @ApiParam("Only include reviews authored/created by me if true") boolean authoredByMe,
                                    @QueryParam("labels")
                                    @ApiParam("Only include reviews that match all the given labels") List<String> labels,
+                                   @QueryParam("workspaceIdRegex") @ApiParam("Include reviews with a workspace id matching this regular expression") String workspaceIdRegex,
+                                   @QueryParam("workspaceTypes") @ApiParam("Include reviews with any of the given workspace types") Set<WorkspaceType> workspaceTypes,
                                    @QueryParam("state")
                                    @ApiParam("Only include reviews with the given state") ReviewState state,
                                    @QueryParam("since")
@@ -74,6 +77,6 @@ public class ReviewsOnlyResource extends BaseResource
     {
         return executeWithLogging(
             (state == null) ? ("getting reviews for project type(s) " + projectTypes) : ("getting reviews for project type(s) " + projectTypes + " with state " + state),
-            () -> this.reviewApi.getReviews(assignedToMe, authoredByMe, labels, state, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit));
+            () -> this.reviewApi.getReviews(assignedToMe, authoredByMe, labels, this.getWorkspaceIdAndTypePredicate(workspaceIdRegex, workspaceTypes), state, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit));
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ReviewsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ReviewsResource.java
@@ -48,7 +48,7 @@ import javax.ws.rs.core.MediaType;
 @Api("Reviews")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-public class ReviewsResource extends BaseResource
+public class ReviewsResource extends ReviewFilterResource
 {
     private final ReviewApi reviewApi;
 
@@ -63,13 +63,15 @@ public class ReviewsResource extends BaseResource
     public List<Review> getReviews(@PathParam("projectId") String projectId,
                                    @QueryParam("state") @ApiParam("Only include reviews with the given state") ReviewState state,
                                    @QueryParam("revisionIds") @ApiParam("List of revision IDs that any of the reviews are associated to") Set<String> revisionIds,
+                                   @QueryParam("workspaceIdRegex") @ApiParam("Include reviews with a workspace id matching this regular expression") String workspaceIdRegex,
+                                   @QueryParam("workspaceTypes") @ApiParam("Include reviews with any of the given workspace types") Set<WorkspaceType> workspaceTypes,
                                    @QueryParam("since") @ApiParam("This time limit is interpreted based on the chosen state: for COMMITTED state `since` means committed time, for CLOSED state, it means closed time, for all other case, it means created time") StartInstant since,
                                    @QueryParam("until") @ApiParam("This time limit is interpreted based on the chosen state: for COMMITTED state `until` means committed time, for CLOSED state, it means closed time, for all other case, it means created time") EndInstant until,
                                    @QueryParam("limit") @ApiParam("If not provided or the provided value is non-positive, no filtering will be applied") Integer limit)
     {
         return executeWithLogging(
                 (state == null) ? ("getting reviews for project " + projectId) : ("getting reviews for project " + projectId + " with state " + state),
-                () -> this.reviewApi.getReviews(projectId, state, revisionIds, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.reviewApi.getReviews(projectId, state, revisionIds, this.getWorkspaceIdAndTypePredicate(workspaceIdRegex, workspaceTypes), ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryReviewApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryReviewApi.java
@@ -26,6 +26,9 @@ import org.eclipse.collections.api.factory.Lists;
 import javax.inject.Inject;
 import java.time.Instant;
 import java.util.List;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 
 public class InMemoryReviewApi implements ReviewApi
 {
@@ -47,7 +50,7 @@ public class InMemoryReviewApi implements ReviewApi
     }
     
     @Override
-    public List<Review> getReviews(String projectId, ReviewState state, Iterable<String> revisionIds, Instant since, Instant until, Integer limit)
+    public List<Review> getReviews(String projectId, ReviewState state, Iterable<String> revisionIds, BiPredicate<String, WorkspaceType> workspaceIdAndTypePredicate, Instant since, Instant until, Integer limit)
     {
         InMemoryProject inMemoryProject = this.backend.getProject(projectId);
 
@@ -55,7 +58,7 @@ public class InMemoryReviewApi implements ReviewApi
     }
 
     @Override
-    public List<Review> getReviews(boolean assignedToMe, boolean authoredByMe, List<String> labels, ReviewState state, Instant since, Instant until, Integer limit)
+    public List<Review> getReviews(boolean assignedToMe, boolean authoredByMe, List<String> labels, BiPredicate<String, WorkspaceType> workspaceIdAndTypePredicate, ReviewState state, Instant since, Instant until, Integer limit)
     {
         throw new UnsupportedOperationException("Not implemented");
     }


### PR DESCRIPTION
Add a path paramter to ​/projects​/{projectId}​/reviews which fetches the review from a sourceWorkspace