### PR TITLE
Fix a bug in LegendSDLCTestSuiteBuilder

### DIFF
--- a/legend-sdlc-test-utils/src/main/java/org/finos/legend/sdlc/test/junit/LegendSDLCTestSuiteBuilder.java
+++ b/legend-sdlc-test-utils/src/main/java/org/finos/legend/sdlc/test/junit/LegendSDLCTestSuiteBuilder.java
@@ -72,7 +72,7 @@ public class LegendSDLCTestSuiteBuilder
         this.pureVersion = pureVersion;
         this.testableClassifiers = TestableRunnerExtensionLoader.getClassifierPathToTestableRunnerMap(classLoader).keySet();
         this.entities = getEntities(classLoader);
-        PureModelWithContextData pureModelWithContextData = PureModelBuilder.newBuilder().withEntities(this.entities).build(classLoader);
+        PureModelWithContextData pureModelWithContextData = PureModelBuilder.newBuilder().withEntitiesIfPossible(this.entities).build(classLoader);
         this.pureModel = pureModelWithContextData.getPureModel();
         this.pureModelContextData = pureModelWithContextData.getPureModelContextData();
         this.protocolIndex = Iterate.groupByUniqueKey(this.pureModelContextData.getElements(), PackageableElement::getPath);


### PR DESCRIPTION
Fix a bug in LegendSDLCTestSuiteBuilder in building the Pure model from entities. The building needs to be permissive about entities which do not correspond to Pure model elements.