### PR TITLE
Update test to include enums and generic service parameters

### DIFF
--- a/legend-sdlc-generation-service/src/test/java/org/finos/legend/sdlc/generation/service/TestServiceExecutionClassGenerator.java
+++ b/legend-sdlc-generation-service/src/test/java/org/finos/legend/sdlc/generation/service/TestServiceExecutionClassGenerator.java
@@ -158,7 +158,7 @@ public class TestServiceExecutionClassGenerator
     {
         Class<?> cls = loadAndCompileService("org.finos", "service::RelationalServiceWithEnumParams");
         ClassLoader classLoader = cls.getClassLoader();
-        assertExecuteMethodsExist(cls, classLoader.loadClass("org.finos.model.Country"), classLoader.loadClass("org.finos.model._enum.Country"));
+        assertExecuteMethodsExist(cls, classLoader.loadClass("org.finos.model.Country"), classLoader.loadClass("org.finos.model._enum.Country"), String.class);
     }
 
     @Test

--- a/legend-sdlc-generation-service/src/test/java/org/finos/legend/sdlc/generation/service/TestServiceExecutionGenerator.java
+++ b/legend-sdlc-generation-service/src/test/java/org/finos/legend/sdlc/generation/service/TestServiceExecutionGenerator.java
@@ -191,7 +191,7 @@ public class TestServiceExecutionGenerator
         String packagePrefix = "org.finos";
         Service service = getService("service::RelationalServiceWithEnumParams");
         ClassLoader classLoader = generateAndCompile(packagePrefix, service);
-        assertExecuteMethods(classLoader, "org.finos.service.RelationalServiceWithEnumParams", classLoader.loadClass("org.finos.model.Country"), classLoader.loadClass("org.finos.model._enum.Country"));
+        assertExecuteMethods(classLoader, "org.finos.service.RelationalServiceWithEnumParams", classLoader.loadClass("org.finos.model.Country"), classLoader.loadClass("org.finos.model._enum.Country"), String.class);
     }
 
     @Test
@@ -210,20 +210,21 @@ public class TestServiceExecutionGenerator
             ServiceRunner multiParamServiceRunner = findServiceRunnerByPath("service::RelationalServiceWithEnumParams");
             assertServiceVariables(multiParamServiceRunner,
                     new ServiceVariable("cou", countryClass, new Multiplicity(0, 1)),
-                    new ServiceVariable("couName", countryNameClass, new Multiplicity(1, 1))
+                    new ServiceVariable("couName", countryNameClass, new Multiplicity(1, 1)),
+                    new ServiceVariable("name", String.class, new Multiplicity(1, 1))
             );
             IllegalArgumentException e1 = Assert.assertThrows(IllegalArgumentException.class, () -> multiParamServiceRunner.run(ServiceRunnerInput.newInstance()));
-            Assert.assertEquals("Unexpected number of parameters. Expected parameter size: 2, Passed parameter size: 0", e1.getMessage());
+            Assert.assertEquals("Unexpected number of parameters. Expected parameter size: 3, Passed parameter size: 0", e1.getMessage());
 
-            IllegalArgumentException e2 = Assert.assertThrows(IllegalArgumentException.class, () -> multiParamServiceRunner.run(ServiceRunnerInput.newInstance().withArgs(Arrays.asList(countryValues[0], countryValues[1], countryValues[2]))));
-            Assert.assertEquals("Unexpected number of parameters. Expected parameter size: 2, Passed parameter size: 3", e2.getMessage());
+            IllegalArgumentException e2 = Assert.assertThrows(IllegalArgumentException.class, () -> multiParamServiceRunner.run(ServiceRunnerInput.newInstance().withArgs(Arrays.asList(countryValues[0], countryValues[1]))));
+            Assert.assertEquals("Unexpected number of parameters. Expected parameter size: 3, Passed parameter size: 2", e2.getMessage());
 
