### PR TITLE
Add project dependency exclusions

### DIFF
--- a/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ProjectDependency.java
+++ b/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ProjectDependency.java
@@ -14,7 +14,9 @@
 
 package org.finos.legend.sdlc.domain.model.project.configuration;
 
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 
 public abstract class ProjectDependency extends Dependency
@@ -22,6 +24,11 @@ public abstract class ProjectDependency extends Dependency
     public abstract String getProjectId();
 
     public abstract String getVersionId();
+
+    public List<ProjectDependencyExclusion> getExclusions()
+    {
+        return Collections.emptyList();
+    }
 
     @Override
     public boolean equals(Object other)
@@ -37,7 +44,7 @@ public abstract class ProjectDependency extends Dependency
         }
 
         ProjectDependency that = (ProjectDependency) other;
-        return Objects.equals(this.getProjectId(), that.getProjectId()) && Objects.equals(this.getVersionId(), that.getVersionId());
+        return Objects.equals(this.getProjectId(), that.getProjectId()) && Objects.equals(this.getVersionId(), that.getVersionId()) && Objects.equals(this.getExclusions(), that.getExclusions());
     }
 
     @Override
@@ -95,7 +102,7 @@ public abstract class ProjectDependency extends Dependency
         return newProjectDependency(projectId, versionId);
     }
 
-    public static ProjectDependency newProjectDependency(String projectId, String versionId)
+    public static ProjectDependency newProjectDependency(String projectId, String versionId, List<ProjectDependencyExclusion> exclusions)
     {
         return new ProjectDependency()
         {
@@ -110,7 +117,18 @@ public abstract class ProjectDependency extends Dependency
             {
                 return versionId;
             }
+
+            @Override
+            public List<ProjectDependencyExclusion> getExclusions()
+            {
+                return exclusions == null ? Collections.emptyList() : exclusions;
+            }
         };
+    }
+
+    public static ProjectDependency newProjectDependency(String projectId, String versionId)
+    {
+        return newProjectDependency(projectId, versionId, null);
     }
 
     public static Comparator<ProjectDependency> getDefaultComparator()

--- a/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ProjectDependencyExclusion.java
+++ b/legend-sdlc-model/src/main/java/org/finos/legend/sdlc/domain/model/project/configuration/ProjectDependencyExclusion.java
@@ -1,0 +1,64 @@
+// Copyright 2025 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.domain.model.project.configuration;
+
+import java.util.Objects;
+
+public abstract class ProjectDependencyExclusion
+{
+    public abstract String getProjectId();
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other)
+        {
+            return true;
+        }
+
+        if (!(other instanceof ProjectDependencyExclusion))
+        {
+            return false;
+        }
+
+        ProjectDependencyExclusion that = (ProjectDependencyExclusion) other;
+        return Objects.equals(this.getProjectId(), that.getProjectId());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(getProjectId());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "<" + getClass().getSimpleName() + " " + getProjectId() + ">";
+    }
+
+    public static ProjectDependencyExclusion newProjectDependencyExclusion(String projectId)
+    {
+        return new ProjectDependencyExclusion()
+        {
+            @Override
+            public String getProjectId()
+            {
+                return projectId;
+            }
+        };
+    }
+
+}

--- a/legend-sdlc-model/src/test/java/org/finos/legend/sdlc/domain/model/project/configuration/TestProjectDependency.java
+++ b/legend-sdlc-model/src/test/java/org/finos/legend/sdlc/domain/model/project/configuration/TestProjectDependency.java
@@ -18,6 +18,8 @@ import org.finos.legend.sdlc.domain.model.TestTools;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 
 public class TestProjectDependency
@@ -75,5 +77,23 @@ public class TestProjectDependency
 
         TestTools.assertCompareTo(-1, testProject123, ProjectDependency.newProjectDependency(null, "1.2.3"), comparator);
         TestTools.assertCompareTo(-1, testProject123, ProjectDependency.newProjectDependency("test-project", null), comparator);
+    }
+
+    @Test
+    public void testProjectDependencyExclusions()
+    {
+        ProjectDependencyExclusion exclusion1 = ProjectDependencyExclusion.newProjectDependencyExclusion("org.finos.legend.sdlc.test:exclusion-project-1");
+        ProjectDependencyExclusion exclusion2 = ProjectDependencyExclusion.newProjectDependencyExclusion("org.finos.legend.sdlc.test:exclusion-project-2");
+        ProjectDependency dependencyWithExclusions = ProjectDependency.newProjectDependency("test-project", "1.2.3", Arrays.asList(exclusion1, exclusion2));
+        Assert.assertEquals(Arrays.asList(exclusion1, exclusion2), dependencyWithExclusions.getExclusions());
+
+        ProjectDependency dependencyWithoutExclusions = ProjectDependency.newProjectDependency("test-project", "1.2.3");
+        Assert.assertEquals(Collections.emptyList(), dependencyWithoutExclusions.getExclusions());
+        Assert.assertNotEquals(dependencyWithExclusions, dependencyWithoutExclusions);
+
+        ProjectDependency dependencyWithOnexclusion = ProjectDependency.newProjectDependency("test-project", "1.2.3", Arrays.asList(exclusion1));
+        Assert.assertEquals(Arrays.asList(exclusion1), dependencyWithOnexclusion.getExclusions());
+        Assert.assertNotEquals(dependencyWithExclusions, dependencyWithOnexclusion);
+        Assert.assertNotEquals(dependencyWithoutExclusions, dependencyWithOnexclusion);
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/SimpleProjectDependency.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/SimpleProjectDependency.java
@@ -15,6 +15,7 @@
 package org.finos.legend.sdlc.server.project;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -23,19 +24,24 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
+import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependencyExclusion;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 public class SimpleProjectDependency extends ProjectDependency
 {
     private final String projectId;
     private final String versionId;
+    private final List<ProjectDependencyExclusion> exclusions;
 
     @JsonCreator
-    public SimpleProjectDependency(@JsonProperty("projectId") String projectId, @JsonProperty("versionId") @JsonDeserialize(using = VersionIdDeserializer.class) String versionId)
+    public SimpleProjectDependency(@JsonProperty("projectId") String projectId, @JsonProperty("versionId") @JsonDeserialize(using = VersionIdDeserializer.class) String versionId, @JsonProperty("exclusions") @JsonInclude(JsonInclude.Include.NON_EMPTY) List<ProjectDependencyExclusion> exclusions)
     {
         this.projectId = projectId;
         this.versionId = versionId;
+        this.exclusions = exclusions == null ? Collections.emptyList() : exclusions;
     }
 
     @Override
@@ -48,6 +54,12 @@ public class SimpleProjectDependency extends ProjectDependency
     public String getVersionId()
     {
         return this.versionId;
+    }
+
+    @Override
+    public List<ProjectDependencyExclusion> getExclusions()
+    {
+        return this.exclusions;
     }
 
     private static class VersionIdDeserializer extends JsonDeserializer<String>


### PR DESCRIPTION
Updating maven project structure to have dependency exclusions so users are able to exclude transitive dependencies they may not be using