### PR TITLE
Allow parallel generation of service execution artifacts

### DIFF
--- a/legend-sdlc-generation-service-maven-plugin/pom.xml
+++ b/legend-sdlc-generation-service-maven-plugin/pom.xml
@@ -27,13 +27,6 @@
     <name>Legend SDLC Service Generation Maven Plugin</name>
 
     <dependencies>
-        <!-- PURE -->
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-pure-code-compiled-core</artifactId>
-        </dependency>
-        <!-- PURE -->
-
         <!-- ENGINE -->
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -141,6 +134,12 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
@@ -155,6 +154,10 @@
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.bouncycastle</groupId>

--- a/legend-sdlc-generation-service-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/service/ServicesGenerationMojo.java
+++ b/legend-sdlc-generation-service-maven-plugin/src/main/java/org/finos/legend/sdlc/generation/service/ServicesGenerationMojo.java
@@ -28,16 +28,14 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.factory.Lists;
-import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.factory.Maps;
+import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
-import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.engine.protocol.pure.v1.PureProtocolObjectMapperFactory;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;
-import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
 import org.finos.legend.sdlc.language.pure.compiler.toPureGraph.PureModelBuilder;
 import org.finos.legend.sdlc.protocol.pure.v1.EntityToPureConverter;
@@ -47,13 +45,16 @@ import org.finos.legend.sdlc.tools.entity.EntityPaths;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.lang.model.SourceVersion;
 
-@Mojo(name = "generate-service-executions", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
+@Mojo(name = "generate-service-executions", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = false)
 public class ServicesGenerationMojo extends AbstractMojo
 {
     @Parameter
@@ -76,6 +77,9 @@ public class ServicesGenerationMojo extends AbstractMojo
 
     @Parameter(defaultValue = "${project}", readonly = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "${org.finos.legend.sdlc.generation.service.parallel}")
+    private String parallel;
 
     @Override
     public void execute() throws MojoExecutionException
@@ -100,6 +104,9 @@ public class ServicesGenerationMojo extends AbstractMojo
         {
             throw new MojoExecutionException("Invalid package prefix: " + this.packagePrefix);
         }
+
+        int parallelism = getParallelism();
+        getLog().info("parallelism: " + parallelism);
 
         getLog().info("Loading model");
         long modelStart = System.nanoTime();
@@ -137,46 +144,24 @@ public class ServicesGenerationMojo extends AbstractMojo
         long modelEnd = System.nanoTime();
         getLog().info(String.format("Finished loading model (%.9fs)", (modelEnd - modelStart) / 1_000_000_000.0));
 
-        JsonMapper jsonMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
-                .enable(SerializationFeature.INDENT_OUTPUT)
-                .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
-                .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
-                .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
-                .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
-                .serializationInclusion(JsonInclude.Include.NON_NULL)
-                .build());
-
         long start = System.nanoTime();
-        Map<String, Service> servicesByPath = pureModelContextData.getElementsOfType(Service.class).stream().collect(Collectors.toMap(PackageableElement::getPath, el -> el));
+        MutableMap<String, Service> servicesByPath = Maps.mutable.empty();
+        pureModelContextData.getElements().forEach(e ->
+        {
+            if (e instanceof Service)
+            {
+                String path = e.getPath();
+                Service old = servicesByPath.put(path, (Service) e);
+                if (old != null)
+                {
+                    throw new RuntimeException("Multiple services for path '" + path + "'");
+                }
+            }
+        });
         filterServicesByIncludes(servicesByPath);
         filterServicesByExcludes(servicesByPath);
-        if (servicesByPath.isEmpty())
-        {
-            getLog().info("Found 0 services for generation");
-        }
-        else if (getLog().isInfoEnabled())
-        {
-            getLog().info(servicesByPath.keySet().stream().sorted().collect(Collectors.joining(", ", "Found " + servicesByPath.size() + " services for generation: ", "")));
-        }
 
-        for (Service service : servicesByPath.values())
-        {
-            getLog().info("Generating execution artifacts for " + service.getPath());
-            long serviceStart = System.nanoTime();
-            try
-            {
-                MutableList<PlanGeneratorExtension> extensions = Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class));
-                RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions = extensions.flatCollect(e -> e.getExtraExtensions(pureModel));
-                MutableList<PlanTransformer> planTransformers = extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers);
-                ServiceExecutionGenerator.newGenerator(service, pureModel, this.packagePrefix, this.javaSourceOutputDirectory.toPath(), this.resourceOutputDirectory.toPath(), jsonMapper, routerExtensions, planTransformers, null).generate();
-            }
-            catch (Exception e)
-            {
-                throw new MojoExecutionException("Error generating execution artifacts for " + service.getPath(), e);
-            }
-            long serviceEnd = System.nanoTime();
-            getLog().info(String.format("Finished generating execution artifacts for %s (%.9fs)", service.getPath(), (serviceEnd - serviceStart) / 1_000_000_000.0));
-        }
+        generateServices(servicesByPath, pureModel, parallelism);
 
         if (this.addJavaSourceOutputDirectoryAsSource)
         {
@@ -189,9 +174,9 @@ public class ServicesGenerationMojo extends AbstractMojo
         getLog().info(String.format("Finished generating execution artifacts for %d services (%.9fs)", servicesByPath.size(), (end - start) / 1_000_000_000.0));
     }
 