-            List<Object> args1 = Arrays.asList(countryValues[0], "1");
+            List<Object> args1 = Arrays.asList(countryValues[0], "1", "John");
             IllegalArgumentException e3 = Assert.assertThrows(IllegalArgumentException.class, () -> multiParamServiceRunner.run(ServiceRunnerInput.newInstance().withArgs(args1)));
             Assert.assertEquals("Invalid provided parameter(s): [Invalid enum value 1 for model::enum::Country, valid enum values: [America, Europe, India]]", e3.getMessage());
 
-            JsonNode expected = OBJECT_MAPPER.readTree("{\"columns\":[{\"name\":\"First Name\",\"type\":\"String\"}],\"rows\":[{\"values\":[\"John\"]}]}");
-            Assert.assertEquals(expected, OBJECT_MAPPER.readTree(multiParamServiceRunner.run(ServiceRunnerInput.newInstance().withArgs(Arrays.asList(countryValues[0], countryNameValues[0])).withSerializationFormat(SerializationFormat.PURE))));
+            JsonNode expected = OBJECT_MAPPER.readTree("{\"columns\":[{\"name\":\"Last Name\",\"type\":\"String\"},{\"name\":\"Country\",\"type\":\"String\"}],\"rows\":[{\"values\":[\"Johnson\",\"America\"]},{\"values\":[\"Peterson\",\"America\"]}]}");
+            Assert.assertEquals(expected, OBJECT_MAPPER.readTree(multiParamServiceRunner.run(ServiceRunnerInput.newInstance().withArgs(Arrays.asList(countryValues[0], countryNameValues[0], "John")).withSerializationFormat(SerializationFormat.PURE))));
 
         }
     }

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalServiceWithEnumParams.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalServiceWithEnumParams.generated.java
@@ -21,17 +21,18 @@ public class RelationalServiceWithEnumParams extends AbstractServicePlanExecutor
         super("service::RelationalServiceWithEnumParams", "org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParams.json", storeExecutorConfigurations);
     }
 
-    public Result execute(org.finos.model.Country cou, org.finos.model._enum.Country couName)
+    public Result execute(org.finos.model.Country cou, org.finos.model._enum.Country couName, String name)
     {
-        return this.execute(cou, couName, null);
+        return this.execute(cou, couName, name, null);
     }
 
-    public Result execute(org.finos.model.Country cou, org.finos.model._enum.Country couName, StreamProvider streamProvider)
+    public Result execute(org.finos.model.Country cou, org.finos.model._enum.Country couName, String name, StreamProvider streamProvider)
     {
-        return this.newExecutionBuilder(2)
+        return this.newExecutionBuilder(3)
                      .withStreamProvider(streamProvider)
                      .withParameter("cou", cou)
                      .withParameter("couName", couName)
+                     .withParameter("name", name)
                      .execute();
     }
 
@@ -40,7 +41,8 @@ public class RelationalServiceWithEnumParams extends AbstractServicePlanExecutor
     {
         return Lists.mutable.of(
             this.newServiceVariable("cou", org.finos.model.Country.class, 0, 1),
-            this.newServiceVariable("couName", org.finos.model._enum.Country.class, 1, 1)
+            this.newServiceVariable("couName", org.finos.model._enum.Country.class, 1, 1),
+            this.newServiceVariable("name", String.class, 1, 1)
         );
     }
 }

