### PR TITLE
Allow test dependency on org.slf4j:jul-to-slf4j throughout legend-sdlc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,7 @@
                             <includes>
                                 <include>org.slf4j:slf4j-api:${slf4j.version}</include>
                                 <include>org.slf4j:jcl-over-slf4j:${slf4j.version}:jar:test</include>
+                                <include>org.slf4j:jul-to-slf4j:${slf4j.version}:jar:test</include>
                             </includes>
                         </bannedDependencies>
                     </rules>


### PR DESCRIPTION
Allow dependency on org.slf4j:jul-to-slf4j with test scope throughout legend-sdlc. There are already some modules, such as legend-sdlc-server, which allow it with compile scope.