-    private void filterServicesByIncludes(Map<String, Service> servicesByPath) throws MojoExecutionException
+    private void filterServicesByIncludes(MutableMap<String, Service> servicesByPath) throws MojoExecutionException
     {
-        if (this.inclusions != null)
+        if ((this.inclusions != null) && servicesByPath.notEmpty())
         {
             ResolvedServicesSpecification resolvedIncluded;
             try
@@ -202,17 +187,17 @@ public class ServicesGenerationMojo extends AbstractMojo
             {
                 throw new MojoExecutionException("Error resolving included services", e);
             }
-            servicesByPath.keySet().removeIf(resolvedIncluded::notMatches);
-            if ((resolvedIncluded.servicePaths != null) && resolvedIncluded.servicePaths.stream().anyMatch(p -> !servicesByPath.containsKey(p)))
+            servicesByPath.removeIf((path, service) -> resolvedIncluded.notMatches(path));
+            if ((resolvedIncluded.servicePaths != null) && Iterate.anySatisfy(resolvedIncluded.servicePaths, p -> !servicesByPath.containsKey(p)))
             {
-                throw new MojoExecutionException(resolvedIncluded.servicePaths.stream().filter(p -> !servicesByPath.containsKey(p)).sorted().collect(Collectors.joining(", ", "Could not find included services: ", "")));
+                throw new MojoExecutionException(Iterate.reject(resolvedIncluded.servicePaths, servicesByPath::containsKey, Lists.mutable.empty()).sortThis().makeString(", ", "Could not find included services: ", ""));
             }
         }
     }
 
