### PR TITLE
Make legend-sdlc compatible with JDK 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
         server-id: ossrh
         server-username: CI_DEPLOY_USERNAME
         server-password: CI_DEPLOY_PASSWORD

--- a/.github/workflows/gitlab-com-integration-test.yml
+++ b/.github/workflows/gitlab-com-integration-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/.github/workflows/gitlab-docker-int-test-latest-twelve.yml
+++ b/.github/workflows/gitlab-docker-int-test-latest-twelve.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/.github/workflows/gitlab-docker-int-test-latest.yml
+++ b/.github/workflows/gitlab-docker-int-test-latest.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/.github/workflows/gitlab-docker-int-test-nightly.yml
+++ b/.github/workflows/gitlab-docker-int-test-nightly.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/.github/workflows/legend-stack-release.yml
+++ b/.github/workflows/legend-stack-release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/.github/workflows/ossrh-close-staging-repo.yml
+++ b/.github/workflows/ossrh-close-staging-repo.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: "zulu"
-          java-version: "11"
+          java-version: "17"
           server-id: ossrh
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <maven.compiler.release>8</maven.compiler.release>
-        <java.version.range>[11.0.10,12)</java.version.range>
+        <java.version.range>[11,12),[17,18)</java.version.range>
 
         <!-- Legend dependency versions -->
         <legend.engine.version>4.14.1</legend.engine.version>
@@ -88,8 +88,8 @@
         <findbugs.version>3.0.0</findbugs.version>
         <freemarker.version>2.3.30</freemarker.version>
         <gitlab4j.version>4.16.0</gitlab4j.version>
-        <guava.version>30.0-jre</guava.version>
-        <guice.version>4.2.1</guice.version>
+        <guava.version>31.1-jre</guava.version>
+        <guice.version>6.0.0</guice.version>
         <h2.version>1.4.200</h2.version>
         <hibernate-validator.version>5.4.3.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version>


### PR DESCRIPTION
Update legend-sdlc to make it compatible with JDK 17. Specifically, the previous version of guice was not compatible with JDK 17.

Also, set workflows to use JDK 17.