### PR TITLE
Support EMBEDDED projects

### DIFF
--- a/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/ProjectType.java
+++ b/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/ProjectType.java
@@ -14,8 +14,7 @@
 
 package org.finos.legend.sdlc.domain.model.project;
 
-@Deprecated
 public enum ProjectType
 {
-    @Deprecated PRODUCTION, @Deprecated PROTOTYPE
+    @Deprecated PRODUCTION, @Deprecated PROTOTYPE, MANAGED, EMBEDDED
 }

--- a/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ProjectConfiguration.java
+++ b/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ProjectConfiguration.java
@@ -23,7 +23,6 @@ public interface ProjectConfiguration
 {
     String getProjectId();
 
-    @Deprecated
     default ProjectType getProjectType()
     {
         return null;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/application/project/CreateProjectCommand.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/application/project/CreateProjectCommand.java
@@ -47,13 +47,11 @@ public class CreateProjectCommand
         this.description = description;
     }
 
-    @Deprecated
     public ProjectType getType()
     {
         return this.type;
     }
 
-    @Deprecated
     public void setType(ProjectType type)
     {
         this.type = type;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/application/project/ImportProjectCommand.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/application/project/ImportProjectCommand.java
@@ -33,13 +33,11 @@ public class ImportProjectCommand
         this.id = id;
     }
 
-    @Deprecated
     public ProjectType getType()
     {
         return this.type;
     }
 
-    @Deprecated
     public void setType(ProjectType type)
     {
         this.type = type;

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/application/project/UpdateProjectConfigurationCommand.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/application/project/UpdateProjectConfigurationCommand.java
@@ -17,6 +17,7 @@ package org.finos.legend.sdlc.server.application.project;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactGeneration;
 import org.finos.legend.sdlc.domain.model.project.configuration.PlatformConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
@@ -31,6 +32,7 @@ public class UpdateProjectConfigurationCommand
 {
     private final String message;
     private final UpdateProjectConfigProjectStructureVersion projectStructureVersion;
+    private final ProjectType projectType;
     private final String groupId;
     private final String artifactId;
     private final UpdatePlatformConfigurationsCommand platformConfigurations;
@@ -43,6 +45,7 @@ public class UpdateProjectConfigurationCommand
     public UpdateProjectConfigurationCommand(
             @JsonProperty("message") String message,
             @JsonProperty("projectStructureVersion") UpdateProjectConfigProjectStructureVersion projectStructureVersion,
+            @JsonProperty("projectType") ProjectType projectType,
             @JsonProperty("groupId") String groupId,
             @JsonProperty("artifactId") String artifactId,
             @JsonProperty("platformConfigurations") UpdatePlatformConfigurationsCommand platformConfigurations,
@@ -53,6 +56,7 @@ public class UpdateProjectConfigurationCommand
     {
         this.message = message;
         this.projectStructureVersion = projectStructureVersion;
+        this.projectType = projectType;
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.platformConfigurations = platformConfigurations;
@@ -76,6 +80,10 @@ public class UpdateProjectConfigurationCommand
                 .withProjectDependenciesToRemove(this.projectDependenciesToRemove)
                 .withArtifactGenerationsToAdd(this.artifactGenerationsToAdd)
                 .withArtifactGenerationsToRemove(this.artifactGenerationsNamesToRemove);
+        if (this.projectType != null)
+        {
+            configUpdater.withProjectType(this.projectType);
+        }
         if (this.projectStructureVersion != null)
         {
             configUpdater.withProjectStructureVersion(this.projectStructureVersion.getVersion())

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/project/ProjectApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/project/ProjectApi.java
@@ -41,7 +41,7 @@ public interface ProjectApi
 
     List<Project> getProjects(boolean user, String search, Iterable<String> tags, Integer limit);
 
-    Project createProject(String name, String description, String groupId, String artifactId, Iterable<String> tags);
+    Project createProject(String name, String description, ProjectType type, String groupId, String artifactId, Iterable<String> tags);
 
     void deleteProject(String id);
 
@@ -94,13 +94,7 @@ public interface ProjectApi
      */
     boolean checkUserAuthorizedAction(String id, AuthorizableProjectAction action);
 
-    @Deprecated
-    default ImportReport importProject(String id, ProjectType type, String groupId, String artifactId)
-    {
-        return this.importProject(id, groupId, artifactId);
-    }
-
-    ImportReport importProject(String id, String groupId, String artifactId);
+    ImportReport importProject(String id, ProjectType type, String groupId, String artifactId);
 
     interface ImportReport
     {

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/project/ProjectConfigurationUpdater.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/project/ProjectConfigurationUpdater.java
@@ -20,6 +20,7 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.list.fixed.ArrayAdapter;
 import org.eclipse.collections.impl.utility.ListIterate;
+import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactGeneration;
 import org.finos.legend.sdlc.domain.model.project.configuration.MetamodelDependency;
 import org.finos.legend.sdlc.domain.model.project.configuration.PlatformConfiguration;
@@ -33,6 +34,7 @@ import java.util.Set;
 public class ProjectConfigurationUpdater
 {
     private String projectId;
+    private ProjectType projectType;
     private Integer projectStructureVersion;
     private Integer projectStructureExtensionVersion;
     private String groupId;
@@ -61,6 +63,24 @@ public class ProjectConfigurationUpdater
     public ProjectConfigurationUpdater withProjectId(String projectId)
     {
         setProjectId(projectId);
+        return this;
+    }
+
+    // Project type
+
+    public ProjectType getProjectType()
+    {
+        return this.projectType;
+    }
+
+    public void setProjectType(ProjectType projectType)
+    {
+        this.projectType = projectType;
+    }
+
+    public ProjectConfigurationUpdater withProjectType(ProjectType projectType)
+    {
+        setProjectType(projectType);
         return this;
     }
 
@@ -360,13 +380,17 @@ public class ProjectConfigurationUpdater
         // Project id
         String newProjectId = (this.projectId == null) ? configuration.getProjectId() : this.projectId;
 
+        // Project type
+        ProjectType newProjectType = (this.projectType == null) ? configuration.getProjectType() : this.projectType;
+
         // Project structure version
         ProjectStructureVersion newProjectStructureVersion;
         if (this.projectStructureVersion != null)
         {
             newProjectStructureVersion = ProjectStructureVersion.newProjectStructureVersion(this.projectStructureVersion, this.projectStructureExtensionVersion);
         }
-        else if (this.projectStructureExtensionVersion != null)
+        // For EMBEDDED projects drop extension version from current configuration
+        else if (this.projectStructureExtensionVersion != null || newProjectType == ProjectType.EMBEDDED)
         {
             newProjectStructureVersion = ProjectStructureVersion.newProjectStructureVersion(configuration.getProjectStructureVersion().getVersion(), this.projectStructureExtensionVersion);
         }
@@ -441,6 +465,12 @@ public class ProjectConfigurationUpdater
             public String getProjectId()
             {
                 return newProjectId;
+            }
+
+            @Override
+            public ProjectType getProjectType()
+            {
+                return newProjectType;
             }
 
             @Override

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/SimpleProjectConfiguration.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/SimpleProjectConfiguration.java
@@ -31,6 +31,7 @@ import java.util.List;
 public class SimpleProjectConfiguration implements ProjectConfiguration
 {
     private final String projectId;
+    private ProjectType projectType;
     private ProjectStructureVersion projectStructureVersion;
     private List<PlatformConfiguration> platformConfigurations;
     private String groupId;
@@ -39,9 +40,10 @@ public class SimpleProjectConfiguration implements ProjectConfiguration
     private List<MetamodelDependency> metamodelDependencies;
     private List<ArtifactGeneration> artifactGeneration;
 
-    private SimpleProjectConfiguration(String projectId, ProjectStructureVersion projectStructureVersion, List<PlatformConfiguration> platformConfigurations, String groupId, String artifactId, List<ProjectDependency> projectDependencies, List<MetamodelDependency> metamodelDependencies, List<ArtifactGeneration> artifactGeneration)
+    private SimpleProjectConfiguration(String projectId, ProjectType projectType, ProjectStructureVersion projectStructureVersion, List<PlatformConfiguration> platformConfigurations, String groupId, String artifactId, List<ProjectDependency> projectDependencies, List<MetamodelDependency> metamodelDependencies, List<ArtifactGeneration> artifactGeneration)
     {
         this.projectId = projectId;
+        this.projectType = projectType;
         this.projectStructureVersion = projectStructureVersion;
         this.platformConfigurations = platformConfigurations;
         this.groupId = groupId;
@@ -53,13 +55,24 @@ public class SimpleProjectConfiguration implements ProjectConfiguration
 
     SimpleProjectConfiguration(ProjectConfiguration config)
     {
-        this(config.getProjectId(), config.getProjectStructureVersion(), config.getPlatformConfigurations(), config.getGroupId(), config.getArtifactId(), config.getProjectDependencies(), config.getMetamodelDependencies(), config.getArtifactGenerations());
+        this(config.getProjectId(), config.getProjectType(), config.getProjectStructureVersion(), config.getPlatformConfigurations(), config.getGroupId(), config.getArtifactId(), config.getProjectDependencies(), config.getMetamodelDependencies(), config.getArtifactGenerations());
     }
 
     @Override
     public String getProjectId()
     {
         return this.projectId;
+    }
+
+    @Override
+    public ProjectType getProjectType()
+    {
+        return this.projectType;
+    }
+
+    public void setProjectType(ProjectType projectType)
+    {
+        this.projectType = projectType;
     }
 
     @Override
@@ -148,7 +161,7 @@ public class SimpleProjectConfiguration implements ProjectConfiguration
     @JsonCreator
     static SimpleProjectConfiguration newConfiguration(
             @JsonProperty("projectId") String projectId,
-            @Deprecated @JsonProperty("projectType") ProjectType projectType,
+            @JsonProperty("projectType") ProjectType projectType,
             @JsonProperty("projectStructureVersion") @JsonDeserialize(as = SimpleProjectStructureVersion.class) ProjectStructureVersion projectStructureVersion,
             @JsonProperty("platformConfigurations") @JsonDeserialize(contentAs = SimplePlatformConfiguration.class) List<PlatformConfiguration> platforms,
             @JsonProperty("groupId") String groupId,
@@ -157,18 +170,18 @@ public class SimpleProjectConfiguration implements ProjectConfiguration
             @JsonProperty("metamodelDependencies") @JsonDeserialize(contentAs = SimpleMetamodelDependency.class) List<MetamodelDependency> metamodelDependencies,
             @Deprecated @JsonProperty("artifactGenerations") @JsonDeserialize(contentAs = SimpleArtifactGeneration.class) List<ArtifactGeneration> artifactGenerations)
     {
-        return new SimpleProjectConfiguration(projectId, projectStructureVersion, platforms, groupId, artifactId, projectDependencies, metamodelDependencies, artifactGenerations);
+        return new SimpleProjectConfiguration(projectId, projectType, projectStructureVersion, platforms, groupId, artifactId, projectDependencies, metamodelDependencies, artifactGenerations);
     }
 
     @Deprecated
     static SimpleProjectConfiguration newConfiguration(String projectId, ProjectStructureVersion projectStructureVersion, String groupId, String artifactId, List<ProjectDependency> projectDependencies, List<MetamodelDependency> metamodelDependencies, List<ArtifactGeneration> artifactGenerations)
     {
-        return newConfiguration(projectId, null, projectStructureVersion, null, groupId, artifactId, projectDependencies, metamodelDependencies, artifactGenerations);
+        return newConfiguration(projectId, ProjectType.MANAGED, projectStructureVersion, null, groupId, artifactId, projectDependencies, metamodelDependencies, artifactGenerations);
     }
 
     static SimpleProjectConfiguration newConfiguration(String projectId, ProjectStructureVersion projectStructureVersion, List<PlatformConfiguration> platforms, String groupId, String artifactId, List<ProjectDependency> projectDependencies, List<MetamodelDependency> metamodelDependencies, List<ArtifactGeneration> artifactGenerations)
     {
-        return newConfiguration(projectId, null, projectStructureVersion, platforms, groupId, artifactId, projectDependencies, metamodelDependencies, artifactGenerations);
+        return newConfiguration(projectId, ProjectType.MANAGED, projectStructureVersion, platforms, groupId, artifactId, projectDependencies, metamodelDependencies, artifactGenerations);
     }
 
     public static class SimpleProjectStructureVersion extends ProjectStructureVersion

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/ProjectsResource.java
@@ -109,6 +109,7 @@ public class ProjectsResource extends BaseResource
             "creating new project \"" + command.getName() + "\"",
             () -> this.projectApi.createProject(command.getName(),
                 command.getDescription(),
+                command.getType(),
                 command.getGroupId(),
                 command.getArtifactId(),
                 command.getTags())

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabComparisonApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabComparisonApiTestResource.java
@@ -21,6 +21,7 @@ import org.finos.legend.sdlc.domain.model.comparison.EntityDiff;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 import org.finos.legend.sdlc.domain.model.entity.change.EntityChangeType;
 import org.finos.legend.sdlc.domain.model.project.Project;
+import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.server.gitlab.api.server.AbstractGitLabServerApiTest;
@@ -62,7 +63,7 @@ public class GitLabComparisonApiTestResource
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
         String workspaceOneId = "testworkspaceone";
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         Assert.assertNotNull(createdProject);
         Assert.assertEquals(projectName, createdProject.getName());
@@ -131,7 +132,7 @@ public class GitLabComparisonApiTestResource
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
         String workspaceOneId = "testworkspaceone";
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         Assert.assertNotNull(createdProject);
         Assert.assertEquals(projectName, createdProject.getName());

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApiTestResource.java
@@ -18,6 +18,7 @@ import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 import org.finos.legend.sdlc.domain.model.project.Project;
+import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.review.Review;
@@ -74,7 +75,7 @@ public class GitLabEntityApiTestResource
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
         String workspaceName = "entitytestworkspace";
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         String projectId = createdProject.getProjectId();
         Workspace createdWorkspace = gitLabWorkspaceApi.newUserWorkspace(projectId, workspaceName);
@@ -222,7 +223,7 @@ public class GitLabEntityApiTestResource
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
         String workspaceName = "entitytestworkspace";
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         String projectId = createdProject.getProjectId();
         Workspace createdWorkspace = gitLabWorkspaceApi.newGroupWorkspace(projectId, workspaceName);

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectApiTestResource.java
@@ -17,11 +17,17 @@ package org.finos.legend.sdlc.server.gitlab.api;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.sdlc.domain.model.project.Project;
+import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.gitlab.api.server.AbstractGitLabServerApiTest;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider;
 import org.junit.Assert;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Substantial test resource class for project API tests shared by the docker-based and server-based GitLab tests.
@@ -43,13 +49,103 @@ public class GitLabProjectApiTestResource
         String artifactId = "testprojone";
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, null, groupId, artifactId, tags);
 
         Assert.assertNotNull(createdProject);
         Assert.assertEquals(projectName, createdProject.getName());
         Assert.assertEquals(description, createdProject.getDescription());
         Assert.assertNull(createdProject.getProjectType());
         Assert.assertEquals(Sets.mutable.withAll(tags), Sets.mutable.withAll(createdProject.getTags()));
+
+        String projectId = createdProject.getProjectId();
+        Assert.assertNotNull(projectId);
+
+        Assert.assertEquals(ProjectType.MANAGED, gitLabProjectApi.getProjectConfiguration(projectId).getProjectType());
+        Assert.assertNull(gitLabProjectApi.getProject(projectId).getProjectType());
+        Assert.assertNotNull(gitLabProjectApi.getProjectConfiguration(projectId).getProjectStructureVersion().getExtensionVersion());
+
+        Assert.assertEquals(Sets.mutable.with("/project.json",
+                "/PANGRAM.TXT",
+                "/pom.xml",
+                "/testprojone-entities/pom.xml",
+                "/testprojone-entities/src/test/java/org/finos/legend/sdlc/EntityValidationTest.java",
+                "/testprojone-file-generation/pom.xml",
+                "/testprojone-service-execution/pom.xml",
+                "/testprojone-versioned-entities/pom.xml"
+        ), gitLabProjectApi.getProjectFileAccessProvider().getProjectFileAccessContext(projectId).getFiles().map(ProjectFileAccessProvider.ProjectFile::getPath).collect(Collectors.toSet()));
+    }
+
+    public void runCreateManagedProjectTest() throws LegendSDLCServerException
+    {
+        String projectName = "TestManagedProjectOne";
+        String description = "A test project.";
+        String groupId = "org.finos.sdlc.test";
+        String artifactId = "testprojone";
+        List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
+
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
+
+        Assert.assertNotNull(createdProject);
+        Assert.assertEquals(projectName, createdProject.getName());
+        Assert.assertEquals(description, createdProject.getDescription());
+        Assert.assertNull(createdProject.getProjectType());
+        Assert.assertEquals(Sets.mutable.withAll(tags), Sets.mutable.withAll(createdProject.getTags()));
+
+        String projectId = createdProject.getProjectId();
+        Assert.assertNotNull(projectId);
+
+        Assert.assertEquals(ProjectType.MANAGED, gitLabProjectApi.getProjectConfiguration(projectId).getProjectType());
+        Assert.assertNull(gitLabProjectApi.getProject(projectId).getProjectType());
+        Assert.assertNotNull(gitLabProjectApi.getProjectConfiguration(projectId).getProjectStructureVersion().getExtensionVersion());
+
+        Assert.assertEquals(Sets.mutable.with("/project.json",
+                "/PANGRAM.TXT",
+                "/pom.xml",
+                "/testprojone-entities/pom.xml",
+                "/testprojone-entities/src/test/java/org/finos/legend/sdlc/EntityValidationTest.java",
+                "/testprojone-file-generation/pom.xml",
+                "/testprojone-service-execution/pom.xml",
+                "/testprojone-versioned-entities/pom.xml"
+        ), gitLabProjectApi.getProjectFileAccessProvider().getProjectFileAccessContext(projectId).getFiles().map(ProjectFileAccessProvider.ProjectFile::getPath).collect(Collectors.toSet()));
+    }
+
+    public void runCreateProductionProjectTest() throws LegendSDLCServerException
+    {
+        String projectName = "TestProductionProjectOne";
+        String description = "A test project.";
+        String groupId = "org.finos.sdlc.test";
+        String artifactId = "testprojone";
+        List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
+
+        LegendSDLCServerException e = Assert.assertThrows(LegendSDLCServerException.class, () -> gitLabProjectApi.createProject(projectName, description, ProjectType.PRODUCTION, groupId, artifactId, tags));
+        Assert.assertEquals("Invalid type: PRODUCTION", e.getMessage());
+    }
+
+    public void runCreateEmbeddedProjectTest() throws LegendSDLCServerException
+    {
+        String projectName = "TestEmbeddedProjectOne";
+        String description = "A test project.";
+        String groupId = "org.finos.sdlc.test";
+        String artifactId = "testprojone";
+        List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
+
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.EMBEDDED, groupId, artifactId, tags);
+
+        Assert.assertNotNull(createdProject);
+        Assert.assertEquals(projectName, createdProject.getName());
+        Assert.assertEquals(description, createdProject.getDescription());
+        Assert.assertNull(createdProject.getProjectType());
+        Assert.assertEquals(Sets.mutable.withAll(tags), Sets.mutable.withAll(createdProject.getTags()));
+
+        String projectId = createdProject.getProjectId();
+        Assert.assertNotNull(projectId);
+
+        Assert.assertEquals(ProjectType.EMBEDDED, gitLabProjectApi.getProjectConfiguration(projectId).getProjectType());
+        Assert.assertNull(gitLabProjectApi.getProject(projectId).getProjectType());
+        Assert.assertNull(gitLabProjectApi.getProjectConfiguration(projectId).getProjectStructureVersion().getExtensionVersion());
+
+        Assert.assertEquals(Sets.mutable.with("/project.json"
+        ), gitLabProjectApi.getProjectFileAccessProvider().getProjectFileAccessContext(projectId).getFiles().map(ProjectFileAccessProvider.ProjectFile::getPath).collect(Collectors.toSet()));
     }
 
     public void runGetProjectTest() throws LegendSDLCServerException
@@ -60,7 +156,7 @@ public class GitLabProjectApiTestResource
         String artifactId = "testprojtwo";
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         Assert.assertNotNull(createdProject);
         Assert.assertEquals(projectName, createdProject.getName());
@@ -84,7 +180,7 @@ public class GitLabProjectApiTestResource
         String artifactId = "testprojthree";
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         Assert.assertNotNull(createdProject);
         Assert.assertEquals(projectName, createdProject.getName());

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectConfigurationApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectConfigurationApiTestResource.java
@@ -17,6 +17,7 @@ package org.finos.legend.sdlc.server.gitlab.api;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.sdlc.domain.model.project.Project;
+import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.finos.legend.sdlc.server.gitlab.api.server.AbstractGitLabServerApiTest;
@@ -55,7 +56,7 @@ public class GitLabProjectConfigurationApiTestResource
         String workspaceOneId = "testworkspaceone";
         String workspaceTwoId = "testworkspacetwo";
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         Assert.assertNotNull(createdProject);
         Assert.assertEquals(projectName, createdProject.getName());
@@ -74,7 +75,7 @@ public class GitLabProjectConfigurationApiTestResource
         ProjectConfiguration projectConfiguration = gitLabProjectConfigurationApi.getUserWorkspaceProjectConfiguration(projectId, workspaceOneId);
 
         Assert.assertNotNull(projectConfiguration);
-        Assert.assertNull(projectConfiguration.getProjectType());
+        Assert.assertEquals(ProjectType.MANAGED, projectConfiguration.getProjectType());
         Assert.assertEquals(projectConfiguration.getArtifactId(), artifactId);
         Assert.assertEquals(projectConfiguration.getGroupId(), groupId);
 

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabRevisionApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabRevisionApiTestResource.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.impl.factory.Maps;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 import org.finos.legend.sdlc.domain.model.project.Project;
+import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.server.gitlab.api.server.AbstractGitLabServerApiTest;
@@ -58,7 +59,7 @@ public class GitLabRevisionApiTestResource
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
         String workspaceOneId = "testworkspaceone";
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         Assert.assertNotNull(createdProject);
         Assert.assertEquals(projectName, createdProject.getName());
@@ -149,7 +150,7 @@ public class GitLabRevisionApiTestResource
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
         String workspaceOneId = "testworkspaceone";
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         Assert.assertNotNull(createdProject);
         Assert.assertEquals(projectName, createdProject.getName());

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabWorkspaceApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabWorkspaceApiTestResource.java
@@ -19,6 +19,7 @@ import org.eclipse.collections.api.factory.Sets;
 import org.eclipse.collections.impl.factory.Maps;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 import org.finos.legend.sdlc.domain.model.project.Project;
+import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.review.Review;
@@ -76,7 +77,7 @@ public class GitLabWorkspaceApiTestResource
         String workspaceTwoId = "testworkspacetwo";
         String workspaceThreeId = "testworkspacethree";
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         Assert.assertNotNull(createdProject);
         Assert.assertEquals(projectName, createdProject.getName());
@@ -154,7 +155,7 @@ public class GitLabWorkspaceApiTestResource
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
         String workspaceName = "workspaceone";
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         String projectId = createdProject.getProjectId();
         Workspace createdWorkspace = gitLabWorkspaceApi.newUserWorkspace(projectId, workspaceName);
@@ -291,7 +292,7 @@ public class GitLabWorkspaceApiTestResource
         List<String> tags = Lists.mutable.with("doe", "moffitt", AbstractGitLabServerApiTest.INTEGRATION_TEST_PROJECT_TAG);
         String workspaceName = "workspaceone";
 
-        Project createdProject = gitLabProjectApi.createProject(projectName, description, groupId, artifactId, tags);
+        Project createdProject = gitLabProjectApi.createProject(projectName, description, ProjectType.MANAGED, groupId, artifactId, tags);
 
         String projectId = createdProject.getProjectId();
         Workspace createdWorkspace = gitLabWorkspaceApi.newGroupWorkspace(projectId, workspaceName);

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/docker/IntegrationTestGitLabProjectApis.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/docker/IntegrationTestGitLabProjectApis.java
@@ -19,9 +19,17 @@ import org.finos.legend.sdlc.server.gitlab.GitLabConfiguration;
 import org.finos.legend.sdlc.server.gitlab.api.GitLabProjectApi;
 import org.finos.legend.sdlc.server.gitlab.api.GitLabProjectApiTestResource;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabUserContext;
+import org.finos.legend.sdlc.server.project.ProjectStructure;
 import org.finos.legend.sdlc.server.project.config.ProjectStructureConfiguration;
+import org.finos.legend.sdlc.server.project.extension.DefaultProjectStructureExtension;
+import org.finos.legend.sdlc.server.project.extension.DefaultProjectStructureExtensionProvider;
+import org.finos.legend.sdlc.server.project.extension.ProjectStructureExtension;
+import org.finos.legend.sdlc.server.project.extension.ProjectStructureExtensionProvider;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 public class IntegrationTestGitLabProjectApis extends AbstractGitLabApiTest
 {
@@ -37,6 +45,24 @@ public class IntegrationTestGitLabProjectApis extends AbstractGitLabApiTest
     public void testCreateProject() throws LegendSDLCServerException
     {
         gitLabProjectApiTestResource.runCreateProjectTest();
+    }
+
+    @Test
+    public void testCreateManagedProject() throws LegendSDLCServerException
+    {
+        gitLabProjectApiTestResource.runCreateManagedProjectTest();
+    }
+
+    @Test
+    public void testCreateEmbeddedProject() throws LegendSDLCServerException
+    {
+        gitLabProjectApiTestResource.runCreateEmbeddedProjectTest();
+    }
+
+    @Test
+    public void testCreateProductionProject() throws LegendSDLCServerException
+    {
+        gitLabProjectApiTestResource.runCreateProductionProjectTest();
     }
 
     @Test
@@ -58,11 +84,17 @@ public class IntegrationTestGitLabProjectApis extends AbstractGitLabApiTest
      */
     private static void setUpProjectApi() throws LegendSDLCServerException
     {
+        int projectStructureVersion = ProjectStructure.getLatestProjectStructureVersion();
+        int projectStructureExtensionVersion = 1;
+        ProjectStructureExtension extension = DefaultProjectStructureExtension.newProjectStructureExtension(projectStructureVersion, projectStructureExtensionVersion, Collections.singletonMap("/PANGRAM.TXT", "THE QUICK BROWN FOX JUMPED OVER THE LAZY DOG"));
+        List<ProjectStructureExtension> extensions = Collections.singletonList(extension);
+        ProjectStructureExtensionProvider extensionProvider = DefaultProjectStructureExtensionProvider.fromExtensions(extensions);
+
         GitLabConfiguration gitLabConfig = GitLabConfiguration.newGitLabConfiguration(null, null, null, null, null, null);
-        ProjectStructureConfiguration projectStructureConfig = ProjectStructureConfiguration.emptyConfiguration();
+        ProjectStructureConfiguration projectStructureConfig = ProjectStructureConfiguration.newConfiguration(null, extensionProvider, null,null, null,null);
         GitLabUserContext gitLabUserContext = prepareGitLabOwnerUserContext();
 
-        GitLabProjectApi gitLabProjectApi = new GitLabProjectApi(gitLabConfig, gitLabUserContext, projectStructureConfig, null, backgroundTaskProcessor, null);
+        GitLabProjectApi gitLabProjectApi = new GitLabProjectApi(gitLabConfig, gitLabUserContext, projectStructureConfig, extensionProvider, backgroundTaskProcessor, null);
         gitLabProjectApiTestResource = new GitLabProjectApiTestResource(gitLabProjectApi);
     }
 }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/server/TestGitLabServerProjectApis.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/server/TestGitLabServerProjectApis.java
@@ -19,10 +19,18 @@ import org.finos.legend.sdlc.server.gitlab.GitLabConfiguration;
 import org.finos.legend.sdlc.server.gitlab.api.GitLabProjectApi;
 import org.finos.legend.sdlc.server.gitlab.api.GitLabProjectApiTestResource;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabUserContext;
+import org.finos.legend.sdlc.server.project.ProjectStructure;
 import org.finos.legend.sdlc.server.project.config.ProjectStructureConfiguration;
+import org.finos.legend.sdlc.server.project.extension.DefaultProjectStructureExtension;
+import org.finos.legend.sdlc.server.project.extension.DefaultProjectStructureExtensionProvider;
+import org.finos.legend.sdlc.server.project.extension.ProjectStructureExtension;
+import org.finos.legend.sdlc.server.project.extension.ProjectStructureExtensionProvider;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 public class TestGitLabServerProjectApis extends AbstractGitLabServerApiTest
 {
@@ -51,6 +59,24 @@ public class TestGitLabServerProjectApis extends AbstractGitLabServerApiTest
     }
 
     @Test
+    public void testCreateManagedProject() throws LegendSDLCServerException
+    {
+        gitLabProjectApiTestResource.runCreateManagedProjectTest();
+    }
+
+    @Test
+    public void testCreateEmbeddedProject() throws LegendSDLCServerException
+    {
+        gitLabProjectApiTestResource.runCreateEmbeddedProjectTest();
+    }
+
+    @Test
+    public void testCreateProductionProject() throws LegendSDLCServerException
+    {
+        gitLabProjectApiTestResource.runCreateProductionProjectTest();
+    }
+
+    @Test
     public void testGetProject() throws LegendSDLCServerException
     {
         gitLabProjectApiTestResource.runGetProjectTest();
@@ -69,11 +95,17 @@ public class TestGitLabServerProjectApis extends AbstractGitLabServerApiTest
      */
     private static void setUpProjectApi() throws LegendSDLCServerException
     {
+        int projectStructureVersion = ProjectStructure.getLatestProjectStructureVersion();
+        int projectStructureExtensionVersion = 1;
+        ProjectStructureExtension extension = DefaultProjectStructureExtension.newProjectStructureExtension(projectStructureVersion, projectStructureExtensionVersion, Collections.singletonMap("/PANGRAM.TXT", "THE QUICK BROWN FOX JUMPED OVER THE LAZY DOG"));
+        List<ProjectStructureExtension> extensions = Collections.singletonList(extension);
+        ProjectStructureExtensionProvider extensionProvider = DefaultProjectStructureExtensionProvider.fromExtensions(extensions);
+
         GitLabConfiguration gitLabConfig = GitLabConfiguration.newGitLabConfiguration(null, null, null, null, null, GitLabConfiguration.NewProjectVisibility.PRIVATE);
-        ProjectStructureConfiguration projectStructureConfig = ProjectStructureConfiguration.emptyConfiguration();
+        ProjectStructureConfiguration projectStructureConfig = ProjectStructureConfiguration.newConfiguration(null, extensionProvider, null,null, null,null);
         GitLabUserContext gitLabUserContext = prepareGitLabOwnerUserContext();
 
-        GitLabProjectApi gitLabProjectApi = new GitLabProjectApi(gitLabConfig, gitLabUserContext, projectStructureConfig, null, backgroundTaskProcessor, null);
+        GitLabProjectApi gitLabProjectApi = new GitLabProjectApi(gitLabConfig, gitLabUserContext, projectStructureConfig, extensionProvider, backgroundTaskProcessor, null);
         gitLabProjectApiTestResource = new GitLabProjectApiTestResource(gitLabProjectApi);
     }
 }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryProjectApi.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/inmemory/backend/api/InMemoryProjectApi.java
@@ -16,6 +16,7 @@ package org.finos.legend.sdlc.server.inmemory.backend.api;
 
 import org.eclipse.collections.api.factory.Lists;
 import org.finos.legend.sdlc.domain.model.project.Project;
+import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.accessRole.AccessRole;
 import org.finos.legend.sdlc.domain.model.project.accessRole.AuthorizableProjectAction;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectApi;
@@ -53,7 +54,7 @@ public class InMemoryProjectApi implements ProjectApi
     }
 
     @Override
-    public Project createProject(String name, String description, String groupId, String artifactId, Iterable<String> tags)
+    public Project createProject(String name, String description, ProjectType type, String groupId, String artifactId, Iterable<String> tags)
     {
         throw new UnsupportedOperationException("Not implemented");
     }
@@ -107,7 +108,7 @@ public class InMemoryProjectApi implements ProjectApi
     }
 
     @Override
-    public ImportReport importProject(String id, String groupId, String artifactId)
+    public ImportReport importProject(String id, ProjectType type, String groupId, String artifactId)
     {
         throw new UnsupportedOperationException("Not implemented");
     }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureStaticMethods.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructureStaticMethods.java
@@ -17,6 +17,7 @@ package org.finos.legend.sdlc.server.project;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.set.primitive.ImmutableIntSet;
 import org.eclipse.collections.impl.factory.primitive.IntSets;
+import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectStructureVersion;
@@ -160,6 +161,6 @@ public class TestProjectStructureStaticMethods
         Assert.assertEquals(0, config.getProjectStructureVersion().getVersion());
         Assert.assertNull(config.getProjectStructureVersion().getExtensionVersion());
         Assert.assertEquals(projectId, config.getProjectId());
-        Assert.assertNull(config.getProjectType());
+        Assert.assertEquals(ProjectType.MANAGED, config.getProjectType());
     }
 }


### PR DESCRIPTION
* For MANAGED projects functionality as is.
* For EMBEDDED projects do not create pom.xml files or trigger files created by extensions.
* For EMBEDDED disallow setting extensions version.
* Allow converting between EMBEDDED and MANAGED and vice versa.