-    private void filterServicesByExcludes(Map<String, Service> servicesByPath) throws MojoExecutionException
+    private void filterServicesByExcludes(MutableMap<String, Service> servicesByPath) throws MojoExecutionException
     {
-        if ((this.exclusions != null) && !servicesByPath.isEmpty())
+        if ((this.exclusions != null) && servicesByPath.notEmpty())
         {
             ResolvedServicesSpecification resolvedExcluded;
             try
@@ -223,8 +208,87 @@ public class ServicesGenerationMojo extends AbstractMojo
             {
                 throw new MojoExecutionException("Error resolving excluded services", e);
             }
-            servicesByPath.keySet().removeIf(resolvedExcluded::matches);
+            servicesByPath.removeIf((path, service) -> resolvedExcluded.matches(path));
         }
+    }
+
+    private void generateServices(MutableMap<String, Service> servicesByPath, PureModel pureModel, int parallelism)
+    {
+        if (servicesByPath.isEmpty())
+        {
+            getLog().info("Found 0 services for generation");
+            return;
+        }
+
+        if (getLog().isInfoEnabled())
+        {
+            getLog().info(Lists.mutable.withAll(servicesByPath.keySet()).toSortedList().makeString("Found " + servicesByPath.size() + " services for generation: ", ", ", ""));
+        }
+
+        JsonMapper jsonMapper = PureProtocolObjectMapperFactory.withPureProtocolExtensions(JsonMapper.builder()
+                .enable(SerializationFeature.INDENT_OUTPUT)
+                .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+                .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+                .disable(StreamWriteFeature.AUTO_CLOSE_TARGET)
+                .disable(StreamReadFeature.AUTO_CLOSE_SOURCE)
+                .serializationInclusion(JsonInclude.Include.NON_NULL)
+                .build());
+
+        int effectiveParallelism = Math.min(parallelism, servicesByPath.size());
+        ForkJoinPool pool;
+        if (effectiveParallelism > 1)
+        {
+            getLog().info("Generating services in parallel with parallelism level " + effectiveParallelism);
+            pool = createForkJoinPool(effectiveParallelism);
+        }
+        else
+        {
+            pool = null;
+        }
+        try
+        {
+            ServiceExecutionGenerator.newBuilder()
+                    .withServices(servicesByPath.values())
+                    .withPureModel(pureModel)
+                    .withPackagePrefix(this.packagePrefix)
+                    .withOutputDirectories(this.javaSourceOutputDirectory.toPath(), this.resourceOutputDirectory.toPath())
+                    .withJsonMapper(jsonMapper)
+                    .withPlanGeneratorExtensions(ServiceLoader.load(PlanGeneratorExtension.class))
+                    .withExecutorService(pool)
+                    .build()
+                    .generate();
+        }
+        finally
+        {
+            if (pool != null)
+            {
+                pool.shutdown();
+            }
+        }
+    }
+
+    private int getParallelism()
+    {
+        int parallelism = parseParallel(this.parallel);
+        if (parallelism < 1)
+        {
+            getLog().warn("Specified parallelism is less than 1 (" + parallelism + "), effective parallelism will be 1");
+            return 1;
+        }
+        return parallelism;
+    }
+
+    private ForkJoinPool createForkJoinPool(int parallelism)
+    {
+        // We have to create a custom fork join thread worker factory to ensure the worker threads use this thread's
+        // context class loader. This is why we cannot use the common pool.
+        return new ForkJoinPool(
+                parallelism,
+                pool -> new ForkJoinWorkerThread(pool)
+                {
+                },
+                null,
+                false);
     }
 
     private static ResolvedServicesSpecification resolveServicesSpecification(ServicesSpecification servicesSpec) throws Exception
@@ -271,7 +335,7 @@ public class ServicesGenerationMojo extends AbstractMojo
         private ResolvedServicesSpecification(Set<String> servicePaths, Set<String> packages)
         {
             this.servicePaths = servicePaths;
-            this.packages = (packages == null) ? null : Iterate.collect(packages, p -> p + EntityPaths.PACKAGE_SEPARATOR, Lists.mutable.ofInitialCapacity(packages.size()))
+            this.packages = (packages == null) ? null : Iterate.collect(packages, p -> p.endsWith(EntityPaths.PACKAGE_SEPARATOR) ? p : (p + EntityPaths.PACKAGE_SEPARATOR), Lists.mutable.ofInitialCapacity(packages.size()))
                     .sortThis(Comparator.comparingInt(String::length).thenComparing(Comparator.naturalOrder()));
         }
 
@@ -292,12 +356,89 @@ public class ServicesGenerationMojo extends AbstractMojo
 
         private boolean inSomePackage(String servicePath)
         {
-            return this.packages.anySatisfy(servicePath::startsWith);
+            int lastSeparator = servicePath.lastIndexOf(EntityPaths.PACKAGE_SEPARATOR);
+            int pkgLen = (lastSeparator == -1) ? 0 : lastSeparator + EntityPaths.PACKAGE_SEPARATOR.length();
+            for (String pkg : this.packages)
+            {
+                if (servicePath.startsWith(pkg))
+                {
+                    return true;
+                }
+                if (pkg.length() > pkgLen)
+                {
+                    return false;
+                }
+            }
+            return false;
         }
 
         boolean notMatches(String servicePath)
         {
             return !matches(servicePath);
         }
