### PR TITLE
Generate jar for Services with Enums as Parameters

### DIFF
--- a/legend-sdlc-generation-service/src/main/java/org/finos/legend/sdlc/generation/service/ServiceParamEnumClassGenerator.java
+++ b/legend-sdlc-generation-service/src/main/java/org/finos/legend/sdlc/generation/service/ServiceParamEnumClassGenerator.java
@@ -1,0 +1,118 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.generation.service;
+
+import freemarker.ext.beans.BeansWrapper;
+import freemarker.template.Configuration;
+import freemarker.template.DefaultObjectWrapper;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
+import org.finos.legend.engine.plan.platform.java.JavaSourceHelper;
+import org.finos.legend.sdlc.generation.service.ServiceExecutionClassGenerator.GeneratedJavaClass;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+import javax.lang.model.SourceVersion;
+
+public class ServiceParamEnumClassGenerator
+{
+    private final String packagePrefix;
+    private final EnumParameter enumParameter;
+
+    private ServiceParamEnumClassGenerator(String packagePrefix, EnumParameter enumParameter)
+    {
+        this.packagePrefix = packagePrefix;
+        this.enumParameter = enumParameter;
+    }
+
+    public GeneratedJavaClass generate()
+    {
+        String enumClass = enumParameter.getEnumClass();
+        String enumClassName = enumClass.substring(enumClass.lastIndexOf("::") + 2);
+        String packageName = generatePackageName(enumClass);
+        MutableMap<String, Object> dataModel = Maps.mutable.<String, Object>empty()
+                .withKeyValue("classPackage", packageName)
+                .withKeyValue("enumClassName", enumClassName)
+                .withKeyValue("validEnumValues", enumParameter.getValidEnumValues());
+
+        DefaultObjectWrapper objectWrapper = new DefaultObjectWrapper(Configuration.VERSION_2_3_30);
+        objectWrapper.setExposeFields(true);
+        objectWrapper.setExposureLevel(BeansWrapper.EXPOSE_ALL);
+        Template template = ServiceExecutionClassGenerator.loadTemplate("generation/service/ServiceParamEnumClassGenerator.ftl", "ServiceParamEnumClassGenerator");
+        try
+        {
+            StringWriter code = new StringWriter();
+            template.process(dataModel, code, objectWrapper);
+            // Use \n for all line breaks to ensure consistent behavior across environments
+            String codeString = code.toString().replaceAll("\\R", "\n");
+            return new GeneratedJavaClass(packageName + "." + enumClassName, codeString);
+        }
+        catch (TemplateException | IOException e)
+        {
+            throw new RuntimeException("Error generating execution class for enum" + enumClass, e);
+        }
+    }
+
+    public static ServiceParamEnumClassGenerator newGenerator(String packagePrefix, EnumParameter enumParam)
+    {
+        return new ServiceParamEnumClassGenerator(packagePrefix, enumParam);
+    }
+
+    private String generatePackageName(String enumClassWithPackage)
+    {
+        String enumPackage = enumClassWithPackage.substring(0, enumClassWithPackage.lastIndexOf("::"));
+        if ((enumPackage == null) || enumPackage.isEmpty())
+        {
+            throw new RuntimeException("Enum does not have a package: " + enumClassWithPackage);
+        }
+        StringBuilder builder = new StringBuilder();
+        if (this.packagePrefix != null)
+        {
+            if (!SourceVersion.isName(this.packagePrefix))
+            {
+                throw new RuntimeException("Invalid package prefix: \"" + this.packagePrefix + "\"");
+            }
+            builder.append(this.packagePrefix).append('.');
+        }
+        ArrayAdapter.adapt(enumPackage.split("::")).asLazy().collect(JavaSourceHelper::toValidJavaIdentifier).appendString(builder, ".");
+        return builder.toString();
+    }
+
+    public static class EnumParameter
+    {
+        public final String enumClass;
+        public final List<String> validEnumValues;
+
+        public EnumParameter(String enumClass, List<String> validEnumValues)
+        {
+            this.enumClass = enumClass;
+            this.validEnumValues = validEnumValues;
+        }
+
+        public String getEnumClass()
+        {
+            return this.enumClass;
+        }
+
+        public List<String> getValidEnumValues()
+        {
+            return this.validEnumValues;
+        }
+    }
+}

--- a/legend-sdlc-generation-service/src/main/resources/generation/service/ServiceParamEnumClassGenerator.ftl
+++ b/legend-sdlc-generation-service/src/main/resources/generation/service/ServiceParamEnumClassGenerator.ftl
@@ -1,0 +1,21 @@
+<#--
+Copyright 2023 Goldman Sachs
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+package ${classPackage};
+
+public enum ${enumClassName}
+{
+    ${validEnumValues?map(enumValue-> "${enumValue}")?join(",\n    ", ");", ";")}
+}

