### PR TITLE
Backend Skeleton for SDLC Server

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/BaseLegendSDLCServer.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/BaseLegendSDLCServer.java
@@ -19,6 +19,7 @@ import io.dropwizard.lifecycle.Managed;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.eclipse.collections.impl.block.factory.Functions;
 import org.finos.legend.engine.protocol.pure.v1.PureProtocolObjectMapperFactory;
 import org.finos.legend.sdlc.server.config.LegendSDLCServerConfiguration;
 import org.finos.legend.sdlc.server.depot.DepotConfiguration;
@@ -27,6 +28,7 @@ import org.finos.legend.sdlc.server.gitlab.GitLabConfiguration;
 import org.finos.legend.sdlc.server.guice.AbstractBaseModule;
 import org.finos.legend.sdlc.server.guice.BaseModule;
 import org.finos.legend.sdlc.server.project.config.ProjectStructureConfiguration;
+import org.finos.legend.sdlc.server.backend.BackendConfiguration;
 import org.finos.legend.sdlc.server.tools.BackgroundTaskProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,7 +74,7 @@ public abstract class BaseLegendSDLCServer<T extends LegendSDLCServerConfigurati
         if (GITLAB_MODE.equals(this.mode))
         {
             // Add GitLab bundle
-            bootstrap.addBundle(new GitLabBundle<>(LegendSDLCServerConfiguration::getGitLabConfiguration));
+            bootstrap.addBundle(new GitLabBundle<>(Functions.chain(LegendSDLCServerConfiguration::getBackendConfiguration, BackendConfiguration::getGitLabConfiguration)));
         }
 
         // Guice bootstrapping..

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/backend/BackendConfiguration.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/backend/BackendConfiguration.java
@@ -1,0 +1,40 @@
+// Copyright 2023 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.server.backend;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.finos.legend.sdlc.server.gitlab.GitLabConfiguration;
+
+public class BackendConfiguration
+{
+    private final GitLabConfiguration gitLabConfig;
+
+    private BackendConfiguration(GitLabConfiguration gitLabConfig)
+    {
+        this.gitLabConfig = gitLabConfig;
+    }
+
+    public GitLabConfiguration getGitLabConfiguration()
+    {
+        return this.gitLabConfig;
+    }
+
+    @JsonCreator
+    public static BackendConfiguration newBackendConfiguration(@JsonProperty("gitLab") GitLabConfiguration gitLabConfig)
+    {
+        return new BackendConfiguration(gitLabConfig);
+    }
+}

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/config/LegendSDLCServerConfiguration.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/config/LegendSDLCServerConfiguration.java
@@ -16,13 +16,13 @@ package org.finos.legend.sdlc.server.config;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.finos.legend.sdlc.server.depot.DepotConfiguration;
-import org.finos.legend.sdlc.server.gitlab.GitLabConfiguration;
 import org.finos.legend.sdlc.server.project.config.ProjectStructureConfiguration;
+import org.finos.legend.sdlc.server.backend.BackendConfiguration;
 
 public class LegendSDLCServerConfiguration extends ServerConfiguration
 {
-    @JsonProperty("gitLab")
-    private GitLabConfiguration gitLabConfig;
+    @JsonProperty("backend")
+    private BackendConfiguration backendConfig;
 
     @JsonProperty("projectStructure")
     private ProjectStructureConfiguration projectStructureConfiguration;
@@ -33,9 +33,9 @@ public class LegendSDLCServerConfiguration extends ServerConfiguration
     @JsonProperty("features")
     private LegendSDLCServerFeaturesConfiguration featuresConfiguration;
 
-    public GitLabConfiguration getGitLabConfiguration()
+    public BackendConfiguration getBackendConfiguration()
     {
-        return this.gitLabConfig;
+        return this.backendConfig;
     }
 
     public ProjectStructureConfiguration getProjectStructureConfiguration()

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/guice/BaseModule.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/guice/BaseModule.java
@@ -94,8 +94,8 @@ public class BaseModule extends AbstractBaseModule
             binder.bind(GitLabUserContext.class);
             binder.bind(GitLabAuthResource.class);
             binder.bind(GitLabAuthCheckResource.class);
-            binder.bind(GitLabConfiguration.class).toProvider(() -> getConfiguration().getGitLabConfiguration());
-            binder.bind(GitLabAppInfo.class).toProvider(() -> GitLabAppInfo.newAppInfo(getConfiguration().getGitLabConfiguration()));
+            binder.bind(GitLabConfiguration.class).toProvider(() -> getConfiguration().getBackendConfiguration().getGitLabConfiguration());
+            binder.bind(GitLabAppInfo.class).toProvider(() -> GitLabAppInfo.newAppInfo(getConfiguration().getBackendConfiguration().getGitLabConfiguration()));
             binder.bind(GitLabAuthorizerManager.class).toProvider(() -> this.provideGitLabAuthorizerManager(getConfiguration())).in(Scopes.SINGLETON);
         }
         configureMetadataApi(binder);
