### PR TITLE
Bump apache commons text from 1.8 to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1091,7 +1091,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.8</version>
+                <version>1.10.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This is to avoid using dependency wit new discovered [vulnerability](https://www.cve.org/CVERecord?id=CVE-2022-42889).