--- a/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParams.json
+++ b/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParams.json
@@ -18,21 +18,21 @@
                 "parameters": [
                   {
                     "_type": "func",
-                    "function": "filter",
+                    "function": "getAll",
                     "parameters": [
                       {
-                        "_type": "func",
-                        "function": "getAll",
-                        "parameters": [
-                          {
-                            "_type": "packageableElementPtr",
-                            "fullPath": "model::SourcePerson"
-                          }
-                        ]
-                      },
+                        "_type": "packageableElementPtr",
+                        "fullPath": "model::SourcePerson"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
                       {
-                        "_type": "lambda",
-                        "body": [
+                        "_type": "func",
+                        "function": "and",
+                        "parameters": [
                           {
                             "_type": "func",
                             "function": "equal",
@@ -45,44 +45,33 @@
                                     "name": "p"
                                   }
                                 ],
-                                "property": "country"
+                                "property": "countryName"
                               },
                               {
                                 "_type": "var",
-                                "name": "cou"
+                                "name": "couName"
                               }
                             ]
-                          }
-                        ],
-                        "parameters": [
-                          {
-                            "_type": "var",
-                            "name": "p"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "_type": "lambda",
-                    "body": [
-                      {
-                        "_type": "func",
-                        "function": "equal",
-                        "parameters": [
-                          {
-                            "_type": "property",
-                            "parameters": [
-                              {
-                                "_type": "var",
-                                "name": "p"
-                              }
-                            ],
-                            "property": "countryName"
                           },
                           {
-                            "_type": "var",
-                            "name": "couName"
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "p"
+                                  }
+                                ],
+                                "property": "firstName"
+                              },
+                              {
+                                "_type": "var",
+                                "name": "name"
+                              }
+                            ]
                           }
                         ]
                       }
@@ -99,8 +88,8 @@
               {
                 "_type": "collection",
                 "multiplicity": {
-                  "lowerBound": 1,
-                  "upperBound": 1
+                  "lowerBound": 2,
+                  "upperBound": 2
                 },
                 "values": [
                   {
@@ -114,7 +103,80 @@
                             "name": "x"
                           }
                         ],
-                        "property": "firstName"
+                        "property": "lastName"
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "x"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "if",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "and",
+                            "parameters": [
+                              {
+                                "_type": "func",
+                                "function": "isNotEmpty",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "cou"
+                                  }
+                                ]
+                              },
+                              {
+                                "_type": "func",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "cou"
+                                  },
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "packageableElementPtr",
+                                        "fullPath": "model::Country"
+                                      }
+                                    ],
+                                    "property": "AMEA"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "string",
+                                "value": "America"
+                              }
+                            ],
+                            "parameters": []
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "string",
+                                "value": "India"
+                              }
+                            ],
+                            "parameters": []
+                          }
+                        ]
                       }
                     ],
                     "parameters": [
@@ -129,13 +191,17 @@
               {
                 "_type": "collection",
                 "multiplicity": {
-                  "lowerBound": 1,
-                  "upperBound": 1
+                  "lowerBound": 2,
+                  "upperBound": 2
                 },
                 "values": [
                   {
                     "_type": "string",
-                    "value": "First Name"
+                    "value": "Last Name"
+                  },
+                  {
+                    "_type": "string",
+                    "value": "Country"
                   }
                 ]
               }
@@ -160,6 +226,15 @@
               "upperBound": 1
             },
             "name": "couName"
+          },
+          {
+            "_type": "var",
+            "class": "String",
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name"
           }
         ]
       },
@@ -182,7 +257,7 @@
                   "databaseType": "H2",
                   "datasourceSpecification": {
                     "_type": "h2Local",
-                    "testDataSetupCsv": "MAIN_SCHEMA\nPERSON_TABLE\nID,FIRST_NAME,LAST_NAME,AGE,COUNTRY,COUNTRY_NAME\n1,Peter,Smith,22,AMEA,Europe\n2,John,Johnson,23,AMEA,America\n"
+                    "testDataSetupCsv": "MAIN_SCHEMA\nPERSON_TABLE\nID,FIRST_NAME,LAST_NAME,AGE,COUNTRY,COUNTRY_NAME\n1,Peter,Smith,22,AMEA,Europe\n2,John,Johnson,23,AMEA,America\n3,John,Peterson,26,AMEA,America\n"
                   },
                   "element": "store::MyDatabase",
                   "type": "H2"
@@ -203,7 +278,7 @@
     "name": "RelationalServiceWithEnumParams",
     "owners": [],
     "package": "service",
-    "pattern": "/relationalService/{cou}/{couName}",
+    "pattern": "/relationalService/{couName}/{name}",
     "test": {
       "_type": "singleExecutionTest",
       "asserts": [],


### PR DESCRIPTION
Update the testcase to a service that takes in both enums and other primitive types as parameters.