### PR TITLE
Add project metadata to PureModelContext in File Generation plugin

### DIFF
--- a/legend-sdlc-generation-file-maven-plugin/pom.xml
+++ b/legend-sdlc-generation-file-maven-plugin/pom.xml
@@ -72,6 +72,16 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-dsl-generation</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-shared-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol</artifactId>
+        </dependency>
         <!-- ENGINE-->
 
         <dependency>
@@ -107,6 +117,16 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
 
         <!-- TEST -->

--- a/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/FileGenerationMojo.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/FileGenerationMojo.java
@@ -14,6 +14,7 @@
 
 package org.finos.legend.sdlc.generation.file;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -29,12 +30,15 @@ import org.eclipse.collections.impl.utility.Iterate;
 import org.eclipse.collections.impl.utility.LazyIterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension;
+import org.finos.legend.engine.protocol.Protocol;
+import org.finos.legend.engine.protocol.pure.PureClientVersions;
 import org.finos.legend.engine.protocol.pure.v1.model.context.AlloySDLC;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.context.SDLC;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.fileGeneration.FileGenerationSpecification;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.generationSpecification.GenerationSpecification;
+import org.finos.legend.engine.shared.core.ObjectMapperFactory;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 import org.finos.legend.sdlc.generation.artifact.ArtifactGenerationFactory;
 import org.finos.legend.sdlc.generation.artifact.ArtifactGenerationResult;
@@ -44,6 +48,7 @@ import org.finos.legend.sdlc.tools.entity.EntityPaths;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -112,7 +117,7 @@ public class FileGenerationMojo extends AbstractMojo
             throw new MojoExecutionException("Error loading entities from model", e);
         }
         getLog().info("Compiling model");
-        PureModelBuilder.PureModelWithContextData pureModelWithContextData = pureModelBuilder.withSDLC(buildSDLCInfo()).build();
+        PureModelBuilder.PureModelWithContextData pureModelWithContextData = pureModelBuilder.withSDLC(buildSDLCInfo()).withProtocol(buildProtocol()).build();
         PureModelContextData pureModelContextData = pureModelWithContextData.getPureModelContextData();
         PureModel pureModel = pureModelWithContextData.getPureModel();
         long modelEnd = System.nanoTime();
@@ -294,16 +299,43 @@ public class FileGenerationMojo extends AbstractMojo
 
     private SDLC buildSDLCInfo()
     {
-        MavenProject projectToInspect = mavenProject.getParent() != null ? mavenProject.getParent() : mavenProject;
-
         AlloySDLC sdlcInfo = new AlloySDLC();
-        sdlcInfo.groupId = projectToInspect.getGroupId();
-        sdlcInfo.artifactId = projectToInspect.getArtifactId();
-        sdlcInfo.version = projectToInspect.getVersion();
+
+        MavenProject rootMavenProject = findRootMavenProject();
+        Path baseDir = rootMavenProject.getBasedir().toPath();
+
+        try (InputStream stream = Files.newInputStream(baseDir.resolve("project.json")))
+        {
+            ObjectMapper mapper = ObjectMapperFactory.getNewStandardObjectMapper();
+            ReducedProjectConfiguration projectConfiguration = mapper.readValue(stream, ReducedProjectConfiguration.class);
+
+            sdlcInfo.groupId = projectConfiguration.getGroupId();
+            sdlcInfo.artifactId = projectConfiguration.getArtifactId();
+            sdlcInfo.version = mavenProject.getVersion();
+        }
+        catch (IOException e)
+        {
+            getLog().warn("Unable to build SDLC info");
+        }
 
         return sdlcInfo;
     }
 
+    private MavenProject findRootMavenProject()
+    {
+        MavenProject currentMavenProject = mavenProject;
+        while (currentMavenProject.hasParent())
+        {
+            currentMavenProject = currentMavenProject.getParent();
+        }
+
+        return currentMavenProject;
+    }
+
+    private Protocol buildProtocol()
+    {
+        return new Protocol("pure", PureClientVersions.production);
+    }
 
     public static class PackageableElementFilter
     {

--- a/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/FileGenerationMojo.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/FileGenerationMojo.java
@@ -294,18 +294,14 @@ public class FileGenerationMojo extends AbstractMojo
 
     private SDLC buildSDLCInfo()
     {
-        MavenProject parentProject = mavenProject.getParent();
-        if (parentProject != null)
-        {
-            AlloySDLC sdlcInfo = new AlloySDLC();
-            sdlcInfo.groupId = parentProject.getGroupId();
-            sdlcInfo.artifactId = parentProject.getArtifactId();
-            sdlcInfo.version = parentProject.getVersion();
+        MavenProject projectToInspect = mavenProject.getParent() != null ? mavenProject.getParent() : mavenProject;
 
-            return sdlcInfo;
-        }
+        AlloySDLC sdlcInfo = new AlloySDLC();
+        sdlcInfo.groupId = projectToInspect.getGroupId();
+        sdlcInfo.artifactId = projectToInspect.getArtifactId();
+        sdlcInfo.version = projectToInspect.getVersion();
 
-        return null;
+        return sdlcInfo;
     }
 
 

--- a/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/FileGenerationMojo.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/FileGenerationMojo.java
@@ -315,7 +315,7 @@ public class FileGenerationMojo extends AbstractMojo
         }
         catch (IOException e)
         {
-            getLog().warn("Unable to build SDLC info");
+            getLog().warn("Unable to build SDLC info", e);
         }
 
         return sdlcInfo;

