### PR TITLE
Add project structure version 13

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructureV11Factory.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructureV11Factory.java
@@ -58,6 +58,9 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
 
     public static class ProjectStructureV11 extends MultiModuleMavenProjectStructure
     {
+        public static final String ENTITY_VALIDATION_TEST_FILE_PATH = "/src/test/java/org/finos/legend/sdlc/EntityValidationTest.java";
+        public static final String ENTITY_TEST_SUITE_FILE_PATH = "/src/test/java/org/finos/legend/sdlc/EntityTestSuite.java";
+
         private static final String ENTITIES_MODULE_NAME = "entities";
         private static final ImmutableList<String> ENTITY_SERIALIZERS = Lists.immutable.with("pure", "legend");
 
@@ -120,13 +123,13 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
 
         private Dependency getExtensionsCollectionDependency(String extensionName, boolean includeVersion, boolean scopeTest)
         {
-            Dependency dependency = this.getOverrideExtensionsCollectionDependency(extensionName, includeVersion, scopeTest);
+            Dependency dependency = getOverrideExtensionsCollectionDependency(extensionName, includeVersion, scopeTest);
             if (dependency == null)
             {
                 MavenCoordinates mavenCoordinates = DEFAULT_EXTENSIONS_COLLECTION.get(extensionName);
-                String groupId = mavenCoordinates.groupId;
-                String artifactId = mavenCoordinates.artifactId;
-                String version = includeVersion ? mavenCoordinates.version : null;
+                String groupId = mavenCoordinates.getGroupId();
+                String artifactId = mavenCoordinates.getArtifactId();
+                String version = includeVersion ? mavenCoordinates.getVersion() : null;
                 return scopeTest ? newMavenTestDependency(groupId, artifactId, version) : newMavenDependency(groupId, artifactId, version);
             }
             return dependency;
@@ -134,13 +137,13 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
 
         private Dependency getOverrideExtensionsCollectionDependency(String extensionName, boolean includeVersion, boolean scopeTest)
         {
-            if (this.getProjectStructureExtensions() != null && this.getProjectStructureExtensions().containsExtension(extensionName))
+            if (getProjectStructureExtensions() != null && getProjectStructureExtensions().containsExtension(extensionName))
             {
-                ProjectStructurePlatformExtensions.ExtensionsCollection extensionsCollection = this.getProjectStructureExtensions().getExtensionsCollection(extensionName);
-                ProjectStructurePlatformExtensions.Platform platform = this.getProjectStructureExtensions().getPlatform(extensionsCollection.getPlatform());
+                ProjectStructurePlatformExtensions.ExtensionsCollection extensionsCollection = getProjectStructureExtensions().getExtensionsCollection(extensionName);
+                ProjectStructurePlatformExtensions.Platform platform = getProjectStructureExtensions().getPlatform(extensionsCollection.getPlatform());
                 String groupId = platform.getGroupId();
                 String artifactId = extensionsCollection.getArtifactId();
-                String versionId = includeVersion ? this.getPlatformPropertyReference(platform.getName()) : null;
+                String versionId = includeVersion ? getPlatformPropertyReference(platform.getName()) : null;
                 return scopeTest ? newMavenTestDependency(groupId, artifactId, versionId) : newMavenDependency(groupId, artifactId, versionId);
             }
             return null;
@@ -340,13 +343,13 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
             getProjectDependenciesAsMavenDependencies(ArtifactType.versioned_entities, true).forEach(configuration::addDependency);
         }
 
-        // package private for testing
+        // public for testing
         public static String getEntityValidationTestCode()
         {
             return loadJavaTestCode(4, "EntityValidationTest");
         }
 
-        // package private for testing
+        // public for testing
         public static String getEntityTestSuiteCode()
         {
             return loadJavaTestCode(4, "EntityTestSuite");
@@ -356,35 +359,6 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
         {
             Map<String, EntitySerializer> serializers = EntitySerializers.getAvailableSerializersByName();
             return getDefaultEntitySourceDirectoriesForSerializers(projectConfiguration, ENTITIES_MODULE_NAME, ENTITY_SERIALIZERS.collectIf(serializers::containsKey, serializers::get).castToList());
-        }
-
-        private static class MavenCoordinates
-        {
-            private final String groupId;
-            private final String artifactId;
-            private final String version;
-
-            public MavenCoordinates(String groupdId, String artifactId, String version)
-            {
-                this.groupId = groupdId;
-                this.artifactId = artifactId;
-                this.version = version;
-            }
-
-            public String getArtifactId()
-            {
-                return artifactId;
-            }
-
-            public String getVersion()
-            {
-                return version;
-            }
-
-            public String getGroupId()
-            {
-                return groupId;
-            }
         }
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructureV11Factory.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructureV11Factory.java
@@ -111,7 +111,7 @@ public class ProjectStructureV11Factory extends ProjectStructureVersionFactory
             super(projectConfiguration, ENTITIES_MODULE_NAME, getEntitySourceDirectories(projectConfiguration), OTHER_MODULES.castToMap(), false, projectStructurePlatformExtensions);
             Dependency generationExtensionsCollection = getExtensionsCollectionDependency(GENERATION_EXTENSIONS_COLLECTION_KEY, true, false);
             Dependency serializerExtensionsCollection = getExtensionsCollectionDependency(SERIALIZER_EXTENSIONS_COLLECTION_KEY, true, false);
-            this.legendEntityPluginMavenHelper = new LegendEntityPluginMavenHelper(LEGEND_SDLC_GROUP_ID, "legend-sdlc-entity-maven-plugin", LEGEND_SDLC_PROPERTY_REFERENCE, Lists.immutable.with(generationExtensionsCollection, serializerExtensionsCollection).toList());
+            this.legendEntityPluginMavenHelper = new LegendEntityPluginMavenHelper(LEGEND_SDLC_GROUP_ID, "legend-sdlc-entity-maven-plugin", LEGEND_SDLC_PROPERTY_REFERENCE, generationExtensionsCollection, serializerExtensionsCollection);
             this.legendTestUtilsMavenHelper = new LegendTestUtilsMavenHelper(LEGEND_SDLC_GROUP_ID, "legend-sdlc-test-utils", LEGEND_SDLC_PROPERTY_REFERENCE);
             this.legendServiceExecutionGenerationPluginMavenHelper = new LegendServiceExecutionGenerationPluginMavenHelper(LEGEND_SDLC_GROUP_ID, "legend-sdlc-generation-service-maven-plugin", LEGEND_SDLC_PROPERTY_REFERENCE, generationExtensionsCollection);
             this.legendModelGenerationPluginMavenHelper = new LegendModelGenerationPluginMavenHelper(LEGEND_SDLC_GROUP_ID, "legend-sdlc-generation-model-maven-plugin", LEGEND_SDLC_PROPERTY_REFERENCE, generationExtensionsCollection);

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructureV12Factory.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructureV12Factory.java
@@ -111,7 +111,7 @@ public class ProjectStructureV12Factory extends ProjectStructureVersionFactory
             super(projectConfiguration, ENTITIES_MODULE_NAME, getEntitySourceDirectories(projectConfiguration), OTHER_MODULES.castToMap(), false, projectStructurePlatformExtensions);
             Dependency generationExtensionsCollection = getExtensionsCollectionDependency(GENERATION_EXTENSIONS_COLLECTION_KEY, true, false);
             Dependency serializerExtensionsCollection = getExtensionsCollectionDependency(SERIALIZER_EXTENSIONS_COLLECTION_KEY, true, false);
-            this.legendEntityPluginMavenHelper = new LegendEntityPluginMavenHelper(LEGEND_SDLC_GROUP_ID, "legend-sdlc-entity-maven-plugin", LEGEND_SDLC_PROPERTY_REFERENCE, Lists.immutable.with(generationExtensionsCollection, serializerExtensionsCollection).toList());
+            this.legendEntityPluginMavenHelper = new LegendEntityPluginMavenHelper(LEGEND_SDLC_GROUP_ID, "legend-sdlc-entity-maven-plugin", LEGEND_SDLC_PROPERTY_REFERENCE, generationExtensionsCollection, serializerExtensionsCollection);
             this.legendTestUtilsMavenHelper = new LegendTestUtilsMavenHelper(LEGEND_SDLC_GROUP_ID, "legend-sdlc-test-utils", LEGEND_SDLC_PROPERTY_REFERENCE);
             this.legendServiceExecutionGenerationPluginMavenHelper = new LegendServiceExecutionGenerationPluginMavenHelper(LEGEND_SDLC_GROUP_ID, "legend-sdlc-generation-service-maven-plugin", LEGEND_SDLC_PROPERTY_REFERENCE, generationExtensionsCollection);
             this.legendModelGenerationPluginMavenHelper = new LegendModelGenerationPluginMavenHelper(LEGEND_SDLC_GROUP_ID, "legend-sdlc-generation-model-maven-plugin", LEGEND_SDLC_PROPERTY_REFERENCE, generationExtensionsCollection);

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/AbstractLegendMavenPluginHelper.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/AbstractLegendMavenPluginHelper.java
@@ -20,7 +20,9 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
@@ -40,7 +42,17 @@ public abstract class AbstractLegendMavenPluginHelper
         this.version = version;
         this.phase = phase;
         this.goal = goal;
-        this.extensionsCollections = extensionsCollections;
+        this.extensionsCollections = Objects.requireNonNull(extensionsCollections);
+    }
+
+    protected AbstractLegendMavenPluginHelper(String groupId, String artifactId, String version, String phase, String goal, Dependency extensionsCollection)
+    {
+        this(groupId, artifactId, version, phase, goal, Collections.singletonList(Objects.requireNonNull(extensionsCollection)));
+    }
+
+    protected AbstractLegendMavenPluginHelper(String groupId, String artifactId, String version, String phase, String goal)
+    {
+        this(groupId, artifactId, version, phase, goal, Collections.emptyList());
     }
 
     public final Plugin getPlugin(MavenProjectStructure projectStructure)
@@ -74,9 +86,6 @@ public abstract class AbstractLegendMavenPluginHelper
 
     protected void addDependencies(MavenProjectStructure projectStructure, Consumer<? super Dependency> dependencyConsumer)
     {
-        if (this.extensionsCollections != null && !this.extensionsCollections.isEmpty())
-        {
-            this.extensionsCollections.forEach(dependencyConsumer);
-        }
+        this.extensionsCollections.forEach(dependencyConsumer);
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendEntityPluginMavenHelper.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendEntityPluginMavenHelper.java
@@ -20,15 +20,20 @@ import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.sdlc.serialization.EntitySerializer;
 import org.finos.legend.sdlc.server.project.ProjectStructure;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
 public class LegendEntityPluginMavenHelper extends AbstractLegendMavenPluginHelper
 {
-
     public LegendEntityPluginMavenHelper(String groupId, String artifactId, String version, List<Dependency> extensionsCollections)
     {
         super(groupId, artifactId, version, "compile", "process-entities", extensionsCollections);
+    }
+
+    public LegendEntityPluginMavenHelper(String groupId, String artifactId, String version, Dependency... extensionsCollections)
+    {
+        this(groupId, artifactId, version, Arrays.asList(extensionsCollections));
     }
 
     @Override

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendFileGenerationPluginMavenHelper.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendFileGenerationPluginMavenHelper.java
@@ -17,14 +17,13 @@ package org.finos.legend.sdlc.server.project.maven;
 import org.apache.maven.model.Dependency;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
-import java.util.Collections;
 import java.util.function.Consumer;
 
 public class LegendFileGenerationPluginMavenHelper extends AbstractLegendMavenPluginHelper
 {
-    public LegendFileGenerationPluginMavenHelper(String groupId, String artifactId, String version, Dependency extensionsGenerationCollection)
+    public LegendFileGenerationPluginMavenHelper(String groupId, String artifactId, String version, Dependency generationExtensionsCollection)
     {
-        super(groupId, artifactId, version, "generate-sources", "generate-file-generations", Collections.singletonList(extensionsGenerationCollection));
+        super(groupId, artifactId, version, "generate-sources", "generate-file-generations", generationExtensionsCollection);
     }
 
     @Override

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendJUnitTestGenerationPluginMavenHelper.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendJUnitTestGenerationPluginMavenHelper.java
@@ -1,0 +1,38 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.server.project.maven;
+
+import org.apache.maven.model.Dependency;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import java.util.function.Consumer;
+
+public class LegendJUnitTestGenerationPluginMavenHelper extends AbstractLegendMavenPluginHelper
+{
+    public LegendJUnitTestGenerationPluginMavenHelper(String groupId, String artifactId, String version, Dependency generationExtensionsCollection)
+    {
+        super(groupId, artifactId, version, "generate-test-sources", "generate-junit-tests", generationExtensionsCollection);
+    }
+
+    @Override
+    protected void configurePlugin(MavenProjectStructure projectStructure, Consumer<? super Xpp3Dom> configConsumer)
+    {
+        String groupId = projectStructure.getProjectConfiguration().getGroupId();
+        if (groupId != null)
+        {
+            configConsumer.accept(MavenPluginTools.newDom("packagePrefix", groupId));
+        }
+    }
+}

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendModelGenerationPluginMavenHelper.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendModelGenerationPluginMavenHelper.java
@@ -17,7 +17,6 @@ package org.finos.legend.sdlc.server.project.maven;
 import org.apache.maven.model.Dependency;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
-import java.util.Collections;
 import java.util.function.Consumer;
 
 public class LegendModelGenerationPluginMavenHelper extends AbstractLegendMavenPluginHelper
@@ -25,7 +24,7 @@ public class LegendModelGenerationPluginMavenHelper extends AbstractLegendMavenP
 
     public LegendModelGenerationPluginMavenHelper(String groupId, String artifactId, String version, Dependency generationExtensionsCollection)
     {
-        super(groupId, artifactId, version, "compile", "generate-model-generations", Collections.singletonList(generationExtensionsCollection));
+        super(groupId, artifactId, version, "compile", "generate-model-generations", generationExtensionsCollection);
     }
 
     @Override

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendServiceExecutionGenerationPluginMavenHelper.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendServiceExecutionGenerationPluginMavenHelper.java
@@ -21,14 +21,13 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
 
-import java.util.Collections;
 import java.util.function.Consumer;
 
 public class LegendServiceExecutionGenerationPluginMavenHelper extends AbstractLegendMavenPluginHelper
 {
     public LegendServiceExecutionGenerationPluginMavenHelper(String groupId, String artifactId, String version, Dependency generationExtensionsCollection)
     {
-        super(groupId, artifactId, version, "generate-sources", "generate-service-executions", Collections.singletonList(generationExtensionsCollection));
+        super(groupId, artifactId, version, "generate-sources", "generate-service-executions", generationExtensionsCollection);
     }
 
     public Plugin getBuildHelperPlugin(String version)

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendTestUtilsMavenHelper.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendTestUtilsMavenHelper.java
@@ -21,30 +21,45 @@ import org.eclipse.collections.api.list.ImmutableList;
 
 public class LegendTestUtilsMavenHelper
 {
-    private static final ImmutableList<String> INCLUSION_PATTERNS = Lists.immutable.with("**/Test*.java", "**/*Test.java", "**/*Tests.java", "**/*TestCase.java", "**/*TestSuite.java");
+    private static final ImmutableList<String> DEFAULT_INCLUSION_PATTERNS = Lists.immutable.with("**/Test*.java", "**/*Test.java", "**/*Tests.java", "**/*TestCase.java", "**/*TestSuite.java");
 
     private final String version;
-    private final String group_id;
-    private final String artifact_id;
+    private final String groupId;
+    private final String artifactId;
 
     public LegendTestUtilsMavenHelper(String groupId, String artifactId, String version)
     {
-        this.group_id = groupId;
-        this.artifact_id = artifactId;
+        this.groupId = groupId;
+        this.artifactId = artifactId;
         this.version = version;
     }
 
     public Dependency getDependency(boolean includeVersion)
     {
-        return MavenProjectStructure.newMavenTestDependency(group_id, artifact_id, includeVersion ? this.version : null);
+        return MavenProjectStructure.newMavenTestDependency(this.groupId, this.artifactId, includeVersion ? this.version : null);
     }
 
     public Plugin getMavenSurefirePlugin(boolean useSystemClassLoader)
     {
-        Plugin plugin = MavenPluginTools.newPlugin(null, "maven-surefire-plugin", null);
-        MavenPluginTools.setConfiguration(plugin,
-                MavenPluginTools.newDom("includes", INCLUSION_PATTERNS.stream().map(p -> MavenPluginTools.newDom("include", p))),
-                MavenPluginTools.newDom("useSystemClassLoader", useSystemClassLoader ? "true" : "false"));
+        return getMavenSurefirePlugin(null, DEFAULT_INCLUSION_PATTERNS, useSystemClassLoader);
+    }
+
+    public Plugin getMavenSurefirePlugin(String version)
+    {
+        return getMavenSurefirePlugin(version, null, null);
+    }
+
+    public Plugin getMavenSurefirePlugin(String version, Iterable<String> inclusionPatterns, Boolean useSystemClassLoader)
+    {
+        Plugin plugin = MavenPluginTools.newPlugin(null, "maven-surefire-plugin", version);
+        if (inclusionPatterns != null)
+        {
+            MavenPluginTools.addConfiguration(plugin, MavenPluginTools.newDom("includes", DEFAULT_INCLUSION_PATTERNS.asLazy().collect(p -> MavenPluginTools.newDom("include", p))));
+        }
+        if (useSystemClassLoader != null)
+        {
+            MavenPluginTools.addConfiguration(plugin, MavenPluginTools.newDom("useSystemClassLoader", useSystemClassLoader.toString()));
+        }
         return plugin;
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendVersionPackagePluginMavenHelper.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/LegendVersionPackagePluginMavenHelper.java
@@ -28,7 +28,7 @@ public class LegendVersionPackagePluginMavenHelper extends AbstractLegendMavenPl
 
     public LegendVersionPackagePluginMavenHelper(String groupId, String artifactId,  String version, List<String> entitySourceDirectories, String outputDirectory)
     {
-        super(groupId, artifactId, version, "compile", "version-qualify-packages", null);
+        super(groupId, artifactId, version, "compile", "version-qualify-packages");
         this.entitySourceDirectories = entitySourceDirectories;
         this.outputDirectory = outputDirectory;
     }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/MavenProjectStructure.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/MavenProjectStructure.java
@@ -593,6 +593,35 @@ public abstract class MavenProjectStructure extends ProjectStructure
         return obj1.compareTo(obj2);
     }
 
+    protected static class MavenCoordinates
+    {
+        private final String groupId;
+        private final String artifactId;
+        private final String version;
+
+        public MavenCoordinates(String groupdId, String artifactId, String version)
+        {
+            this.groupId = groupdId;
+            this.artifactId = artifactId;
+            this.version = version;
+        }
+
+        public String getArtifactId()
+        {
+            return artifactId;
+        }
+
+        public String getVersion()
+        {
+            return version;
+        }
+
+        public String getGroupId()
+        {
+            return groupId;
+        }
+    }
+
     protected static class MavenModelConfiguration
     {
         private final SortedProperties properties = new SortedProperties();

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/MultiModuleMavenProjectStructure.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/maven/MultiModuleMavenProjectStructure.java
@@ -63,9 +63,6 @@ public abstract class MultiModuleMavenProjectStructure extends MavenProjectStruc
 {
     private static final Pattern VALID_MODULE_NAME = Pattern.compile("\\w++(-\\w++)*+");
 
-    public static final String ENTITY_VALIDATION_TEST_FILE_PATH = "/src/test/java/org/finos/legend/sdlc/EntityValidationTest.java";
-    public static final String ENTITY_TEST_SUITE_FILE_PATH = "/src/test/java/org/finos/legend/sdlc/EntityTestSuite.java";
-
     private final String entitiesModuleName;
     private final Map<String, ArtifactType> otherModules;
     private final boolean useDependencyManagement;
@@ -392,6 +389,12 @@ public abstract class MultiModuleMavenProjectStructure extends MavenProjectStruc
         String oldFullPath = (oldStructure instanceof MultiModuleMavenProjectStructure) ? ((MultiModuleMavenProjectStructure) oldStructure).getModuleFilePath(oldModule, oldPath) : oldPath;
         String newFullPath = getModuleFilePath(newModule, newPath);
         moveOrAddOrModifyFile(oldFullPath, newFullPath, newContent, fileAccessContext, operationConsumer);
+    }
+
+    protected void deleteModuleFileIfPresent(ProjectStructure structure, String moduleName, String pathWithinModule, FileAccessContext fileAccessContext, Consumer<ProjectFileOperation> operationConsumer)
+    {
+        String fullPath = (structure instanceof MultiModuleMavenProjectStructure) ? ((MultiModuleMavenProjectStructure) structure).getModuleFilePath(moduleName, pathWithinModule) : pathWithinModule;
+        deleteFileIfPresent(fullPath, fileAccessContext, operationConsumer);
     }
 
     private Model createMavenModuleModel(String moduleName)

--- a/legend-sdlc-server/src/main/resources/META-INF/services/org.finos.legend.sdlc.server.project.ProjectStructureVersionFactory
+++ b/legend-sdlc-server/src/main/resources/META-INF/services/org.finos.legend.sdlc.server.project.ProjectStructureVersionFactory
@@ -1,3 +1,4 @@
 org.finos.legend.sdlc.server.project.ProjectStructureV0Factory
 org.finos.legend.sdlc.server.project.ProjectStructureV11Factory
 org.finos.legend.sdlc.server.project.ProjectStructureV12Factory
+org.finos.legend.sdlc.server.project.ProjectStructureV13Factory

--- a/legend-sdlc-server/src/main/resources/org/finos/legend/sdlc/server/gitlab/finos/finos-extension.yaml
+++ b/legend-sdlc-server/src/main/resources/org/finos/legend/sdlc/server/gitlab/finos/finos-extension.yaml
@@ -10,3 +10,7 @@
         .gitlab-ci.yml: org/finos/legend/sdlc/server/gitlab/finos/gitlab-ci-2.yml
     - files:
         .gitlab-ci.yml: org/finos/legend/sdlc/server/gitlab/finos/gitlab-ci-2.yml
+- projectStructureVersion: 13
+  extensions:
+    - files:
+        .gitlab-ci.yml: org/finos/legend/sdlc/server/gitlab/finos/gitlab-ci-2.yml

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/finos/TestFinosGitlabProjectStructureExtension.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/finos/TestFinosGitlabProjectStructureExtension.java
@@ -91,9 +91,18 @@ public class TestFinosGitlabProjectStructureExtension
     }
 
     @Test
+    public void testProjectStructureVersion13()
+    {
+        Assert.assertEquals(Integer.valueOf(1), this.provider.getLatestVersionForProjectStructureVersion(13));
+
+        ProjectStructureExtension ext2 = this.provider.getProjectStructureExtension(13, 1);
+        assertFiles(Maps.mutable.with("/.gitlab-ci.yml", loadTextResource("org/finos/legend/sdlc/server/gitlab/finos/gitlab-ci-2.yml")), ext2);
+    }
+
+    @Test
     public void testNoUntestedProjectStructureVersions()
     {
-        int expectedLatest = 12;
+        int expectedLatest = 13;
         if (this.latestProjectStructureVersion > expectedLatest)
         {
             Assert.fail(IntInterval.fromTo(expectedLatest + 1, this.latestProjectStructureVersion).makeString("Add tests for project structure version(s): ", ", ", ""));

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestMultiGenerationProjectStructure.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestMultiGenerationProjectStructure.java
@@ -64,13 +64,6 @@ public abstract class TestMultiGenerationProjectStructure<T extends MultiModuleM
     }
 
     @Override
-    protected void collectExpectedEntitiesModelPlugins(T projectStructure, Consumer<Plugin> pluginConsumer)
-    {
-        super.collectExpectedEntitiesModelPlugins(projectStructure, pluginConsumer);
-        pluginConsumer.accept(LEGEND_TEST_UTILS_MAVEN_HELPER.getMavenSurefirePlugin(false));
-    }
-
-    @Override
     protected void assertMultiFormatGenerationStateValid(String projectId, String workspaceId, String revisionId, ArtifactType artifactType)
     {
         ProjectConfiguration configuration = ProjectStructure.getProjectConfiguration(projectId, workspaceId, revisionId, this.fileAccessProvider, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE);

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureFactory.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureFactory.java
@@ -21,14 +21,12 @@ import org.eclipse.collections.impl.factory.primitive.IntLists;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.Collections;
-
 public class TestProjectStructureFactory
 {
     @Test
-    public void testFactoryWithV0_V11_V12()
+    public void testFactoryWithV0_V11_V12_V13()
     {
-        assertFactoryWithV0(ProjectStructureFactory.newFactory(Lists.mutable.with(new ProjectStructureV0Factory(), new ProjectStructureV11Factory(), new ProjectStructureV12Factory())));
+        assertFactoryWithV0(ProjectStructureFactory.newFactory(Lists.mutable.with(new ProjectStructureV0Factory(), new ProjectStructureV11Factory(), new ProjectStructureV12Factory(), new ProjectStructureV13Factory())));
     }
 
     @Test
@@ -70,7 +68,7 @@ public class TestProjectStructureFactory
 
     private void assertFactoryWithV0(ProjectStructureFactory factory)
     {
-        assertSupportsVersions(factory, 0, 11, 12);
+        assertSupportsVersions(factory, 0, 11, 12, 13);
 
         ProjectStructure structure = factory.newProjectStructure(null, null);
         Assert.assertEquals(0, structure.getVersion());

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureStaticMethods.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureStaticMethods.java
@@ -103,7 +103,7 @@ public class TestProjectStructureStaticMethods
     @Test
     public void testGetLatestProjectStructureVersion()
     {
-        Assert.assertEquals(12, ProjectStructure.getLatestProjectStructureVersion());
+        Assert.assertEquals(13, ProjectStructure.getLatestProjectStructureVersion());
     }
 
     @Test

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureV11.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureV11.java
@@ -16,23 +16,22 @@ package org.finos.legend.sdlc.server.project;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactType;
 import org.finos.legend.sdlc.server.project.ProjectStructureV11Factory.ProjectStructureV11;
 import org.finos.legend.sdlc.server.project.maven.LegendEntityPluginMavenHelper;
+import org.finos.legend.sdlc.server.project.maven.LegendFileGenerationPluginMavenHelper;
 import org.finos.legend.sdlc.server.project.maven.LegendModelGenerationPluginMavenHelper;
+import org.finos.legend.sdlc.server.project.maven.LegendServiceExecutionGenerationPluginMavenHelper;
 import org.finos.legend.sdlc.server.project.maven.MavenProjectStructure;
 import org.finos.legend.sdlc.server.project.maven.MultiModuleMavenProjectStructure;
-import org.finos.legend.sdlc.server.project.maven.LegendServiceExecutionGenerationPluginMavenHelper;
-import org.finos.legend.sdlc.server.project.maven.LegendFileGenerationPluginMavenHelper;
 import org.finos.legend.sdlc.server.project.maven.MultiModuleMavenProjectStructure.ModuleConfig;
 
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Collections;
-import java.util.EnumMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -100,7 +99,7 @@ public class TestProjectStructureV11 extends TestMultiGenerationProjectStructure
     {
         super.collectExpectedEntitiesModelDependencies(projectStructure, dependencyConsumer);
         dependencyConsumer.accept(LEGEND_TEST_UTILS_MAVEN_HELPER.getDependency(false));
-        Dependency executionDependency = projectStructure.newMavenDependency("org.finos.legend.engine", "legend-engine-extensions-collection-execution", null);
+        Dependency executionDependency = MavenProjectStructure.newMavenDependency("org.finos.legend.engine", "legend-engine-extensions-collection-execution", null);
         executionDependency.setScope("test");
         dependencyConsumer.accept(executionDependency);
         Dependency generationDependency = MavenProjectStructure.newMavenDependency("org.finos.legend.engine", "legend-engine-extensions-collection-generation", null);
@@ -113,8 +112,8 @@ public class TestProjectStructureV11 extends TestMultiGenerationProjectStructure
     protected void collectExpectedEntitiesModelPlugins(ProjectStructureV11 projectStructure, Consumer<Plugin> pluginConsumer)
     {
         super.collectExpectedEntitiesModelPlugins(projectStructure, pluginConsumer);
-        pluginConsumer.accept((new LegendEntityPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-entity-maven-plugin","${platform.legend-sdlc.version}", Lists.immutable.with(getGenerationDependency(), getSerializerDependency()).toList())).getPlugin(projectStructure));
-        pluginConsumer.accept((new LegendModelGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-model-maven-plugin", "${platform.legend-sdlc.version}", getGenerationDependency())).getPlugin(projectStructure));
+        pluginConsumer.accept(new LegendEntityPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-entity-maven-plugin","${platform.legend-sdlc.version}", getGenerationDependency(), getSerializerDependency()).getPlugin(projectStructure));
+        pluginConsumer.accept(new LegendModelGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-model-maven-plugin", "${platform.legend-sdlc.version}", getGenerationDependency()).getPlugin(projectStructure));
     }
 
     @Override

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureV11.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureV11.java
@@ -37,7 +37,6 @@ import java.util.function.Consumer;
 
 public class TestProjectStructureV11 extends TestMultiGenerationProjectStructure<ProjectStructureV11>
 {
-
     private Dependency getGenerationDependency()
     {
         return MavenProjectStructure.newMavenDependency("org.finos.legend.engine", "legend-engine-extensions-collection-generation", "${platform.legend-engine.version}");
@@ -112,6 +111,7 @@ public class TestProjectStructureV11 extends TestMultiGenerationProjectStructure
     protected void collectExpectedEntitiesModelPlugins(ProjectStructureV11 projectStructure, Consumer<Plugin> pluginConsumer)
     {
         super.collectExpectedEntitiesModelPlugins(projectStructure, pluginConsumer);
+        pluginConsumer.accept(LEGEND_TEST_UTILS_MAVEN_HELPER.getMavenSurefirePlugin(false));
         pluginConsumer.accept(new LegendEntityPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-entity-maven-plugin","${platform.legend-sdlc.version}", getGenerationDependency(), getSerializerDependency()).getPlugin(projectStructure));
         pluginConsumer.accept(new LegendModelGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-model-maven-plugin", "${platform.legend-sdlc.version}", getGenerationDependency()).getPlugin(projectStructure));
     }
@@ -142,6 +142,5 @@ public class TestProjectStructureV11 extends TestMultiGenerationProjectStructure
     {
         pluginConsumer.accept((new LegendFileGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-file-maven-plugin","${platform.legend-sdlc.version}", getGenerationDependency())).getPlugin(projectStructure));
     }
-
 }
 

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureV12.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureV12.java
@@ -16,7 +16,6 @@ package org.finos.legend.sdlc.server.project;
 
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactType;
 import org.finos.legend.sdlc.server.project.maven.LegendEntityPluginMavenHelper;
@@ -111,8 +110,8 @@ public class TestProjectStructureV12 extends TestMultiGenerationProjectStructure
     protected void collectExpectedEntitiesModelPlugins(ProjectStructureV12Factory.ProjectStructureV12 projectStructure, Consumer<Plugin> pluginConsumer)
     {
         super.collectExpectedEntitiesModelPlugins(projectStructure, pluginConsumer);
-        pluginConsumer.accept((new LegendEntityPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-entity-maven-plugin","${platform.legend-sdlc.version}", Lists.immutable.with(getGenerationDependency(), getSerializerDependency()).toList())).getPlugin(projectStructure));
-        pluginConsumer.accept((new LegendModelGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-model-maven-plugin", "${platform.legend-sdlc.version}", getGenerationDependency())).getPlugin(projectStructure));
+        pluginConsumer.accept(new LegendEntityPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-entity-maven-plugin","${platform.legend-sdlc.version}", getGenerationDependency(), getSerializerDependency()).getPlugin(projectStructure));
+        pluginConsumer.accept(new LegendModelGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-model-maven-plugin", "${platform.legend-sdlc.version}", getGenerationDependency()).getPlugin(projectStructure));
     }
 
     @Override

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureV13.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureV13.java
@@ -1,4 +1,4 @@
-// Copyright 2022 Goldman Sachs
+// Copyright 2023 Goldman Sachs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Plugin;
 import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactType;
-import org.finos.legend.sdlc.server.project.ProjectStructureV12Factory.ProjectStructureV12;
+import org.finos.legend.sdlc.server.project.ProjectStructureV13Factory.ProjectStructureV13;
 import org.finos.legend.sdlc.server.project.maven.LegendEntityPluginMavenHelper;
 import org.finos.legend.sdlc.server.project.maven.LegendFileGenerationPluginMavenHelper;
+import org.finos.legend.sdlc.server.project.maven.LegendJUnitTestGenerationPluginMavenHelper;
 import org.finos.legend.sdlc.server.project.maven.LegendModelGenerationPluginMavenHelper;
 import org.finos.legend.sdlc.server.project.maven.LegendServiceExecutionGenerationPluginMavenHelper;
 import org.finos.legend.sdlc.server.project.maven.MavenProjectStructure;
@@ -34,7 +35,7 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public class TestProjectStructureV12 extends TestMultiGenerationProjectStructure<ProjectStructureV12>
+public class TestProjectStructureV13 extends TestMultiGenerationProjectStructure<ProjectStructureV13>
 {
     private Dependency getGenerationDependency()
     {
@@ -47,23 +48,22 @@ public class TestProjectStructureV12 extends TestMultiGenerationProjectStructure
     }
 
     @Override
-    protected void collectExpectedProjectProperties(ProjectStructureV12 projectStructure, BiConsumer<String, String> propertyConsumer)
+    protected void collectExpectedProjectProperties(ProjectStructureV13 projectStructure, BiConsumer<String, String> propertyConsumer)
     {
         super.collectExpectedProjectProperties(projectStructure, propertyConsumer);
-        propertyConsumer.accept("platform.legend-engine.version", "2.57.0");
-        propertyConsumer.accept("platform.legend-sdlc.version", "0.69.1");
+        propertyConsumer.accept("platform.legend-engine.version", "4.12.1");
+        propertyConsumer.accept("platform.legend-sdlc.version", "0.129.0");
     }
 
     @Override
-    protected void collectExpectedFiles(ProjectStructureV12 projectStructure, BiConsumer<String, String> expectedFilePathAndContentConsumer, Consumer<String> unexpectedFilePathConsumer)
+    protected void collectExpectedFiles(ProjectStructureV13 projectStructure, BiConsumer<String, String> expectedFilePathAndContentConsumer, Consumer<String> unexpectedFilePathConsumer)
     {
         super.collectExpectedFiles(projectStructure, expectedFilePathAndContentConsumer, unexpectedFilePathConsumer);
-        expectedFilePathAndContentConsumer.accept(projectStructure.getModuleFilePath(projectStructure.getEntitiesModuleName(), ProjectStructureV12.ENTITY_VALIDATION_TEST_FILE_PATH), ProjectStructureV12.getEntityValidationTestCode());
-        expectedFilePathAndContentConsumer.accept(projectStructure.getModuleFilePath(projectStructure.getEntitiesModuleName(), ProjectStructureV12.ENTITY_TEST_SUITE_FILE_PATH), ProjectStructureV12.getEntityTestSuiteCode());
+        expectedFilePathAndContentConsumer.accept(projectStructure.getModuleFilePath(projectStructure.getEntitiesModuleName(), ProjectStructureV13.ENTITY_VALIDATION_TEST_FILE_PATH), ProjectStructureV13.getEntityValidationTestCode());
     }
 
     @Override
-    protected Map<ArtifactType, List<String>> getExpectedArtifactIdsByType(ProjectStructureV12 projectStructure)
+    protected Map<ArtifactType, List<String>> getExpectedArtifactIdsByType(ProjectStructureV13 projectStructure)
     {
         Map<ArtifactType, List<String>> map = new EnumMap<>(ArtifactType.class);
         map.put(ArtifactType.entities, Collections.singletonList(projectStructure.getModuleFullName(projectStructure.getEntitiesModuleName())));
@@ -76,13 +76,13 @@ public class TestProjectStructureV12 extends TestMultiGenerationProjectStructure
     @Override
     protected int getProjectStructureVersion()
     {
-        return 12;
+        return 13;
     }
 
     @Override
-    protected Class<ProjectStructureV12> getProjectStructureClass()
+    protected Class<ProjectStructureV13> getProjectStructureClass()
     {
-        return ProjectStructureV12.class;
+        return ProjectStructureV13.class;
     }
 
     @Override
@@ -93,7 +93,7 @@ public class TestProjectStructureV12 extends TestMultiGenerationProjectStructure
 
 
     @Override
-    protected void collectExpectedEntitiesModelDependencies(ProjectStructureV12 projectStructure, Consumer<Dependency> dependencyConsumer)
+    protected void collectExpectedEntitiesModelDependencies(ProjectStructureV13 projectStructure, Consumer<Dependency> dependencyConsumer)
     {
         super.collectExpectedEntitiesModelDependencies(projectStructure, dependencyConsumer);
         dependencyConsumer.accept(LEGEND_TEST_UTILS_MAVEN_HELPER.getDependency(false));
@@ -107,16 +107,16 @@ public class TestProjectStructureV12 extends TestMultiGenerationProjectStructure
 
 
     @Override
-    protected void collectExpectedEntitiesModelPlugins(ProjectStructureV12 projectStructure, Consumer<Plugin> pluginConsumer)
+    protected void collectExpectedEntitiesModelPlugins(ProjectStructureV13 projectStructure, Consumer<Plugin> pluginConsumer)
     {
         super.collectExpectedEntitiesModelPlugins(projectStructure, pluginConsumer);
-        pluginConsumer.accept(LEGEND_TEST_UTILS_MAVEN_HELPER.getMavenSurefirePlugin(true));
         pluginConsumer.accept(new LegendEntityPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-entity-maven-plugin","${platform.legend-sdlc.version}", getGenerationDependency(), getSerializerDependency()).getPlugin(projectStructure));
         pluginConsumer.accept(new LegendModelGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-model-maven-plugin", "${platform.legend-sdlc.version}", getGenerationDependency()).getPlugin(projectStructure));
+        pluginConsumer.accept(new LegendJUnitTestGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-test-generation-maven-plugin", "${platform.legend-sdlc.version}", getGenerationDependency()).getPlugin(projectStructure));
     }
 
     @Override
-    protected void collectExpectedProjectModelDependencyManagement(ProjectStructureV12 projectStructure, Consumer<Dependency> dependencyManagementConsumer)
+    protected void collectExpectedProjectModelDependencyManagement(ProjectStructureV13 projectStructure, Consumer<Dependency> dependencyManagementConsumer)
     {
         super.collectExpectedProjectModelDependencyManagement(projectStructure, dependencyManagementConsumer);
         dependencyManagementConsumer.accept(MavenProjectStructure.newMavenDependency("org.finos.legend.engine", "legend-engine-extensions-collection-execution", "${platform.legend-engine.version}"));
@@ -124,21 +124,20 @@ public class TestProjectStructureV12 extends TestMultiGenerationProjectStructure
     }
 
     @MultiModuleMavenProjectStructure.ModuleConfig(artifactType = ArtifactType.service_execution, type = MultiModuleMavenProjectStructure.ModuleConfigType.PLUGINS)
-    protected void collectExpectedServiceExecutionModulePlugins(String name, ProjectStructureV12 projectStructure, Consumer<Plugin> pluginConsumer)
+    protected void collectExpectedServiceExecutionModulePlugins(String name, ProjectStructureV13 projectStructure, Consumer<Plugin> pluginConsumer)
     {
         pluginConsumer.accept(new LegendServiceExecutionGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-service-maven-plugin","${platform.legend-sdlc.version}", getGenerationDependency()).getPlugin(projectStructure));
-        pluginConsumer.accept(new LegendServiceExecutionGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-service-maven-plugin","${platform.legend-sdlc.version}", getGenerationDependency()).getBuildHelperPlugin("3.0.0"));
         pluginConsumer.accept(new LegendServiceExecutionGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-service-maven-plugin","${platform.legend-sdlc.version}", getGenerationDependency()).getShadePlugin());
     }
 
     @MultiModuleMavenProjectStructure.ModuleConfig(artifactType = ArtifactType.service_execution, type = MultiModuleMavenProjectStructure.ModuleConfigType.DEPENDENCIES)
-    protected void collectExpectedServiceExecutionModuleDependencies(ProjectStructureV12 projectStructure, Consumer<Dependency> dependencyConsumer)
+    protected void collectExpectedServiceExecutionModuleDependencies(ProjectStructureV13 projectStructure, Consumer<Dependency> dependencyConsumer)
     {
         dependencyConsumer.accept(MavenProjectStructure.newMavenDependency("org.finos.legend.engine",  "legend-engine-extensions-collection-execution", null));
     }
 
     @MultiModuleMavenProjectStructure.ModuleConfig(artifactType = ArtifactType.file_generation, type = MultiModuleMavenProjectStructure.ModuleConfigType.PLUGINS)
-    protected void collectExpectedFileGenerationModulePlugins(String name, ProjectStructureV12 projectStructure, Consumer<Plugin> pluginConsumer)
+    protected void collectExpectedFileGenerationModulePlugins(String name, ProjectStructureV13 projectStructure, Consumer<Plugin> pluginConsumer)
     {
         pluginConsumer.accept((new LegendFileGenerationPluginMavenHelper("org.finos.legend.sdlc", "legend-sdlc-generation-file-maven-plugin","${platform.legend-sdlc.version}", getGenerationDependency())).getPlugin(projectStructure));
     }


### PR DESCRIPTION
Add project structure version 13. This leverages the new test generation plugin to replace the old JUnit 3 style test suite with JUnit 4 style test classes.