### PR TITLE
Avoid duplicate enum class generations

### DIFF
--- a/legend-sdlc-generation-service/src/main/java/org/finos/legend/sdlc/generation/service/ServiceExecutionGenerator.java
+++ b/legend-sdlc-generation-service/src/main/java/org/finos/legend/sdlc/generation/service/ServiceExecutionGenerator.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.StreamWriteFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
-import jdk.dynalink.StandardOperation;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;

--- a/legend-sdlc-generation-service/src/main/java/org/finos/legend/sdlc/generation/service/ServiceExecutionGenerator.java
+++ b/legend-sdlc-generation-service/src/main/java/org/finos/legend/sdlc/generation/service/ServiceExecutionGenerator.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.StreamWriteFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import jdk.dynalink.StandardOperation;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
@@ -47,6 +48,7 @@ import org.finos.legend.sdlc.tools.entity.EntityPaths;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -183,16 +185,13 @@ public class ServiceExecutionGenerator
             byte[] foundContent = Files.readAllBytes(javaClassPath);
             if (!Arrays.equals(content, foundContent))
             {
-                throw new IOException("Duplicate file path found with different content for enum: " + javaClassPath);
+                throw new FileAlreadyExistsException("Duplicate file path found with different content for enum: " + javaClassPath);
             }
         }
         else
         {
             Files.createDirectories(javaClassPath.getParent());
-            try (Writer writer = Files.newBufferedWriter(javaClassPath, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW))
-            {
-                writer.write(generatedJavaClass.getText());
-            }
+            Files.write(javaClassPath, content, StandardOpenOption.CREATE_NEW);
         }
     }
     

--- a/legend-sdlc-generation-service/src/main/java/org/finos/legend/sdlc/generation/service/ServiceExecutionGenerator.java
+++ b/legend-sdlc-generation-service/src/main/java/org/finos/legend/sdlc/generation/service/ServiceExecutionGenerator.java
@@ -184,7 +184,7 @@ public class ServiceExecutionGenerator
             byte[] foundContent = Files.readAllBytes(javaClassPath);
             if (!Arrays.equals(content, foundContent))
             {
-                throw new FileAlreadyExistsException("Duplicate file path found with different content for enum: " + javaClassPath);
+                throw new FileAlreadyExistsException(javaClassPath.toString(), null, "Duplicate file path found with different content for enum: " + generatedJavaClass.getClassName());
             }
         }
         else

--- a/legend-sdlc-generation-service/src/test/java/org/finos/legend/sdlc/generation/service/TestServiceExecutionGenerator.java
+++ b/legend-sdlc-generation-service/src/test/java/org/finos/legend/sdlc/generation/service/TestServiceExecutionGenerator.java
@@ -77,6 +77,7 @@ import java.time.temporal.Temporal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -217,9 +218,16 @@ public class TestServiceExecutionGenerator
     public void testRelationalWithEnumParams() throws Exception
     {
         String packagePrefix = "org.finos";
-        Service service = getService("service::RelationalServiceWithEnumParams");
-        ClassLoader classLoader = generateAndCompile(packagePrefix, service);
+        Service enumParamService = getService("service::RelationalServiceWithEnumParams");
+        Service reusedEnumParamService = getService("service::RelationalServiceWithEnumParamsReused");
+
+        Collection<Service> services = new HashSet<Service>();
+        services.add(enumParamService);
+        services.add(reusedEnumParamService);
+        ClassLoader classLoader = generateAndCompile(packagePrefix, services);
+
         assertExecuteMethods(classLoader, "org.finos.service.RelationalServiceWithEnumParams", classLoader.loadClass("org.finos.model.Country"), classLoader.loadClass("org.finos.model._enum.Country"), String.class);
+        assertExecuteMethods(classLoader, "org.finos.service.RelationalServiceWithEnumParamsReused", classLoader.loadClass("org.finos.model.Country"), classLoader.loadClass("org.finos.model._enum.Country"), String.class);
     }
 
     @Test

--- a/legend-sdlc-generation-service/src/test/java/org/finos/legend/sdlc/generation/service/TestServiceExecutionGenerator.java
+++ b/legend-sdlc-generation-service/src/test/java/org/finos/legend/sdlc/generation/service/TestServiceExecutionGenerator.java
@@ -77,7 +77,6 @@ import java.time.temporal.Temporal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -220,12 +219,7 @@ public class TestServiceExecutionGenerator
         String packagePrefix = "org.finos";
         Service enumParamService = getService("service::RelationalServiceWithEnumParams");
         Service reusedEnumParamService = getService("service::RelationalServiceWithEnumParamsReused");
