### PR TITLE
Allow parallelization of multi-execution service execution plans

### DIFF
--- a/legend-sdlc-generation-service/src/main/java/org/finos/legend/sdlc/generation/service/ServiceExecutionGenerator.java
+++ b/legend-sdlc-generation-service/src/main/java/org/finos/legend/sdlc/generation/service/ServiceExecutionGenerator.java
@@ -376,7 +376,7 @@ public class ServiceExecutionGenerator
         ExecutionPlan plan;
         try
         {
-            plan = ServicePlanGenerator.generateServiceExecutionPlan(service, null, this.pureModel, this.clientVersion, PlanPlatform.JAVA, planId, this.extensions, this.transformers);
+            plan = ServicePlanGenerator.generateServiceExecutionPlan(service, null, this.pureModel, this.clientVersion, PlanPlatform.JAVA, planId, this.extensions, this.transformers, this.executorService);
         }
         catch (Exception e)
         {

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <java.version.range>[11,12),[17,18)</java.version.range>
 
         <!-- Legend dependency versions -->
-        <legend.engine.version>4.25.2</legend.engine.version>
+        <legend.engine.version>4.26.0</legend.engine.version>
         <legend.pure.version>4.5.12</legend.pure.version>
         <legend.shared.version>0.24.0</legend.shared.version>
 


### PR DESCRIPTION
If service execution plan generation is being parallelized, then parallelize the generation of multi-execution service execution plans. 