--- a/legend-sdlc-generation-service/src/test/java/org/finos/model/Country.java
+++ b/legend-sdlc-generation-service/src/test/java/org/finos/model/Country.java
@@ -1,0 +1,20 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.model;
+
+public enum Country
+{
+        AMEA, EMEA, ASIA;
+}

--- a/legend-sdlc-generation-service/src/test/java/org/finos/model/_enum/Country.java
+++ b/legend-sdlc-generation-service/src/test/java/org/finos/model/_enum/Country.java
@@ -1,0 +1,20 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.model._enum;
+
+public enum Country
+{
+       America, Europe, India;
+}

--- a/legend-sdlc-generation-service/src/test/resources/generation/model/Country.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/model/Country.generated.java
@@ -1,0 +1,8 @@
+package org.finos.model;
+
+public enum Country
+{
+    AMEA,
+    EMEA,
+    ASIA;
+}

--- a/legend-sdlc-generation-service/src/test/resources/generation/model/_enum/Country.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/model/_enum/Country.generated.java
@@ -1,0 +1,8 @@
+package org.finos.model._enum;
+
+public enum Country
+{
+    America,
+    Europe,
+    India;
+}

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalServiceWithEnumParams.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalServiceWithEnumParams.generated.java
@@ -1,0 +1,46 @@
+package org.finos.service;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
+import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
+import org.finos.legend.engine.shared.core.url.StreamProvider;
+
+import java.util.List;
+
+public class RelationalServiceWithEnumParams extends AbstractServicePlanExecutor
+{
+    public RelationalServiceWithEnumParams()
+    {
+        super("service::RelationalServiceWithEnumParams", "org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParams.json", false);
+    }
+
+    public RelationalServiceWithEnumParams(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("service::RelationalServiceWithEnumParams", "org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParams.json", storeExecutorConfigurations);
+    }
+
+    public Result execute(org.finos.model.Country cou, org.finos.model._enum.Country couName)
+    {
+        return this.execute(cou, couName, null);
+    }
+
+    public Result execute(org.finos.model.Country cou, org.finos.model._enum.Country couName, StreamProvider streamProvider)
+    {
+        return this.newExecutionBuilder(2)
+                     .withStreamProvider(streamProvider)
+                     .withParameter("cou", cou)
+                     .withParameter("couName", couName)
+                     .execute();
+    }
+
+    @Override
+    public final List<ServiceVariable> getServiceVariables()
+    {
+        return Lists.mutable.of(
+            this.newServiceVariable("cou", org.finos.model.Country.class, 0, 1),
+            this.newServiceVariable("couName", org.finos.model._enum.Country.class, 1, 1)
+        );
+    }
+}

--- a/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/model/Country.json
+++ b/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/model/Country.json
@@ -1,0 +1,19 @@
+{
+    "classifierPath": "meta::pure::metamodel::type::Enumeration",
+    "content": {
+      "_type": "Enumeration",
+      "name": "Country",
+      "package": "model",
+      "values": [
+        {
+          "value": "AMEA"
+        },
+        {
+          "value": "EMEA"
+        },
+        {
+          "value": "ASIA"
+        }
+      ]
+    }
+}

--- a/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/model/RelationalMapping.json
+++ b/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/model/RelationalMapping.json
@@ -9,6 +9,7 @@
         "mainTable": {
           "_type": "Table",
           "database": "store::MyDatabase",
+          "mainTableDb": "store::MyDatabase",
           "schema": "MAIN_SCHEMA",
           "table": "PERSON_TABLE"
         },
@@ -19,6 +20,7 @@
             "table": {
               "_type": "Table",
               "database": "store::MyDatabase",
+              "mainTableDb": "store::MyDatabase",
               "schema": "MAIN_SCHEMA",
               "table": "PERSON_TABLE"
             },
@@ -38,12 +40,12 @@
               "table": {
                 "_type": "Table",
                 "database": "store::MyDatabase",
+                "mainTableDb": "store::MyDatabase",
                 "schema": "MAIN_SCHEMA",
                 "table": "PERSON_TABLE"
               },
               "tableAlias": "PERSON_TABLE"
