### PR TITLE
Change parallelization of service execution generation

### DIFF
--- a/legend-sdlc-test-utils/src/main/java/org/finos/legend/sdlc/test/junit/LegendSDLCTestSuiteBuilder.java
+++ b/legend-sdlc-test-utils/src/main/java/org/finos/legend/sdlc/test/junit/LegendSDLCTestSuiteBuilder.java
@@ -32,7 +32,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextDa
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.Mapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.service.Service;
-import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
+import org.finos.legend.engine.pure.code.core.PureCoreExtension;
 import org.finos.legend.engine.testable.extension.TestableRunnerExtensionLoader;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.test.Test;
@@ -65,7 +65,7 @@ public class LegendSDLCTestSuiteBuilder
     private final PureModelContextData pureModelContextData;
     private final MapIterable<String, PackageableElement> protocolIndex;
     private final RichIterable<? extends Root_meta_pure_extension_Extension> routerExtensions;
-    private final MutableList<PlanTransformer> planTransformers;
+    private final Iterable<? extends PlanTransformer> planTransformers;
 
     private LegendSDLCTestSuiteBuilder(String name, String pureVersion, ClassLoader classLoader)
     {
@@ -77,9 +77,8 @@ public class LegendSDLCTestSuiteBuilder
         this.pureModel = pureModelWithContextData.getPureModel();
         this.pureModelContextData = pureModelWithContextData.getPureModelContextData();
         this.protocolIndex = Iterate.groupByUniqueKey(this.pureModelContextData.getElements(), PackageableElement::getPath);
-        MutableList<PlanGeneratorExtension> extensions = Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class, classLoader));
-        this.routerExtensions = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(this.pureModel.getExecutionSupport()));
-        this.planTransformers = extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers);
+        this.routerExtensions = Iterate.flatCollect(ServiceLoader.load(PureCoreExtension.class, classLoader), e -> e.extraPureCoreExtensions(this.pureModel.getExecutionSupport()), Lists.mutable.empty());
+        this.planTransformers = Iterate.flatCollect(ServiceLoader.load(PlanGeneratorExtension.class, classLoader), PlanGeneratorExtension::getExtraPlanTransformers, Lists.mutable.empty());
     }
 
     public LegendSDLCTestSuiteBuilder(String name, String pureVersion)

--- a/legend-sdlc-test-utils/src/main/java/org/finos/legend/sdlc/test/junit/pure/v1/LegacyMappingTestCase.java
+++ b/legend-sdlc-test-utils/src/main/java/org/finos/legend/sdlc/test/junit/pure/v1/LegacyMappingTestCase.java
@@ -15,7 +15,6 @@
 package org.finos.legend.sdlc.test.junit.pure.v1;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
