### PR TITLE
Revert "[maven-release-plugin] prepare release legend-sdlc-0.171.1"

### DIFF
--- a/legend-sdlc-entity-maven-plugin/pom.xml
+++ b/legend-sdlc-entity-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-entity-serialization/pom.xml
+++ b/legend-sdlc-entity-serialization/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-extensions-collection-entity-serializer/pom.xml
+++ b/legend-sdlc-extensions-collection-entity-serializer/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>legend-sdlc</artifactId>
         <groupId>org.finos.legend.sdlc</groupId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-generation-file-maven-plugin/pom.xml
+++ b/legend-sdlc-generation-file-maven-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/legend-sdlc-generation-file/pom.xml
+++ b/legend-sdlc-generation-file/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-generation-model-maven-plugin/pom.xml
+++ b/legend-sdlc-generation-model-maven-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/legend-sdlc-generation-model/pom.xml
+++ b/legend-sdlc-generation-model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-generation-service-maven-plugin/pom.xml
+++ b/legend-sdlc-generation-service-maven-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/legend-sdlc-generation-service/pom.xml
+++ b/legend-sdlc-generation-service/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-generation-shared/pom.xml
+++ b/legend-sdlc-generation-shared/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-language-pure-compiler/pom.xml
+++ b/legend-sdlc-language-pure-compiler/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-model/pom.xml
+++ b/legend-sdlc-model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-protocol-pure/pom.xml
+++ b/legend-sdlc-protocol-pure/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-protocol/pom.xml
+++ b/legend-sdlc-protocol/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-server-fs/pom.xml
+++ b/legend-sdlc-server-fs/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-server-shared/pom.xml
+++ b/legend-sdlc-server-shared/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-server/pom.xml
+++ b/legend-sdlc-server/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-test-generation-maven-plugin/pom.xml
+++ b/legend-sdlc-test-generation-maven-plugin/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>maven-plugin</packaging>

--- a/legend-sdlc-test-generation/pom.xml
+++ b/legend-sdlc-test-generation/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-test-reports/pom.xml
+++ b/legend-sdlc-test-reports/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/legend-sdlc-test-utils/pom.xml
+++ b/legend-sdlc-test-utils/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>legend-sdlc-test-utils</artifactId>

--- a/legend-sdlc-version-package-maven-plugin/pom.xml
+++ b/legend-sdlc-version-package-maven-plugin/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.finos.legend.sdlc</groupId>
         <artifactId>legend-sdlc</artifactId>
-        <version>0.171.1</version>
+        <version>0.171.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <name>Legend SDLC</name>
     <groupId>org.finos.legend.sdlc</groupId>
     <artifactId>legend-sdlc</artifactId>
-    <version>0.171.1</version>
+    <version>0.171.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -125,7 +125,7 @@
 
     <scm>
         <developerConnection>scm:git:https://github.com/finos/legend-sdlc</developerConnection>
-        <tag>legend-sdlc-0.171.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>


### PR DESCRIPTION
This reverts commit 27e2eb5ab213e3253676d3766bbd9b17309494ed.

---

I made a mistake during release to put the same version as the latest version 0.171.1