-
-        Collection<Service> services = new HashSet<Service>();
-        services.add(enumParamService);
-        services.add(reusedEnumParamService);
-        ClassLoader classLoader = generateAndCompile(packagePrefix, services);
-
+        ClassLoader classLoader = generateAndCompile(packagePrefix, Lists.fixedSize.of(enumParamService, reusedEnumParamService));
         assertExecuteMethods(classLoader, "org.finos.service.RelationalServiceWithEnumParams", classLoader.loadClass("org.finos.model.Country"), classLoader.loadClass("org.finos.model._enum.Country"), String.class);
         assertExecuteMethods(classLoader, "org.finos.service.RelationalServiceWithEnumParamsReused", classLoader.loadClass("org.finos.model.Country"), classLoader.loadClass("org.finos.model._enum.Country"), String.class);
     }

--- a/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalServiceWithEnumParamsReused.generated.java
+++ b/legend-sdlc-generation-service/src/test/resources/generation/service/RelationalServiceWithEnumParamsReused.generated.java
@@ -1,0 +1,48 @@
+package org.finos.service;
+
+import org.eclipse.collections.api.factory.Lists;
+import org.finos.legend.engine.language.pure.dsl.service.execution.AbstractServicePlanExecutor;
+import org.finos.legend.engine.language.pure.dsl.service.execution.ServiceVariable;
+import org.finos.legend.engine.plan.execution.result.Result;
+import org.finos.legend.engine.plan.execution.stores.StoreExecutorConfiguration;
+import org.finos.legend.engine.shared.core.url.StreamProvider;
+
+import java.util.List;
+
+public class RelationalServiceWithEnumParamsReused extends AbstractServicePlanExecutor
+{
+    public RelationalServiceWithEnumParamsReused()
+    {
+        super("service::RelationalServiceWithEnumParamsReused", "org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParamsReused.json", false);
+    }
+
+    public RelationalServiceWithEnumParamsReused(StoreExecutorConfiguration... storeExecutorConfigurations)
+    {
+        super("service::RelationalServiceWithEnumParamsReused", "org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParamsReused.json", storeExecutorConfigurations);
+    }
+
+    public Result execute(org.finos.model.Country cou, org.finos.model._enum.Country couName, String name)
+    {
+        return this.execute(cou, couName, name, null);
+    }
+
+    public Result execute(org.finos.model.Country cou, org.finos.model._enum.Country couName, String name, StreamProvider streamProvider)
+    {
+        return this.newExecutionBuilder(3)
+                     .withStreamProvider(streamProvider)
+                     .withParameter("cou", cou)
+                     .withParameter("couName", couName)
+                     .withParameter("name", name)
+                     .execute();
+    }
+
+    @Override
+    public final List<ServiceVariable> getServiceVariables()
+    {
+        return Lists.mutable.of(
+            this.newServiceVariable("cou", org.finos.model.Country.class, 0, 1),
+            this.newServiceVariable("couName", org.finos.model._enum.Country.class, 1, 1),
+            this.newServiceVariable("name", String.class, 1, 1)
+        );
+    }
+}

