### PR TITLE
Remove double definition of dependency

### DIFF
--- a/legend-sdlc-generation-service-maven-plugin/pom.xml
+++ b/legend-sdlc-generation-service-maven-plugin/pom.xml
@@ -193,12 +193,6 @@
             <artifactId>maven-compat</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.finos.legend.engine</groupId>
-            <artifactId>legend-engine-xt-functionJar-protocol</artifactId>
-            <version>${legend.engine.version}</version>
-            <scope>compile</scope>
-        </dependency>
         <!-- TEST -->
     </dependencies>
 </project>


### PR DESCRIPTION
Legend Engine dependency _org.finos.legend.engine:legend-engine-xt-functionJar-protocol_ is defined twice in the same `pom.xml`. Remove the double definition.