@@ -28,7 +27,7 @@ public class LegacyMappingTestCase extends LegendSDLCTestCase
 {
     private final LegacyMappingTestHelper helper;
 
-    public LegacyMappingTestCase(String mappingPath, PureModel pureModel, MappingTest_Legacy mappingTest, MutableList<PlanTransformer> planTransformers, RichIterable<? extends Root_meta_pure_extension_Extension> extensions, String pureVersion)
+    public LegacyMappingTestCase(String mappingPath, PureModel pureModel, MappingTest_Legacy mappingTest, Iterable<? extends PlanTransformer> planTransformers, RichIterable<? extends Root_meta_pure_extension_Extension> extensions, String pureVersion)
     {
         super(mappingPath);
         this.helper = new LegacyMappingTestHelper(3, mappingPath, new MappingTestRunner(pureModel, mappingPath, mappingTest, PlanExecutor.newPlanExecutorBuilder().withAvailableStoreExecutors().build(), extensions, planTransformers, pureVersion));

--- a/legend-sdlc-test-utils/src/main/java/org/finos/legend/sdlc/test/junit/pure/v1/LegacyServiceTestCase.java
+++ b/legend-sdlc-test-utils/src/main/java/org/finos/legend/sdlc/test/junit/pure/v1/LegacyServiceTestCase.java
@@ -15,7 +15,6 @@
 package org.finos.legend.sdlc.test.junit.pure.v1;
 
 import org.eclipse.collections.api.RichIterable;
-import org.eclipse.collections.api.list.MutableList;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.plan.execution.PlanExecutor;
 import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
@@ -29,7 +28,7 @@ public class LegacyServiceTestCase extends LegendSDLCTestCase
 {
     private final LegacyServiceTestHelper helper;
 
-    public LegacyServiceTestCase(String servicePath, PureModel pureModel, PureModelContextData pureModelContextData, Service service, MutableList<PlanTransformer> planTransformers, RichIterable<? extends Root_meta_pure_extension_Extension> extensions, String pureVersion)
+    public LegacyServiceTestCase(String servicePath, PureModel pureModel, PureModelContextData pureModelContextData, Service service, Iterable<? extends PlanTransformer> planTransformers, RichIterable<? extends Root_meta_pure_extension_Extension> extensions, String pureVersion)
     {
         super(servicePath);
         this.helper = new LegacyServiceTestHelper(3, servicePath, new ServiceTestRunner(service, null, pureModelContextData, pureModel, null, PlanExecutor.newPlanExecutorBuilder().withAvailableStoreExecutors().build(), extensions, planTransformers, pureVersion));

--- a/legend-sdlc-test-utils/src/main/java/org/finos/legend/sdlc/test/junit/pure/v1/PureTestHelper.java
+++ b/legend-sdlc-test-utils/src/main/java/org/finos/legend/sdlc/test/junit/pure/v1/PureTestHelper.java
@@ -20,12 +20,13 @@ import org.eclipse.collections.api.factory.Maps;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MapIterable;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.impl.utility.Iterate;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.PureModel;
 import org.finos.legend.engine.plan.generation.extension.PlanGeneratorExtension;
 import org.finos.legend.engine.plan.generation.transformers.PlanTransformer;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
-import org.finos.legend.engine.pure.code.core.PureCoreExtensionLoader;
+import org.finos.legend.engine.pure.code.core.PureCoreExtension;
 import org.finos.legend.pure.generated.Root_meta_pure_extension_Extension;
 import org.finos.legend.sdlc.language.pure.compiler.toPureGraph.PureModelBuilder;
 import org.finos.legend.sdlc.language.pure.compiler.toPureGraph.PureModelBuilder.PureModelWithContextData;
@@ -94,9 +95,8 @@ class PureTestHelper
                     PROTOCOL_ELEMENT_INDEX = indexPureModelContextData(PURE_MODEL_CONTEXT_DATA);
                     PURE_MODEL = pureModelWithContextData.getPureModel();
 
-                    MutableList<PlanGeneratorExtension> extensions = Lists.mutable.withAll(ServiceLoader.load(PlanGeneratorExtension.class));
-                    PLAN_TRANSFORMERS = extensions.flatCollect(PlanGeneratorExtension::getExtraPlanTransformers).asUnmodifiable();
-                    ROUTER_EXTENSIONS = PureCoreExtensionLoader.extensions().flatCollect(e -> e.extraPureCoreExtensions(PURE_MODEL.getExecutionSupport())).asUnmodifiable();
+                    PLAN_TRANSFORMERS = Iterate.flatCollect(ServiceLoader.load(PlanGeneratorExtension.class, classLoader), PlanGeneratorExtension::getExtraPlanTransformers, Lists.mutable.empty()).asUnmodifiable();
+                    ROUTER_EXTENSIONS = Iterate.flatCollect(ServiceLoader.load(PureCoreExtension.class, classLoader), e -> e.extraPureCoreExtensions(PURE_MODEL.getExecutionSupport()), Lists.mutable.empty()).asUnmodifiable();
                     LOGGER.debug("Finished initialization");
                 }
                 catch (Throwable t)


### PR DESCRIPTION
Change parallelization of service execution generation to give better control. In particular, try to terminate tasks as quickly as possible in case one completes abnormally (by error or cancellation).

In passing, fix the handling of extensions.