### PR TITLE
update java Docker image to `eclipse-temurin:11.0.17_8-jdk-jammy`

### DIFF
--- a/legend-sdlc-server/Dockerfile
+++ b/legend-sdlc-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.16-bullseye
+FROM eclipse-temurin:11.0.17_8-jdk-jammy
 COPY target/legend-sdlc-server-*-shaded.jar /app/bin/
 COPY src/main/resources/docker/config /config
 CMD java -cp /app/bin/*.jar \


### PR DESCRIPTION
It seems that `openjdk` no longer publish docker images for jdk11 - https://github.com/docker-library/openjdk/issues/505
So per their recommendation, we are trying out the alternative - `eclipse-temurin`