-            },
-            "source": "model_SourcePerson"
+            }
           },
           {
             "_type": "relationalPropertyMapping",
@@ -57,12 +59,12 @@
               "table": {
                 "_type": "Table",
                 "database": "store::MyDatabase",
+                "mainTableDb": "store::MyDatabase",
                 "schema": "MAIN_SCHEMA",
                 "table": "PERSON_TABLE"
               },
               "tableAlias": "PERSON_TABLE"
-            },
-            "source": "model_SourcePerson"
+            }
           },
           {
             "_type": "relationalPropertyMapping",
@@ -76,18 +78,123 @@
               "table": {
                 "_type": "Table",
                 "database": "store::MyDatabase",
+                "mainTableDb": "store::MyDatabase",
                 "schema": "MAIN_SCHEMA",
                 "table": "PERSON_TABLE"
               },
               "tableAlias": "PERSON_TABLE"
+            }
+          },
+          {
+            "_type": "relationalPropertyMapping",
+            "enumMappingId": "model_Country",
+            "property": {
+              "class": "model::SourcePerson",
+              "property": "country"
             },
-            "source": "model_SourcePerson"
+            "relationalOperation": {
+              "_type": "column",
+              "column": "COUNTRY",
+              "table": {
+                "_type": "Table",
+                "database": "store::MyDatabase",
+                "mainTableDb": "store::MyDatabase",
+                "schema": "MAIN_SCHEMA",
+                "table": "PERSON_TABLE"
+              },
+              "tableAlias": "PERSON_TABLE"
+            }
+          },
+          {
+            "_type": "relationalPropertyMapping",
+            "enumMappingId": "model_enum_Country",
+            "property": {
+              "class": "model::SourcePerson",
+              "property": "countryName"
+            },
+            "relationalOperation": {
+              "_type": "column",
+              "column": "COUNTRY_NAME",
+              "table": {
+                "_type": "Table",
+                "database": "store::MyDatabase",
+                "mainTableDb": "store::MyDatabase",
+                "schema": "MAIN_SCHEMA",
+                "table": "PERSON_TABLE"
+              },
+              "tableAlias": "PERSON_TABLE"
+            }
           }
         ],
         "root": false
       }
     ],
-    "enumerationMappings": [],
+    "enumerationMappings": [
+      {
+        "enumValueMappings": [
+          {
+            "enumValue": "AMEA",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "AMEA"
+              }
+            ]
+          },
+          {
+            "enumValue": "EMEA",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "EMEA"
+              }
+            ]
+          },
+          {
+            "enumValue": "ASIA",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "ASIA"
+              }
+            ]
+          }
+        ],
+        "enumeration": "model::Country"
+      },
+      {
+        "enumValueMappings": [
+          {
+            "enumValue": "America",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "America"
+              }
+            ]
+          },
+          {
+            "enumValue": "Europe",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "Europe"
+              }
+            ]
+          },
+          {
+            "enumValue": "India",
+            "sourceValues": [
+              {
+                "_type": "stringSourceValue",
+                "value": "India"
+              }
+            ]
+          }
+        ],
+        "enumeration": "model::enum::Country"
+      }
+    ],
     "includedMappings": [],
     "name": "RelationalMapping",
     "package": "model",

--- a/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/model/SourcePerson.json
+++ b/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/model/SourcePerson.json
@@ -1,34 +1,50 @@
 {
-  "classifierPath": "meta::pure::metamodel::type::Class",
-  "content": {
-    "_type": "class",
-    "name": "SourcePerson",
-    "package": "model",
-    "properties": [
-      {
-        "multiplicity": {
-          "lowerBound": 1,
-          "upperBound": 1
+    "classifierPath": "meta::pure::metamodel::type::Class",
+    "content": {
+      "_type": "class",
+      "name": "SourcePerson",
+      "package": "model",
+      "properties": [
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "firstName",
+          "type": "String"
         },
-        "name": "firstName",
-        "type": "String"
-      },
-      {
-        "multiplicity": {
-          "lowerBound": 1,
-          "upperBound": 1
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "lastName",
+          "type": "String"
         },
-        "name": "lastName",
-        "type": "String"
-      },
-      {
-        "multiplicity": {
-          "lowerBound": 1,
-          "upperBound": 1
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "age",
+          "type": "Integer"
         },
-        "name": "age",
-        "type": "Integer"
-      }
-    ]
-  }
+        {
+          "multiplicity": {
+            "lowerBound": 0,
+            "upperBound": 1
+          },
+          "name": "country",
+          "type": "model::Country"
+        },
+        {
+          "multiplicity": {
+            "lowerBound": 1,
+            "upperBound": 1
+          },
+          "name": "countryName",
+          "type": "model::enum::Country"
+        }
+      ]
+    }
 }

--- a/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/model/enum/Country.json
+++ b/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/model/enum/Country.json
@@ -1,0 +1,19 @@
+{
+  "classifierPath": "meta::pure::metamodel::type::Enumeration",
+  "content": {
+    "_type": "Enumeration",
+    "name": "Country",
+    "package": "model::enum",
+    "values": [
+      {
+        "value": "America"
+      },
+      {
+        "value": "Europe"
+      },
+      {
+        "value": "India"
+      }
+    ]
+  }
+}

