### PR TITLE
Fixing the /authorized endpoint

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthCheckResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthCheckResource.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2023 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthCheckResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthCheckResource.java
@@ -18,6 +18,7 @@ import org.finos.legend.sdlc.server.auth.Session;
 import org.finos.legend.sdlc.server.gitlab.GitLabAppInfo;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabAuthAccessException;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabAuthorizerManager;
+import org.finos.legend.sdlc.server.gitlab.auth.GitLabSession;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabUserContext;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.tools.SessionUtil;
@@ -58,7 +59,7 @@ public class GitLabAuthCheckResource extends BaseResource
         {
             Session session = SessionUtil.findSession(httpRequest);
 
-            if (session != null)
+            if (session instanceof GitLabSession)
             {
                 GitLabUserContext gitLabUserContext = new GitLabUserContext(httpRequest, httpResponse, authorizerManager, appInfo);
                 try

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthCheckResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthCheckResource.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.finos.legend.sdlc.server.gitlab.resources;
 
 import org.finos.legend.sdlc.server.auth.Session;
@@ -47,7 +61,8 @@ public class GitLabAuthCheckResource extends BaseResource
             if (session != null)
             {
                 GitLabUserContext gitLabUserContext = new GitLabUserContext(httpRequest, httpResponse, authorizerManager, appInfo);
-                try {
+                try
+                {
                     return gitLabUserContext.isUserAuthorized();
                 }
                 catch (GitLabAuthAccessException e)
@@ -55,10 +70,7 @@ public class GitLabAuthCheckResource extends BaseResource
                     getLogger().error("Access exception occurred while checking authorization", e);
                 }
             }
-
             return false;
         });
-
     }
-
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthCheckResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthCheckResource.java
@@ -1,0 +1,58 @@
+package org.finos.legend.sdlc.server.gitlab.resources;
+
+import org.finos.legend.sdlc.server.auth.Session;
+import org.finos.legend.sdlc.server.gitlab.GitLabAppInfo;
+import org.finos.legend.sdlc.server.gitlab.auth.GitLabAuthorizerManager;
+import org.finos.legend.sdlc.server.gitlab.auth.GitLabUserContext;
+import org.finos.legend.sdlc.server.resources.BaseResource;
+import org.finos.legend.sdlc.server.tools.SessionUtil;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/auth")
+public class GitLabAuthCheckResource extends BaseResource
+{
+
+    private final HttpServletRequest httpRequest;
+    private final HttpServletResponse httpResponse;
+    private final GitLabAuthorizerManager authorizerManager;
+    private final GitLabAppInfo appInfo;
+
+    @Inject
+    public GitLabAuthCheckResource(HttpServletRequest httpRequest, HttpServletResponse httpResponse, GitLabAuthorizerManager authorizerManager, GitLabAppInfo appInfo)
+    {
+        super();
+        this.httpRequest = httpRequest;
+        this.httpResponse = httpResponse;
+        this.authorizerManager = authorizerManager;
+        this.appInfo = appInfo;
+    }
+
+    @GET
+    @Path("authorized")
+    @Produces(MediaType.APPLICATION_JSON)
+    public boolean isAuthorized()
+    {
+        return executeWithLogging("checking authorization", () ->
+        {
+            Session session = SessionUtil.findSession(httpRequest);
+
+            if (session == null)
+            {
+                return  false;
+            } else
+            {
+                GitLabUserContext gitLabUserContext = new GitLabUserContext(httpRequest, httpResponse, authorizerManager, appInfo);
+                return gitLabUserContext.isUserAuthorized();
+            }
+        });
+
+    }
+
+}

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthCheckResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthCheckResource.java
@@ -2,6 +2,7 @@ package org.finos.legend.sdlc.server.gitlab.resources;
 
 import org.finos.legend.sdlc.server.auth.Session;
 import org.finos.legend.sdlc.server.gitlab.GitLabAppInfo;
+import org.finos.legend.sdlc.server.gitlab.auth.GitLabAuthAccessException;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabAuthorizerManager;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabUserContext;
 import org.finos.legend.sdlc.server.resources.BaseResource;
