### PR TITLE
Downgrade maven-source-plugin to 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <maven.plugin.plugin.version>3.9.0</maven.plugin.plugin.version>
         <maven.pmd.version>3.21.0</maven.pmd.version>
         <maven.shade.plugin.version>3.4.1</maven.shade.plugin.version>
-        <maven.source.plugin.version>3.3.0</maven.source.plugin.version>
+        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.surefire.plugin.version>3.1.0</maven.surefire.plugin.version>
     </properties>
 


### PR DESCRIPTION
Downgrade maven-source-plugin to 3.2.1. Using version 3.3.0 causes problems with the release. The newer version complains about the plugin being run multiple times.