@@ -108,7 +108,7 @@ public class BaseModule extends AbstractBaseModule
 
     private GitLabAuthorizerManager provideGitLabAuthorizerManager(LegendSDLCServerConfiguration configuration)
     {
-        List<GitLabAuthorizer> gitLabAuthorizers = configuration.getGitLabConfiguration().getGitLabAuthorizers();
+        List<GitLabAuthorizer> gitLabAuthorizers = configuration.getBackendConfiguration().getGitLabConfiguration().getGitLabAuthorizers();
         if (gitLabAuthorizers == null)
         {
             return GitLabAuthorizerManager.newManager(Collections.emptyList());

--- a/legend-sdlc-server/src/test/resources/config-sample.yaml
+++ b/legend-sdlc-server/src/test/resources/config-sample.yaml
@@ -65,17 +65,24 @@ pac4j:
     - /api/server/platforms
     - /api/auth/authorized
 
-gitLab:
-  newProjectVisibility: public
-  projectIdPrefix: SAMPLE
-  projectTag: legend
-  server:
-    scheme: https
-    host: $GITLAB_HOST
-  app:
-    id: $APP_ID
-    secret: $APP_SECRET
-    redirectURI: http://$SDLC_SERVER_HOST/api/auth/callback
+backend:
+  inMemory:
+#    engineConfig:
+#      inMemorySizeGB: 256MB
+  fileSystem:
+#    rootDirectory: /location/to/drive
+#    maxThreads: 100
+  gitLab:
+    newProjectVisibility: public
+    projectIdPrefix: SAMPLE
+    projectTag: legend
+    server:
+      scheme: https
+      host: $GITLAB_HOST
+    app:
+      id: $APP_ID
+      secret: $APP_SECRET
+      redirectURI: http://$SDLC_SERVER_HOST/api/auth/callback
 
 projectStructure:
   extensionProvider:

--- a/legend-sdlc-server/src/test/resources/config-test.yaml
+++ b/legend-sdlc-server/src/test/resources/config-test.yaml
@@ -52,16 +52,23 @@ projectStructure:
   projectCreation:
     groupIdPattern: ^org\.finos\.legend\..+
 
-gitLab:
-  projectTag: legendtest
-  projectIdPrefix: PROTOTYPE
-  server:
-    scheme: na
-    host: na-uat
-  app:
-    id: na
-    secret: na
-    redirectURI: na
+backend:
+  inMemory:
+  #    engineConfig:
+  #      inMemorySizeGB: 256MB
+  fileSystem:
+  #    rootDirectory: /location/to/drive
+  #    maxThreads: 100
+  gitLab:
+    projectTag: legendtest
+    projectIdPrefix: PROTOTYPE
+    server:
+      scheme: na
+      host: na-uat
+    app:
+      id: na
+      secret: na
+      redirectURI: na
 
 logging:
   # Change this to affect library class logging


### PR DESCRIPTION
To extend the support of SDLC Server to different Backend modes apart from Gitlab (In-Memory, File System) we are pushing the Gitlab config settings one level down and add the skeleton for Backend Configuration.