### PR TITLE
Update tests to align with MappingInclude changes in Legend-Engine

### DIFF
--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/m2m/TestMapping_full.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/m2m/TestMapping_full.json
@@ -260,6 +260,8 @@
     ],
     "includedMappings": [
       {
+        "_type": "mappingIncludeMapping",
+        "createdFromExplicitType": false,
         "includedMapping": "model::mapping::OtherMapping"
       }
     ],

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/m2m/TestMapping_reduced.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/m2m/TestMapping_reduced.json
@@ -319,6 +319,8 @@
     ],
     "includedMappings": [
       {
+        "_type": "mappingIncludeMapping",
+        "createdFromExplicitType": false,
         "includedMapping": "model::mapping::OtherMapping"
       }
     ],

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/relational/TestMapping_full.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/relational/TestMapping_full.json
@@ -231,6 +231,8 @@
     ],
     "includedMappings": [
       {
+        "_type": "mappingIncludeMapping",
+        "createdFromExplicitType": false,
         "includedMapping": "model::mapping::OtherMapping"
       }
     ],

--- a/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/relational/TestMapping_reduced.json
+++ b/legend-sdlc-protocol-pure/src/test/resources/pure-entity-serializer-test/mapping/relational/TestMapping_reduced.json
@@ -226,6 +226,8 @@
     ],
     "includedMappings": [
       {
+        "_type": "mappingIncludeMapping",
+        "createdFromExplicitType": false,
         "includedMapping": "model::mapping::OtherMapping"
       }
     ],

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <java.version.range>[11.0.10,12)</java.version.range>
 
         <!-- Legend dependency versions -->
-        <legend.engine.version>4.11.0</legend.engine.version>
+        <legend.engine.version>4.11.1</legend.engine.version>
         <legend.pure.version>4.5.1</legend.pure.version>
         <legend.shared.version>0.23.3</legend.shared.version>
 


### PR DESCRIPTION
Dataspace functionality created changes in MappingInclude protocol that need to be reflected in legend-sdlc

Depends on engine version that includes: https://github.com/finos/legend-engine/pull/1649