--- a/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/ReducedProjectConfiguration.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/ReducedProjectConfiguration.java
@@ -1,0 +1,82 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.generation.file;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.finos.legend.sdlc.domain.model.project.configuration.MetamodelDependency;
+import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
+import org.finos.legend.sdlc.domain.model.project.configuration.ProjectStructureVersion;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ReducedProjectConfiguration implements ProjectConfiguration
+{
+    private String projectId;
+    private String groupId;
+    private String artifactId;
+
+    private ReducedProjectConfiguration()
+    {
+    }
+
+    private ReducedProjectConfiguration(String projectId, String groupId, String artifactId)
+    {
+        this.projectId = projectId;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+    }
+
+    @Override
+    public String getProjectId()
+    {
+        return this.projectId;
+    }
+
+    @Override
+    public String getGroupId()
+    {
+        return this.groupId;
+    }
+
+    @Override
+    public String getArtifactId()
+    {
+        return this.artifactId;
+    }
+
+    @Override
+    @JsonIgnore
+    public ProjectStructureVersion getProjectStructureVersion()
+    {
+        return null;
+    }
+
+    @Override
+    @JsonIgnore
+    public List<ProjectDependency> getProjectDependencies()
+    {
+        return null;
+    }
+
+    @Override
+    @JsonIgnore
+    public List<MetamodelDependency> getMetamodelDependencies()
+    {
+        return null;
+    }
+}

--- a/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/ReducedProjectConfiguration.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/file/ReducedProjectConfiguration.java
@@ -24,7 +24,7 @@ import org.finos.legend.sdlc.domain.model.project.configuration.ProjectStructure
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ReducedProjectConfiguration implements ProjectConfiguration
+class ReducedProjectConfiguration implements ProjectConfiguration
 {
     private String projectId;
     private String groupId;

--- a/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestFileGenerationMojo.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestFileGenerationMojo.java
@@ -76,7 +76,7 @@ public class TestFileGenerationMojo
     {
         File[] emptyEntityDirs = {this.tempFolder.newFolder("empty1"), this.tempFolder.newFolder("empty2")};
         File projectDir = buildSingleModuleProject("project", "org.finos.test", "test-project", "1.0.0", emptyEntityDirs);
-
+        serializeProjectConfiguration(projectDir);
         MavenProject mavenProject = this.mojoRule.readMavenProject(projectDir);
 
         File outputDir = new File(mavenProject.getBuild().getOutputDirectory());
@@ -92,6 +92,7 @@ public class TestFileGenerationMojo
         File tempPath = this.tempFolder.getRoot();
         File[] nonExistentEntityDirectories = {new File(tempPath, "nonexistent1"), new File(tempPath, "nonexistent2")};
         File projectDir = buildSingleModuleProject("project", "org.finos.test", "test-project", "1.0.0", nonExistentEntityDirectories);
+        serializeProjectConfiguration(projectDir);
         MavenProject mavenProject = this.mojoRule.readMavenProject(projectDir);
 
         File outputDir = new File(mavenProject.getBuild().getOutputDirectory());
@@ -115,6 +116,7 @@ public class TestFileGenerationMojo
         Assert.assertEquals(13, entities.size());
         entities.forEach(e -> writeEntityToDirectory(entitiesDir.toPath(), e));
         File projectDir = buildSingleModuleProject("project", "org.finos.test", "test-project", "1.0.0", entitiesDir);
+        serializeProjectConfiguration(projectDir);
         MavenProject mavenProject = this.mojoRule.readMavenProject(projectDir);
         File outputDir = new File(mavenProject.getBuild().getOutputDirectory());
         Path generatedSourceDir = Paths.get(mavenProject.getBuild().getDirectory()).resolve("classes");
@@ -136,6 +138,7 @@ public class TestFileGenerationMojo
         Assert.assertEquals(14, entities.size());
         entities.forEach(e -> writeEntityToDirectory(entitiesDir.toPath(), e));
         File projectDir = buildSingleModuleProject("project", "org.finos.test", "test-project", "1.0.0", entitiesDir);
+        serializeProjectConfiguration(projectDir);
         MavenProject mavenProject = this.mojoRule.readMavenProject(projectDir);
         Path outputDir = Paths.get(mavenProject.getBuild().getOutputDirectory());
         Path generatedSourceDir = Paths.get(mavenProject.getBuild().getDirectory()).resolve("classes");
@@ -232,6 +235,7 @@ public class TestFileGenerationMojo
         entities.forEach(e -> writeEntityToDirectory(entitySourceDirectories.toPath(), e));
         entities.forEach(e -> writeEntityToDirectory(includedDirectory.toPath(), e));
         File projectDir = buildSingleModuleProject("project", "org.finos.test", "test-project", "1.0.0", includedDirectory);
+        serializeProjectConfiguration(projectDir);
         MavenProject mavenProject = this.mojoRule.readMavenProject(projectDir);
         Path outputDir = Paths.get(mavenProject.getBuild().getOutputDirectory());
         Path generatedSourceDir = Paths.get(mavenProject.getBuild().getDirectory()).resolve("classes");
@@ -353,6 +357,14 @@ public class TestFileGenerationMojo
         try (Writer writer = Files.newBufferedWriter(projectDir.resolve("pom.xml"), StandardCharsets.UTF_8))
         {
             new MavenXpp3Writer().write(writer, mavenModel);
+        }
+    }
+
+    private void serializeProjectConfiguration(File projectDir) throws IOException
+    {
+        try (Writer writer = Files.newBufferedWriter(projectDir.toPath().resolve("project.json"), StandardCharsets.UTF_8))
+        {
+            writer.write("{ \"groupId\": \"org.finos.test\", \"artifactId\": \"test-project\" }");
         }
     }
 

--- a/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestFileGenerationMojo.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestFileGenerationMojo.java
@@ -142,7 +142,7 @@ public class TestFileGenerationMojo
         assertDirectoryEmpty(outputDir);
         executeMojo(projectDir, entitiesDir);
         Set<String> actualGeneratedSourceFiles = getFileStream(generatedSourceDir, true).map(Path::toString).collect(Collectors.toSet());
-        Assert.assertEquals(23, actualGeneratedSourceFiles.size());
+        Assert.assertEquals(26, actualGeneratedSourceFiles.size());
         // Temporary disable because of ordering issue in the Protobuf generation
         verifyDirsAreEqual(generatedSourceDir, expectedPath);
     }
