### PR TITLE
Update OAuth flow to accommodate new GitLab behaviour

### DIFF
--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/auth/GitLabOAuthAuthenticator.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/auth/GitLabOAuthAuthenticator.java
@@ -207,7 +207,7 @@ public class GitLabOAuthAuthenticator
         {
             String responseString = EntityUtils.toString(response.getEntity());
             Document doc = Jsoup.parse(responseString);
-            Element header = doc.getElementsByTag("h3").get(0);
+            Element header = doc.getElementsByClass("page-title").get(0);
             if ("Redirecting".equals(header.text()))
             {
                 Element anchor = doc.getElementsByTag("a").get(0);


### PR DESCRIPTION
Newer versions (starting v14) have modified the OAuth authorization page formatting from `h3` to `h1`.