+    }
+
+    // package private for testing
+    static int parseParallel(String parallel)
+    {
+        if ((parallel == null) || parallel.isEmpty())
+        {
+            return 1;
+        }
+
+        Pattern pattern = Pattern.compile("\\s*((?<true>true)|(?<false>false)|(?<integer>[+-]?\\d+)|(?<cpu>((?<cpux>\\d+(\\.\\d+)?)\\s*)?C(\\s*(?<cpupm>[+-])\\s*(?<cpua>\\d+))?))?\\s*", Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(parallel);
+        if (!matcher.matches())
+        {
+            throw new RuntimeException("Could not parse parallel value: \"" + parallel + "\"");
+        }
+        if (matcher.group("true") != null)
+        {
+            // by default, we use the number of available processors minus 1
+            return Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
+        }
+        if (matcher.group("false") != null)
+        {
+            return 1;
+        }
+        String integer = matcher.group("integer");
+        if (integer != null)
+        {
+            try
+            {
+                return Integer.parseInt(integer);
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Could not parse parallel value: \"" + parallel + "\"", e);
+            }
+        }
+        if (matcher.group("cpu") != null)
+        {
+            int parallelism = Runtime.getRuntime().availableProcessors();
+            try
+            {
+                String multiplier = matcher.group("cpux");
+                if (multiplier != null)
+                {
+                    parallelism = Math.round(Float.parseFloat(multiplier) * parallelism);
+                }
+
+                String addendum = matcher.group("cpua");
+                if (addendum != null)
+                {
+                    int toAdd = Integer.parseInt(addendum);
+                    parallelism += "-".equals(matcher.group("cpupm")) ? -toAdd : toAdd;
+                }
+            }
+            catch (Exception e)
+            {
+                throw new RuntimeException("Could not parse parallel value: \"" + parallel + "\"", e);
+            }
+            return parallelism;
+        }
+
+        // only whitespace
+        return 1;
     }
 }

--- a/legend-sdlc-generation-service-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/service/TestServicesGenerationMojo.java
+++ b/legend-sdlc-generation-service-maven-plugin/src/test/java/org/finos/legend/sdlc/generation/service/TestServicesGenerationMojo.java
@@ -29,6 +29,7 @@ import org.finos.legend.sdlc.serialization.EntityLoader;
 import org.finos.legend.sdlc.serialization.EntitySerializers;
 import org.finos.legend.sdlc.tools.entity.EntityPaths;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -58,8 +59,8 @@ public class TestServicesGenerationMojo
     private static final String GOAL = "generate-service-executions";
     private static final String SERVICE_CLASSIFIER = "meta::legend::service::metamodel::Service";
 
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
+    @ClassRule
+    public static TemporaryFolder TMP_FOLDER = new TemporaryFolder();
 
     @Rule
     public MojoRule mojoRule = new MojoRule();