@@ -238,7 +238,7 @@ public class TestFileGenerationMojo
         assertDirectoryEmpty(outputDir);
         executeMojo(projectDir, entitySourceDirectories);
         Set<String> actualGeneratedSourceFiles = getFileStream(generatedSourceDir, true).map(Path::toString).collect(Collectors.toSet());
-        Assert.assertEquals(23, actualGeneratedSourceFiles.size());
+        Assert.assertEquals(26, actualGeneratedSourceFiles.size());
     }
 
     private Model buildMavenModel(String groupId, String artifactId, String version, String packaging)

--- a/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestSdlcInfoArtifactGenerationExtension.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestSdlcInfoArtifactGenerationExtension.java
@@ -1,4 +1,4 @@
-// Copyright 2022 Goldman Sachs
+// Copyright 2023 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestSdlcInfoArtifactGenerationExtension.java
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/file/TestSdlcInfoArtifactGenerationExtension.java
@@ -1,0 +1,58 @@
+// Copyright 2022 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.generation.file;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.Artifact;
+import org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension;
+import org.finos.legend.engine.protocol.pure.v1.model.context.AlloySDLC;
+import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.type.Enumeration;
+
+import java.util.List;
+
+public class TestSdlcInfoArtifactGenerationExtension implements ArtifactGenerationExtension
+{
+    @Override
+    public String getKey()
+    {
+        return "test-sdlcinfo-generation";
+    }
+
+    @Override
+    public boolean canGenerate(PackageableElement packageableElement)
+    {
+        return packageableElement instanceof Enumeration;
+    }
+
+    @Override
+    public List<Artifact> generate(PackageableElement packageableElement, PureModel pureModel, PureModelContextData pureModelContextData, String s)
+    {
+        if (pureModelContextData.origin != null && pureModelContextData.origin.sdlcInfo != null)
+        {
+            String groupId = ((AlloySDLC) pureModelContextData.origin.sdlcInfo).groupId;
+            String artifactId = ((AlloySDLC) pureModelContextData.origin.sdlcInfo).artifactId;
+            String versionId = pureModelContextData.origin.sdlcInfo.version;
+
+            String content = "Some output for enumeration '" + packageableElement._name() + "' - SDLC Info '" + groupId + ":" + artifactId  + ":" + versionId + "'";
+            Artifact artifact = new Artifact(content, "SDLCInfo.txt", "txt");
+            return Lists.mutable.with(artifact);
+        }
+
+        return Lists.mutable.empty();
+    }
+}

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/META-INF/services/org.finos.legend.engine.language.pure.dsl.generation.extension.ArtifactGenerationExtension
@@ -1,1 +1,2 @@
 org.finos.legend.sdlc.generation.file.TestSimpleEnumArtifactGenerationExtension