--- a/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParamsReused.json
+++ b/legend-sdlc-generation-service/src/test/resources/org/finos/legend/sdlc/generation/service/entities/service/RelationalServiceWithEnumParamsReused.json
@@ -1,0 +1,289 @@
+{
+  "content": {
+    "_type": "service",
+    "autoActivateUpdates": true,
+    "documentation": "",
+    "execution": {
+      "_type": "pureSingleExecution",
+      "func": {
+        "_type": "lambda",
+        "body": [
+          {
+            "_type": "func",
+            "function": "project",
+            "parameters": [
+              {
+                "_type": "func",
+                "function": "filter",
+                "parameters": [
+                  {
+                    "_type": "func",
+                    "function": "getAll",
+                    "parameters": [
+                      {
+                        "_type": "packageableElementPtr",
+                        "fullPath": "model::SourcePerson"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "and",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "p"
+                                  }
+                                ],
+                                "property": "countryName"
+                              },
+                              {
+                                "_type": "var",
+                                "name": "couName"
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "func",
+                            "function": "equal",
+                            "parameters": [
+                              {
+                                "_type": "property",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "p"
+                                  }
+                                ],
+                                "property": "firstName"
+                              },
+                              {
+                                "_type": "var",
+                                "name": "name"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "p"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "_type": "collection",
+                "multiplicity": {
+                  "lowerBound": 2,
+                  "upperBound": 2
+                },
+                "values": [
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "property",
+                        "parameters": [
+                          {
+                            "_type": "var",
+                            "name": "x"
+                          }
+                        ],
+                        "property": "lastName"
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "x"
+                      }
+                    ]
+                  },
+                  {
+                    "_type": "lambda",
+                    "body": [
+                      {
+                        "_type": "func",
+                        "function": "if",
+                        "parameters": [
+                          {
+                            "_type": "func",
+                            "function": "and",
+                            "parameters": [
+                              {
+                                "_type": "func",
+                                "function": "isNotEmpty",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "cou"
+                                  }
+                                ]
+                              },
+                              {
+                                "_type": "func",
+                                "function": "equal",
+                                "parameters": [
+                                  {
+                                    "_type": "var",
+                                    "name": "cou"
+                                  },
+                                  {
+                                    "_type": "property",
+                                    "parameters": [
+                                      {
+                                        "_type": "packageableElementPtr",
+                                        "fullPath": "model::Country"
+                                      }
+                                    ],
+                                    "property": "AMEA"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "string",
+                                "value": "America"
+                              }
+                            ],
+                            "parameters": []
+                          },
+                          {
+                            "_type": "lambda",
+                            "body": [
+                              {
+                                "_type": "string",
+                                "value": "India"
+                              }
+                            ],
+                            "parameters": []
+                          }
+                        ]
+                      }
+                    ],
+                    "parameters": [
+                      {
+                        "_type": "var",
+                        "name": "x"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "_type": "collection",
+                "multiplicity": {
+                  "lowerBound": 2,
+                  "upperBound": 2
+                },
+                "values": [
+                  {
+                    "_type": "string",
+                    "value": "Last Name"
+                  },
+                  {
+                    "_type": "string",
+                    "value": "Country"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "parameters": [
+          {
+            "_type": "var",
+            "class": "model::Country",
+            "multiplicity": {
+              "lowerBound": 0,
+              "upperBound": 1
+            },
+            "name": "cou"
+          },
+          {
+            "_type": "var",
+            "class": "model::enum::Country",
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "couName"
+          },
+          {
+            "_type": "var",
+            "class": "String",
+            "multiplicity": {
+              "lowerBound": 1,
+              "upperBound": 1
+            },
+            "name": "name"
+          }
+        ]
+      },
+      "mapping": "model::RelationalMapping",
+      "runtime": {
+        "_type": "engineRuntime",
+        "connections": [
+          {
+            "store": {
+              "path": "store::MyDatabase",
+              "type": "STORE"
+            },
+            "storeConnections": [
+              {
+                "connection": {
+                  "_type": "RelationalDatabaseConnection",
+                  "authenticationStrategy": {
+                    "_type": "h2Default"
+                  },
+                  "databaseType": "H2",
+                  "datasourceSpecification": {
+                    "_type": "h2Local",
+                    "testDataSetupCsv": "MAIN_SCHEMA\nPERSON_TABLE\nID,FIRST_NAME,LAST_NAME,AGE,COUNTRY,COUNTRY_NAME\n1,Peter,Smith,22,AMEA,Europe\n2,John,Johnson,23,AMEA,America\n3,John,Peterson,26,AMEA,America\n"
+                  },
+                  "element": "store::MyDatabase",
+                  "type": "H2"
+                },
+                "id": "connection_1"
+              }
+            ]
+          }
+        ],
+        "mappings": [
+          {
+            "path": "model::RelationalMapping",
+            "type": "MAPPING"
+          }
+        ]
+      }
+    },
+    "name": "RelationalServiceWithEnumParamsReused",
+    "owners": [],
+    "package": "service",
+    "pattern": "/relationalService/{couName}/{name}",
+    "test": {
+      "_type": "singleExecutionTest",
+      "asserts": [],
+      "data": ""
+    }
+  },
+  "classifierPath": "meta::legend::service::metamodel::Service"
+}


### PR DESCRIPTION
Skip generating enum classes for service artifact if it exists already.
This is possible when we have two or more services having the same enum (with path to element) as a parameter.