@@ -67,8 +68,8 @@ public class TestServicesGenerationMojo
     @Test
     public void testEmptyEntitiesDirectory() throws Exception
     {
-        File[] emptyEntityDirs = {this.tempFolder.newFolder("empty1"), this.tempFolder.newFolder("empty2")};
-        File projectDir = buildSingleModuleProject("project", "org.finos.test", "test-project", "1.0.0", null, null, emptyEntityDirs, null, null, null, "org.finos.test.test_project", null, null);
+        File[] emptyEntityDirs = {TMP_FOLDER.newFolder(), TMP_FOLDER.newFolder()};
+        File projectDir = buildSingleModuleProject("org.finos.test", "test-project", "1.0.0", null, null, emptyEntityDirs, null, null, null, "org.finos.test.test_project", null, null);
 
         MavenProject mavenProject = this.mojoRule.readMavenProject(projectDir);
 
@@ -81,9 +82,9 @@ public class TestServicesGenerationMojo
     @Test
     public void testNonExistentEntitiesDirectory() throws Exception
     {
-        File tempPath = this.tempFolder.getRoot();
+        File tempPath = TMP_FOLDER.newFolder();
         File[] nonExistentEntityDirectories = {new File(tempPath, "nonexistent1"), new File(tempPath, "nonexistent2")};
-        File projectDir = buildSingleModuleProject("project", "org.finos.test", "test-project", "1.0.0", null, null, nonExistentEntityDirectories, null, null, null, "org.finos.test.test_project", null, null);
+        File projectDir = buildSingleModuleProject("org.finos.test", "test-project", "1.0.0", null, null, nonExistentEntityDirectories, null, null, null, "org.finos.test.test_project", null, null);
 
         MavenProject mavenProject = this.mojoRule.readMavenProject(projectDir);
 
@@ -96,14 +97,14 @@ public class TestServicesGenerationMojo
     @Test
     public void testNoServices() throws Exception
     {
-        File entitiesDir = this.tempFolder.newFolder("testEntities");
+        File entitiesDir = TMP_FOLDER.newFolder();
         try (EntityLoader testEntities = getTestEntities())
         {
             testEntities.getAllEntities()
                     .filter(e -> !isServiceEntity(e))
                     .forEach(e -> writeEntityToDirectory(entitiesDir.toPath(), e));
         }
-        File projectDir = buildSingleModuleProject("project", "org.finos.test", "test-project", "1.0.0", null, null, new File[]{entitiesDir}, null, null, null, "org.finos.test.test_project", null, null);
+        File projectDir = buildSingleModuleProject("org.finos.test", "test-project", "1.0.0", null, null, new File[]{entitiesDir}, null, null, null, "org.finos.test.test_project", null, null);
 
         MavenProject mavenProject = this.mojoRule.readMavenProject(projectDir);
 
@@ -117,7 +118,7 @@ public class TestServicesGenerationMojo
     public void testWithServices() throws Exception
     {
         String packagePrefix = "org.finos.test.test_project";
-        File entitiesDir = this.tempFolder.newFolder("testEntities");
+        File entitiesDir = TMP_FOLDER.newFolder();
         List<Entity> entities;
         try (EntityLoader testEntities = getTestEntities())
         {
@@ -125,7 +126,7 @@ public class TestServicesGenerationMojo
         }
         Assert.assertEquals(5, entities.stream().filter(this::isServiceEntity).count());
         entities.forEach(e -> writeEntityToDirectory(entitiesDir.toPath(), e));
-        File projectDir = buildSingleModuleProject("project", "org.finos.test", "test-project", "1.0.0", null, null, new File[]{entitiesDir}, null, null, null, packagePrefix, null, null);
+        File projectDir = buildSingleModuleProject("org.finos.test", "test-project", "1.0.0", null, null, new File[]{entitiesDir}, null, null, null, packagePrefix, null, null);
 
         MavenProject mavenProject = this.mojoRule.readMavenProject(projectDir);
 
@@ -143,6 +144,68 @@ public class TestServicesGenerationMojo
         MutableList<String> expectedServiceClassJavaPaths = ListIterate.collectIf(entities, this::isServiceEntity, e ->  packagePrefix.replace(".", separator) + separator + e.getPath().replace(EntityPaths.PACKAGE_SEPARATOR, separator) + ".java");
         Set<String> actualGeneratedSourceFiles = getFileStream(generatedSourceDir, true).map(Path::toString).collect(Collectors.toSet());
         Assert.assertEquals(Collections.emptyList(), expectedServiceClassJavaPaths.reject(actualGeneratedSourceFiles::contains));
+    }
+
+    @Test
+    public void testParseParallel()
+    {
+        int procCount = Runtime.getRuntime().availableProcessors();
+
+        // Null, empty, whitespace
+        Assert.assertEquals(1, ServicesGenerationMojo.parseParallel(null));
+        Assert.assertEquals(1, ServicesGenerationMojo.parseParallel(""));
+        Assert.assertEquals(1, ServicesGenerationMojo.parseParallel("   \r\t\n  \r\n \n\r "));
+
+        // Integers
+        for (int i = 0; i < 256; i++)
+        {
+            String s = Integer.toString(i);
+            Assert.assertEquals(s, i, ServicesGenerationMojo.parseParallel(s));
+            Assert.assertEquals(s, i, ServicesGenerationMojo.parseParallel("+" + s));
+            Assert.assertEquals(s, -i, ServicesGenerationMojo.parseParallel("-" + s));
+            Assert.assertEquals(s, i, ServicesGenerationMojo.parseParallel("00000000" + s));
+            Assert.assertEquals(s, i, ServicesGenerationMojo.parseParallel("    " + s + "    "));
+        }
+
+        // False
+        Assert.assertEquals(1, ServicesGenerationMojo.parseParallel("false"));
+        Assert.assertEquals(1, ServicesGenerationMojo.parseParallel("FALSE"));
+        Assert.assertEquals(1, ServicesGenerationMojo.parseParallel("False"));
+        Assert.assertEquals(1, ServicesGenerationMojo.parseParallel("FaLsE"));
+        Assert.assertEquals(1, ServicesGenerationMojo.parseParallel(" false "));
+        Assert.assertEquals(1, ServicesGenerationMojo.parseParallel("   false "));
+
+        // True
+        int defaultParallelism = procCount - 1;
+        Assert.assertEquals(defaultParallelism, ServicesGenerationMojo.parseParallel("true"));
+        Assert.assertEquals(defaultParallelism, ServicesGenerationMojo.parseParallel("TRUE"));
+        Assert.assertEquals(defaultParallelism, ServicesGenerationMojo.parseParallel("True"));
+        Assert.assertEquals(defaultParallelism, ServicesGenerationMojo.parseParallel("TrUe"));
+        Assert.assertEquals(defaultParallelism, ServicesGenerationMojo.parseParallel(" true "));
+        Assert.assertEquals(defaultParallelism, ServicesGenerationMojo.parseParallel("   true "));
+
+        // Processor based
+        Assert.assertEquals(procCount, ServicesGenerationMojo.parseParallel("C"));
+        Assert.assertEquals(procCount, ServicesGenerationMojo.parseParallel("c"));
+        Assert.assertEquals(procCount, ServicesGenerationMojo.parseParallel(" C  "));
+        Assert.assertEquals(procCount, ServicesGenerationMojo.parseParallel("1.0C"));
+        Assert.assertEquals(procCount, ServicesGenerationMojo.parseParallel("1C"));
+        Assert.assertEquals(2 * procCount, ServicesGenerationMojo.parseParallel("2.0C"));
+        Assert.assertEquals(2 * procCount, ServicesGenerationMojo.parseParallel("2\tC"));
+        Assert.assertEquals(Math.round(2.5 * procCount), ServicesGenerationMojo.parseParallel("2.5C"));
+        Assert.assertEquals(Math.round(12.3 * procCount), ServicesGenerationMojo.parseParallel("12.3  C"));
+        Assert.assertEquals(procCount - 1, ServicesGenerationMojo.parseParallel("C-1"));
+        Assert.assertEquals(procCount - 1, ServicesGenerationMojo.parseParallel("C - 1"));
+        Assert.assertEquals(procCount + 1, ServicesGenerationMojo.parseParallel("C + 1"));
+        Assert.assertEquals(procCount + 2, ServicesGenerationMojo.parseParallel("C + 2"));
+        Assert.assertEquals(Math.round(2.5 * procCount) + 2, ServicesGenerationMojo.parseParallel("2.5C + 2"));
+        Assert.assertEquals(Math.round(3.5 * procCount) - 1, ServicesGenerationMojo.parseParallel("3.5c-1"));
+
+        for (String invalid : new String[]{"blah", "trueee", "null", "123.123", "2.5*C", "C / 5"})
+        {
+            RuntimeException e = Assert.assertThrows(RuntimeException.class, () -> ServicesGenerationMojo.parseParallel(invalid));
+            Assert.assertEquals(invalid, "Could not parse parallel value: \"" + invalid + "\"", e.getMessage());
+        }
     }
 
     private boolean isServiceEntity(Entity entity)
@@ -209,15 +272,15 @@ public class TestServicesGenerationMojo
         }
     }
 
-    private File buildSingleModuleProject(String projectDirName, String groupId, String artifactId, String version, Set<String> includePaths, Set<String> includePackages, File[] includeDirectories, Set<String> excludePaths, Set<String> excludePackages, File[] excludeDirectories, String packagePrefix, File javaSourceOutputDirectory, File resourceOutputDirectory) throws IOException
+    private File buildSingleModuleProject(String groupId, String artifactId, String version, Set<String> includePaths, Set<String> includePackages, File[] includeDirectories, Set<String> excludePaths, Set<String> excludePackages, File[] excludeDirectories, String packagePrefix, File javaSourceOutputDirectory, File resourceOutputDirectory) throws IOException
     {
         Model mavenModel = buildMavenModelWithPlugin(groupId, artifactId, version, includePaths, includePackages, includeDirectories, excludePaths, excludePackages, excludeDirectories, packagePrefix, javaSourceOutputDirectory, resourceOutputDirectory);
-        return buildProject(projectDirName, mavenModel);
+        return buildProject(mavenModel);
     }
 
-    private File buildProject(String projectDirName, Model mainModel, Model... childModels) throws IOException
+    private File buildProject(Model mainModel, Model... childModels) throws IOException
     {
-        File projectDir = this.tempFolder.newFolder(projectDirName);
+        File projectDir = TMP_FOLDER.newFolder();
         serializeMavenModel(projectDir, mainModel);
         for (Model childModel : childModels)
         {

--- a/legend-sdlc-generation-service/pom.xml
+++ b/legend-sdlc-generation-service/pom.xml
@@ -119,6 +119,11 @@
         <!-- SDLC -->
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/legend-sdlc-generation-shared/pom.xml
+++ b/legend-sdlc-generation-shared/pom.xml
@@ -31,6 +31,10 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
 
         <!-- TEST -->
         <dependency>

--- a/legend-sdlc-generation-shared/src/main/java/org/finos/legend/sdlc/generation/GeneratorTemplate.java
+++ b/legend-sdlc-generation-shared/src/main/java/org/finos/legend/sdlc/generation/GeneratorTemplate.java
@@ -19,7 +19,8 @@ import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.ObjectWrapper;
 import freemarker.template.Template;
-import freemarker.template.TemplateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -29,9 +30,12 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Objects;
 
 public class GeneratorTemplate
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GeneratorTemplate.class);
+
     private final Template template;
     private final ObjectWrapper objectWrapper;
 
@@ -43,41 +47,61 @@ public class GeneratorTemplate
 
     String generateText(Map<String, ?> parameters)
     {
+        LOGGER.debug("Starting generating text from {}", this.template.getName());
+        String text;
         try (StringWriter writer = new StringWriter())
         {
             this.template.process(parameters, writer, this.objectWrapper);
-            return writer.toString();
+            text = writer.toString();
         }
-        catch (IOException e)
+        catch (Exception e)
         {
-            throw new UncheckedIOException(e);
-        }
-        catch (TemplateException e)
-        {
+            LOGGER.error("Error generating text from {}", this.template.getName(), e);
+            if (e instanceof RuntimeException)
+            {
+                throw (RuntimeException) e;
+            }
+            if (e instanceof IOException)
+            {
+                throw new UncheckedIOException((IOException) e);
+            }
             throw new RuntimeException(e);
         }
+        LOGGER.debug("Finished generating text from {}", this.template.getName());
+        return text;
     }
 
     public static GeneratorTemplate fromResource(String resourceName)
     {
-        return new GeneratorTemplate(loadTemplateFromResource(resourceName));
+        return fromResource(resourceName, Thread.currentThread().getContextClassLoader());
     }
 
-    private static Template loadTemplateFromResource(String templateResource)
+    public static GeneratorTemplate fromResource(String resourceName, ClassLoader classLoader)
     {
-        URL templateURL = Thread.currentThread().getContextClassLoader().getResource(templateResource);
+        return new GeneratorTemplate(loadTemplateFromResource(resourceName, Objects.requireNonNull(classLoader, "class loader may not be null")));
+    }
+
+    private static Template loadTemplateFromResource(String templateResource, ClassLoader classLoader)
+    {
+        LOGGER.debug("Loading freemarker template '{}' in class loader {}", templateResource, classLoader);
+        URL templateURL = classLoader.getResource(templateResource);
         if (templateURL == null)
         {
-            throw new RuntimeException("Unable to find freemarker template '" + templateResource + "' on context classpath");
+            LOGGER.error("Unable to find freemarker template '{}' in class loader {}", templateResource, classLoader);
+            throw new RuntimeException("Unable to find freemarker template '" + templateResource + "'");
         }
+        Template template;
         try (Reader reader = new InputStreamReader(templateURL.openStream(), StandardCharsets.UTF_8))
         {
-            return new Template(templateResource, reader, new Configuration(Configuration.VERSION_2_3_30));
+            template = new Template(templateResource, reader, new Configuration(Configuration.VERSION_2_3_30));
         }
-        catch (IOException e)
+        catch (Exception e)
         {
-            throw new UncheckedIOException("Error loading freemarker template from " + templateResource, e);
+            LOGGER.error("Error loading freemarker template from '{}' ({})", templateResource, templateURL, e);
+            throw new RuntimeException("Error loading freemarker template from '" + templateResource + "'", e);
         }
+        LOGGER.debug("Finished loading freemarker template '{}' ({})", templateResource, templateURL);
+        return template;
     }
 
     private static ObjectWrapper newObjectWrapper()


### PR DESCRIPTION
Allow parallel generation of service execution artifacts. By default, generation will be done sequentially. However, if a ForkJoinPool is given to ServiceExecutionGenerator, it will make use of it. Also, ServicesGenerationMojo provides a parameter for specifying what level of parallelism is desired, if any.