@@ -43,14 +44,19 @@ public class GitLabAuthCheckResource extends BaseResource
         {
             Session session = SessionUtil.findSession(httpRequest);
 
-            if (session == null)
-            {
-                return  false;
-            } else
+            if (session != null)
             {
                 GitLabUserContext gitLabUserContext = new GitLabUserContext(httpRequest, httpResponse, authorizerManager, appInfo);
-                return gitLabUserContext.isUserAuthorized();
+                try {
+                    return gitLabUserContext.isUserAuthorized();
+                }
+                catch (GitLabAuthAccessException e)
+                {
+                    getLogger().error("Access exception occurred while checking authorization", e);
+                }
             }
+
+            return false;
         });
 
     }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthResource.java
@@ -58,26 +58,26 @@ public class GitLabAuthResource extends BaseResource
         return executeWithLogging("processing auth callback", this::processAuthCallback, code, state);
     }
 
-    @GET
-    @Path("authorized")
-    @Produces(MediaType.APPLICATION_JSON)
-    public boolean isAuthorized(
-        // TO BE DEPRECATED (in Swagger 3, we can use the `deprecated` flag)
-        @QueryParam("mode") @ApiParam(hidden = true, value = "DEPRECATED - this parameter will be ignored") Set<String> modes)
-    {
-        return executeWithLogging("checking authorization", () ->
-        {
-            try
-            {
-                return this.userContext.isUserAuthorized();
-            }
-            catch (GitLabAuthAccessException e)
-            {
-                getLogger().error("Access exception occurred while checking authorization", e);
-                return false;
-            }
-        });
-    }
+//    @GET
+//    @Path("authorized")
+//    @Produces(MediaType.APPLICATION_JSON)
+//    public boolean isAuthorized(
+//        // TO BE DEPRECATED (in Swagger 3, we can use the `deprecated` flag)
+//        @QueryParam("mode") @ApiParam(hidden = true, value = "DEPRECATED - this parameter will be ignored") Set<String> modes)
+//    {
+//        return executeWithLogging("checking authorization", () ->
+//        {
+//            try
+//            {
+//                return this.userContext.isUserAuthorized();
+//            }
+//            catch (GitLabAuthAccessException e)
+//            {
+//                getLogger().error("Access exception occurred while checking authorization", e);
+//                return false;
+//            }
+//        });
+//    }
 
     @GET
     @Path("authorize")

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthResource.java
@@ -18,7 +18,6 @@ import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.server.auth.Token;
 import org.finos.legend.sdlc.server.auth.Token.TokenReader;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
-//import org.finos.legend.sdlc.server.gitlab.auth.GitLabAuthAccessException;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabUserContext;
 import org.finos.legend.sdlc.server.gitlab.tools.GitLabApiTools;
 import org.finos.legend.sdlc.server.resources.BaseResource;
@@ -57,27 +56,6 @@ public class GitLabAuthResource extends BaseResource
     {
         return executeWithLogging("processing auth callback", this::processAuthCallback, code, state);
     }
-
-//    @GET
-//    @Path("authorized")
-//    @Produces(MediaType.APPLICATION_JSON)
-//    public boolean isAuthorized(
-//        // TO BE DEPRECATED (in Swagger 3, we can use the `deprecated` flag)
-//        @QueryParam("mode") @ApiParam(hidden = true, value = "DEPRECATED - this parameter will be ignored") Set<String> modes)
-//    {
-//        return executeWithLogging("checking authorization", () ->
-//        {
-//            try
-//            {
-//                return this.userContext.isUserAuthorized();
-//            }
-//            catch (GitLabAuthAccessException e)
-//            {
-//                getLogger().error("Access exception occurred while checking authorization", e);
-//                return false;
-//            }
-//        });
-//    }
 
     @GET
     @Path("authorize")

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthResource.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2023 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,9 +60,7 @@ public class GitLabAuthResource extends BaseResource
     @GET
     @Path("authorize")
     @Produces(MediaType.TEXT_HTML)