+org.finos.legend.sdlc.generation.file.TestSdlcInfoArtifactGenerationExtension

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/City/test-sdlcinfo-generation/SDLCInfo.txt
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/City/test-sdlcinfo-generation/SDLCInfo.txt
@@ -1,0 +1,1 @@
+Some output for enumeration 'City' - SDLC Info 'org.finos.test:test-project:1.0.0'

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/Country/test-sdlcinfo-generation/SDLCInfo.txt
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/Country/test-sdlcinfo-generation/SDLCInfo.txt
@@ -1,0 +1,1 @@
+Some output for enumeration 'Country' - SDLC Info 'org.finos.test:test-project:1.0.0'

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/IncType/test-sdlcinfo-generation/SDLCInfo.txt
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputs/model/IncType/test-sdlcinfo-generation/SDLCInfo.txt
@@ -1,0 +1,1 @@
+Some output for enumeration 'IncType' - SDLC Info 'org.finos.test:test-project:1.0.0'

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputsNoGenerationSpecification/model/City/test-sdlcinfo-generation/SDLCInfo.txt
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputsNoGenerationSpecification/model/City/test-sdlcinfo-generation/SDLCInfo.txt
@@ -1,0 +1,1 @@
+Some output for enumeration 'City' - SDLC Info 'org.finos.test:test-project:1.0.0'

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputsNoGenerationSpecification/model/Country/test-sdlcinfo-generation/SDLCInfo.txt
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputsNoGenerationSpecification/model/Country/test-sdlcinfo-generation/SDLCInfo.txt
@@ -1,0 +1,1 @@
+Some output for enumeration 'Country' - SDLC Info 'org.finos.test:test-project:1.0.0'

--- a/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputsNoGenerationSpecification/model/IncType/test-sdlcinfo-generation/SDLCInfo.txt
+++ b/legend-sdlc-generation-file-maven-plugin/src/test/resources/org/finos/legend/sdlc/generation/file/allFormats/outputsNoGenerationSpecification/model/IncType/test-sdlcinfo-generation/SDLCInfo.txt
@@ -1,0 +1,1 @@
+Some output for enumeration 'IncType' - SDLC Info 'org.finos.test:test-project:1.0.0'

--- a/legend-sdlc-language-pure-compiler/pom.xml
+++ b/legend-sdlc-language-pure-compiler/pom.xml
@@ -42,6 +42,10 @@
         <!-- ENGINE -->
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-protocol-pure</artifactId>
         </dependency>
         <dependency>

--- a/legend-sdlc-language-pure-compiler/src/main/java/org/finos/legend/sdlc/language/pure/compiler/toPureGraph/PureModelBuilder.java
+++ b/legend-sdlc-language-pure-compiler/src/main/java/org/finos/legend/sdlc/language/pure/compiler/toPureGraph/PureModelBuilder.java
@@ -15,6 +15,7 @@
 package org.finos.legend.sdlc.language.pure.compiler.toPureGraph;
 
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
+import org.finos.legend.engine.protocol.Protocol;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.context.SDLC;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
@@ -139,6 +140,12 @@ public class PureModelBuilder
     public PureModelBuilder withSDLC(SDLC sdlc)
     {
         this.contextDataBuilder.withSDLC(sdlc);
+        return this;
+    }
+
+    public PureModelBuilder withProtocol(Protocol protocol)
+    {
+        this.contextDataBuilder.withProtocol(protocol);
         return this;
     }
 

--- a/legend-sdlc-language-pure-compiler/src/main/java/org/finos/legend/sdlc/language/pure/compiler/toPureGraph/PureModelBuilder.java
+++ b/legend-sdlc-language-pure-compiler/src/main/java/org/finos/legend/sdlc/language/pure/compiler/toPureGraph/PureModelBuilder.java
@@ -16,6 +16,7 @@ package org.finos.legend.sdlc.language.pure.compiler.toPureGraph;
 
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.engine.protocol.pure.v1.model.context.SDLC;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.shared.core.deployment.DeploymentMode;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
@@ -132,6 +133,12 @@ public class PureModelBuilder
     public PureModelBuilder withEntitiesIfPossible(Entity... entities)
     {
         addEntitiesIfPossible(entities);
+        return this;
+    }
+
+    public PureModelBuilder withSDLC(SDLC sdlc)
+    {
+        this.contextDataBuilder.withSDLC(sdlc);
         return this;
     }
 


### PR DESCRIPTION
Adds the SDLC project groupId/artifactId/version to the SDLC metadata in the built PureModelContext for downstream consumption in ArtifactGenerationExtensions.