### PR TITLE
Revert "Update legend-shared to 0.23.5 (#645)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <!-- Legend dependency versions -->
         <legend.engine.version>4.12.1</legend.engine.version>
         <legend.pure.version>4.5.2</legend.pure.version>
-        <legend.shared.version>0.23.5</legend.shared.version>
+        <legend.shared.version>0.23.3</legend.shared.version>
 
         <!-- Dependency versions -->
         <commons-codec.version>1.15</commons-codec.version>


### PR DESCRIPTION
This reverts commit 4adca64e3941f96f91390ff6da305d2043006871. The legend-shared version used in legend-sdlc should be consistent with the one used in legend-engine. But legend-engine 4.12.1 uses legend-shared 0.23.3.