-    public String authorize(@QueryParam("redirect_uri") @ApiParam("URI to redirect to when authorization is complete") String redirectUri,
-                            // TO BE DEPRECATED (in Swagger 3, we can use the `deprecated` flag)
-                            @QueryParam("mode") @ApiParam(hidden = true, value = "DEPRECATED - this parameter will be ignored") Set<String> modes)
+    public String authorize(@QueryParam("redirect_uri") @ApiParam("URI to redirect to when authorization is complete") String redirectUri)
     {
         return executeWithLogging("authorizing", () ->
         {
@@ -79,9 +77,7 @@ public class GitLabAuthResource extends BaseResource
     @Path("termsOfServiceAcceptance")
     @Produces(MediaType.APPLICATION_JSON)
     // NOTE: we have to return a set for backward compatibility reason
-    public Set<String> termsOfServiceAcceptance(
-        // TO BE DEPRECATED (in Swagger 3, we can use the `deprecated` flag)
-        @QueryParam("mode") @ApiParam(hidden = true, value = "DEPRECATED - this parameter will be ignored") Set<String> modes)
+    public Set<String> termsOfServiceAcceptance()
     {
         return executeWithLogging("checking acceptance of terms of service", () ->
         {

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/resources/GitLabAuthResource.java
@@ -18,7 +18,7 @@ import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.server.auth.Token;
 import org.finos.legend.sdlc.server.auth.Token.TokenReader;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
-import org.finos.legend.sdlc.server.gitlab.auth.GitLabAuthAccessException;
+//import org.finos.legend.sdlc.server.gitlab.auth.GitLabAuthAccessException;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabUserContext;
 import org.finos.legend.sdlc.server.gitlab.tools.GitLabApiTools;
 import org.finos.legend.sdlc.server.resources.BaseResource;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/guice/BaseModule.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/guice/BaseModule.java
@@ -55,6 +55,7 @@ import org.finos.legend.sdlc.server.gitlab.api.GitlabWorkflowJobApi;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabAuthorizer;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabAuthorizerManager;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabUserContext;
+import org.finos.legend.sdlc.server.gitlab.resources.GitLabAuthCheckResource;
 import org.finos.legend.sdlc.server.gitlab.resources.GitLabAuthResource;
 
 import java.util.Collections;
@@ -89,6 +90,7 @@ public class BaseModule extends AbstractBaseModule
             binder.bind(WorkflowJobApi.class).to(GitlabWorkflowJobApi.class);
             binder.bind(GitLabUserContext.class);
             binder.bind(GitLabAuthResource.class);
+            binder.bind(GitLabAuthCheckResource.class);
             binder.bind(GitLabConfiguration.class).toProvider(() -> getConfiguration().getGitLabConfiguration());
             binder.bind(GitLabAppInfo.class).toProvider(() -> GitLabAppInfo.newAppInfo(getConfiguration().getGitLabConfiguration()));
             binder.bind(GitLabAuthorizerManager.class).toProvider(() -> this.provideGitLabAuthorizerManager(getConfiguration())).in(Scopes.SINGLETON);

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/guice/UserContext.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/guice/UserContext.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2023 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/guice/UserContext.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/guice/UserContext.java
@@ -15,23 +15,18 @@
 package org.finos.legend.sdlc.server.guice;
 
 import com.google.inject.servlet.RequestScoped;
-import org.finos.legend.sdlc.server.auth.LegendSDLCWebFilter;
 import org.finos.legend.sdlc.server.auth.Session;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.finos.legend.sdlc.server.tools.SessionUtil;
 
 import javax.inject.Inject;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletRequestWrapper;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+
 
 @RequestScoped
 public class UserContext
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserContext.class);
 
     protected final HttpServletRequest httpRequest;
     protected final HttpServletResponse httpResponse;
@@ -42,7 +37,7 @@ public class UserContext
     {
         this.httpRequest = httpRequest;
         this.httpResponse = httpResponse;
-        this.session = LegendSDLCServerException.validateNonNull(findSession(httpRequest), "Invalid request");
+        this.session = LegendSDLCServerException.validateNonNull(SessionUtil.findSession(httpRequest), "Invalid request");
     }
 
     public String getCurrentUser()
@@ -55,54 +50,4 @@ public class UserContext
         return this.httpRequest;
     }
 
-    private static Session findSession(ServletRequest request)
-    {
-        Session session = findSession(request, 0);
-        if (session == null)
-        {
-            LOGGER.warn("Could not find SDLC session from request: {} (class: {})", request, request.getClass());
-        }
-        return session;
-    }
-
-    private static Session findSession(ServletRequest request, int depth)
-    {
-        Session sdlcSession = LegendSDLCWebFilter.getSessionFromServletRequestAttribute(request);
-        if (sdlcSession != null)
-        {
-            LOGGER.debug("got SDLC session from request attribute (depth {})", depth);
-            return sdlcSession;
-        }
-
-        if (request instanceof HttpServletRequest)
-        {
-            HttpServletRequest httpRequest = (HttpServletRequest) request;
-            HttpSession httpSession;
-            try
-            {
-                httpSession = httpRequest.getSession(false);
-            }
-            catch (Exception e)
-            {
-                httpSession = null;
-            }
-            if (httpSession != null)
-            {
-                sdlcSession = LegendSDLCWebFilter.getSessionFromHttpSession(httpSession);
-                if (sdlcSession != null)
-                {
-                    LOGGER.debug("got SDLC session from HTTP session (depth {})", depth);
-                    return sdlcSession;
-                }
-            }
-        }
-
-        if (request instanceof ServletRequestWrapper)
-        {
-            return findSession(((ServletRequestWrapper) request).getRequest(), depth + 1);
-        }
-
-        LOGGER.debug("Did not find session at depth {}; no more nested requests to check; request: {}; request class: {}", depth, request, request.getClass());
-        return null;
-    }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/tools/SessionUtil.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/tools/SessionUtil.java
@@ -1,4 +1,4 @@
-// Copyright 2020 Goldman Sachs
+// Copyright 2023 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/tools/SessionUtil.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/tools/SessionUtil.java
@@ -1,3 +1,17 @@
+// Copyright 2020 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package org.finos.legend.sdlc.server.tools;
 
 import org.finos.legend.sdlc.server.auth.LegendSDLCWebFilter;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/tools/SessionUtil.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/tools/SessionUtil.java
@@ -1,0 +1,68 @@
+package org.finos.legend.sdlc.server.tools;
+
+import org.finos.legend.sdlc.server.auth.LegendSDLCWebFilter;
+import org.finos.legend.sdlc.server.auth.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestWrapper;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+public class SessionUtil
+{
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SessionUtil.class);
+
+    public static Session findSession(ServletRequest request)
+    {
+        Session session = findSession(request, 0);
+        if (session == null)
+        {
+            LOGGER.warn("Could not find SDLC session from request: {} (class: {})", request, request.getClass());
+        }
+        return session;
+    }
+
+    private static Session findSession(ServletRequest request, int depth)
+    {
+        Session sdlcSession = LegendSDLCWebFilter.getSessionFromServletRequestAttribute(request);
+        if (sdlcSession != null)
+        {
+            LOGGER.debug("got SDLC session from request attribute (depth {})", depth);
+            return sdlcSession;
+        }
+
+        if (request instanceof HttpServletRequest)
+        {
+            HttpServletRequest httpRequest = (HttpServletRequest) request;
+            HttpSession httpSession;
+            try
+            {
+                httpSession = httpRequest.getSession(false);
+            }
+            catch (Exception e)
+            {
+                httpSession = null;
+            }
+            if (httpSession != null)
+            {
+                sdlcSession = LegendSDLCWebFilter.getSessionFromHttpSession(httpSession);
+                if (sdlcSession != null)
+                {
+                    LOGGER.debug("got SDLC session from HTTP session (depth {})", depth);
+                    return sdlcSession;
+                }
+            }
+        }
+
+        if (request instanceof ServletRequestWrapper)
+        {
+            return findSession(((ServletRequestWrapper) request).getRequest(), depth + 1);
+        }
+
+        LOGGER.debug("Did not find session at depth {}; no more nested requests to check; request: {}; request class: {}", depth, request, request.getClass());
+        return null;
+    }
+}

--- a/legend-sdlc-server/src/test/resources/config-sample.yaml
+++ b/legend-sdlc-server/src/test/resources/config-sample.yaml
@@ -61,6 +61,9 @@ pac4j:
         scope: openid profile api
   bypassPaths:
     - /api/info
+    - /api/server/info
+    - /api/server/platforms
+    - /api/auth/authorized
 
 gitLab:
   newProjectVisibility: public


### PR DESCRIPTION
The /authorized endpoint used to return 503 if there was no user session.

With this change it returns false as expected.