### PR TITLE
updates slf4j version to 1.7.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <junit.version>4.13.1</junit.version>
         <maven.version>3.9.2</maven.version>
         <pac4j.version>3.8.3</pac4j.version>
-        <slf4j.version>1.7.25</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <snakeyaml.version>1.33</snakeyaml.version>
 
         <!-- Plugin versions -->


### PR DESCRIPTION
#### What type of PR is this?
- Improvement


#### What does this PR do / why is it needed ?

We are replacing log4j-1.2.17 with reload4j-1.2.19 (This is done remove vulnerabilities). slf4j 1.7.36 version supports reload4j to keep in sync with other legend repo updating version over here as well.