--- a/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParams.json
+++ b/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParams.json
@@ -1,0 +1,214 @@
+{
+  "content": {
+    "_type": "service",
+    "autoActivateUpdates": true,
+    "documentation": "",
+    "execution": {
+      "_type": "pureSingleExecution",
+      "func": {
+        "_type": "lambda",
+        "body": [
+          {
+            "_type": "func",
+            "function": "project",
+            "parameters": [
+              {
+                "_type": "func",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "filter",
+                    "parameters": [
+                      {
+                        "_type": "func",
+                        "function": "getAll",
+                        "parameters": [
+                          {
+                            "_type": "packageableElementPtr",
+                            "fullPath": "model::SourcePerson"
+                          }
+                        ]
+                      },
+                      {
+                        "_type": "lambda",
+                        "body": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "p"
+                                  }
+                                ],
+                                "property": "country"
+                              },
+                              {
+                                "_type": "var",
+                                "name": "cou"
+                              }
+                            ]
+                          }
+                        ],
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "p"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "equal",
+                        "parameters": [
+                          {
+                            "_type": "property",
+                            "parameters": [
+                              {
+                                "_type": "var",
+                                "name": "p"
+                              }
+                            ],
+                            "property": "countryName"
+                          },
+                          {
+                            "_type": "var",
+                            "name": "couName"
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "p"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "_type": "collection",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "values": [
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "x"
+                          }
+                        ],
+                        "property": "firstName"
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "x"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "_type": "collection",
+                "multiplicity": {
+                  "lowerBound": 1,
+                  "upperBound": 1
+                },
+                "values": [
+                  {
+                    "_type": "string",
+                    "value": "First Name"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "_type": "var",
+            "class": "model::Country",
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "cou"
+          },
+          {
+            "_type": "var",
+            "class": "model::enum::Country",
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "couName"
+          }
+        ]
+      },
+      "mapping": "model::RelationalMapping",
+      "runtime": {
+        "_type": "engineRuntime",
+        "connections": [
+          {
+            "store": {
+              "path": "store::MyDatabase",
+              "type": "STORE"
+            },
+            "storeConnections": [
+              {
+                "connection": {
+                  "_type": "RelationalDatabaseConnection",
+                  "authenticationStrategy": {
+                    "_type": "h2Default"
+                  },
+                  "databaseType": "H2",
+                  "datasourceSpecification": {
+                    "_type": "h2Local",
+                    "testDataSetupCsv": "MAIN_SCHEMA\nPERSON_TABLE\nID,FIRST_NAME,LAST_NAME,AGE,COUNTRY,COUNTRY_NAME\n1,Peter,Smith,22,AMEA,Europe\n2,John,Johnson,23,AMEA,America\n"
+                  },
+                  "element": "store::MyDatabase",
+                  "type": "H2"
+                },
+                "id": "connection_1"
+              }
+            ]
+          }
+        ],
+        "mappings": [
+          {
+            "path": "model::RelationalMapping",
+            "type": "MAPPING"
+          }
+        ]
+      }
+    },
+    "name": "RelationalServiceWithEnumParams",
+    "owners": [],
+    "package": "service",
+    "pattern": "/relationalService/{cou}/{couName}",
+    "test": {
+      "_type": "singleExecutionTest",
+      "asserts": [],
+      "data": ""
+    }
+  },
+  "classifierPath": "meta::legend::service::metamodel::Service"
+}

--- a/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/store/MyDatabase.json
+++ b/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/store/MyDatabase.json
@@ -44,6 +44,22 @@
                   "precision": 38,
                   "scale": 0
                 }
+              },
+              {
+                "name": "COUNTRY",
+                "nullable": true,
+                "type": {
+                  "_type": "Varchar",
+                  "size": 16777216
+                }
+              },
+              {
+                "name": "COUNTRY_NAME",
+                "nullable": true,
+                "type": {
+                  "_type": "Varchar",
+                  "size": 16777216
+                }
               }
             ],
             "name": "PERSON_TABLE",


### PR DESCRIPTION
**What type of PR is this?**
Minor Enhancement

**What does this PR do / why is it needed ?**
During java generation, enum parameters of a service must be identified and the respective enum classes must be generated. Right now only generic types are supported, extending it to user-defined enum types (limited to only the ones used as parameters to services).

**Which issue(s) this PR fixes:**
Users can't merge their changes with services having enums as parameters as the gitlab build fails saying Unknow parameter type which stops from registering the service on PROD. 

**Does this PR introduce a user-facing change?**
No