### PR TITLE
Fix error when a workspace cannot be found

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabWorkspaceApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabWorkspaceApi.java
@@ -89,7 +89,7 @@ public class GitLabWorkspaceApi extends GitLabApiWithFileAccess implements Works
             GitLabProjectId gitLabProjectId = parseProjectId(projectId);
             String branchName = getWorkspaceBranchName(workspaceSpecification);
             RepositoryApi repositoryApi = getGitLabApi().getRepositoryApi();
-            Branch branch = withRetries(() -> GitLabApiTools.getBranch(repositoryApi, gitLabProjectId.getGitLabId(), branchName));
+            Branch branch = withRetries(() -> repositoryApi.getBranch(gitLabProjectId.getGitLabId(), branchName));
             return fromWorkspaceBranchName(projectId, branch.getName());
         }
         catch (Exception e)


### PR DESCRIPTION
Fix error when a workspace cannot be found to make sure a 404 status is returned