### PR TITLE
Eliminate some deprecated methods

### DIFF
--- a/legend-sdlc-project-files/src/main/java/org/finos/legend/sdlc/server/domain/api/project/source/SourceSpecification.java
+++ b/legend-sdlc-project-files/src/main/java/org/finos/legend/sdlc/server/domain/api/project/source/SourceSpecification.java
@@ -14,11 +14,8 @@
 
 package org.finos.legend.sdlc.server.domain.api.project.source;
 
-import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
-import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
-import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider;
 
 public abstract class SourceSpecification
 {
@@ -27,46 +24,6 @@ public abstract class SourceSpecification
     }
 
     public abstract <T> T visit(SourceSpecificationVisitor<T> visitor);
-
-    @Deprecated
-    public String getWorkspaceId()
-    {
-        if (this instanceof WorkspaceSourceSpecification)
-        {
-            return ((WorkspaceSourceSpecification) this).getWorkspaceSpecification().getId();
-        }
-        return null;
-    }
-
-    @Deprecated
-    public final WorkspaceType getWorkspaceType()
-    {
-        if (this instanceof WorkspaceSourceSpecification)
-        {
-            return ((WorkspaceSourceSpecification) this).getWorkspaceSpecification().getType();
-        }
-        return null;
-    }
-
-    @Deprecated
-    public final ProjectFileAccessProvider.WorkspaceAccessType getWorkspaceAccessType()
-    {
-        if (this instanceof WorkspaceSourceSpecification)
-        {
-            return ((WorkspaceSourceSpecification) this).getWorkspaceSpecification().getAccessType();
-        }
-        return null;
-    }
-
-    @Deprecated
-    public final VersionId getPatchReleaseVersionId()
-    {
-        if (this instanceof PatchSourceSpecification)
-        {
-            return ((PatchSourceSpecification) this).getVersionId();
-        }
-        return null;
-    }
 
     @Override
     public final String toString()
@@ -99,75 +56,5 @@ public abstract class SourceSpecification
     public static WorkspaceSourceSpecification workspaceSourceSpecification(WorkspaceSpecification workspaceSpec)
     {
         return new WorkspaceSourceSpecification(workspaceSpec);
-    }
-
-    @Deprecated
-    public static SourceSpecification newSourceSpecification(String workspaceId, WorkspaceType workspaceType, ProjectFileAccessProvider.WorkspaceAccessType workspaceAccessType, VersionId patchReleaseVersionId)
-    {
-        if (workspaceId != null)
-        {
-            WorkspaceSource workspaceSource = (patchReleaseVersionId == null) ? WorkspaceSource.projectWorkspaceSource() : WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId);
-            WorkspaceSpecification workspaceSpec = WorkspaceSpecification.newWorkspaceSpecification(workspaceId, workspaceType, workspaceAccessType, workspaceSource);
-            return workspaceSourceSpecification(workspaceSpec);
-        }
-        if (patchReleaseVersionId != null)
-        {
-            return patchSourceSpecification(patchReleaseVersionId);
-        }
-        return projectSourceSpecification();
-    }
-
-    @Deprecated
-    public static SourceSpecification newSourceSpecification(String workspaceId, WorkspaceType workspaceType, ProjectFileAccessProvider.WorkspaceAccessType workspaceAccessType)
-    {
-        return newSourceSpecification(workspaceId, workspaceType, workspaceAccessType, null);
-    }
-
-    @Deprecated
-    public static SourceSpecification newSourceSpecification(String workspaceId, WorkspaceType workspaceType)
-    {
-        return newSourceSpecification(workspaceId, workspaceType, null, null);
-    }
-
-    @Deprecated
-    public static SourceSpecification newSourceSpecification(VersionId patchReleaseVersionId)
-    {
-        return newSourceSpecification(null, null, null, patchReleaseVersionId);
-    }
-
-    @Deprecated
-    public static SourceSpecification newGroupWorkspaceSourceSpecification(String workspaceId, ProjectFileAccessProvider.WorkspaceAccessType workspaceAccessType, VersionId patchReleaseVersionId)
-    {
-        return newSourceSpecification(workspaceId, WorkspaceType.GROUP, workspaceAccessType, patchReleaseVersionId);
-    }
-
-    @Deprecated
-    public static SourceSpecification newGroupWorkspaceSourceSpecification(String workspaceId, VersionId patchReleaseVersionId)
-    {
-        return newGroupWorkspaceSourceSpecification(workspaceId, null, patchReleaseVersionId);
-    }
-
-    @Deprecated
-    public static SourceSpecification newGroupWorkspaceSourceSpecification(String workspaceId)
-    {
-        return newGroupWorkspaceSourceSpecification(workspaceId, null);
-    }
-
-    @Deprecated
-    public static SourceSpecification newUserWorkspaceSourceSpecification(String workspaceId, ProjectFileAccessProvider.WorkspaceAccessType workspaceAccessType, VersionId patchReleaseVersionId)
-    {
-        return newSourceSpecification(workspaceId, WorkspaceType.USER, workspaceAccessType, patchReleaseVersionId);
-    }
-
-    @Deprecated
-    public static SourceSpecification newUserWorkspaceSourceSpecification(String workspaceId, VersionId patchReleaseVersionId)
-    {
-        return newUserWorkspaceSourceSpecification(workspaceId, null, patchReleaseVersionId);
-    }
-
-    @Deprecated
-    public static SourceSpecification newUserWorkspaceSourceSpecification(String workspaceId)
-    {
-        return newUserWorkspaceSourceSpecification(workspaceId, null);
     }
 }

--- a/legend-sdlc-project-files/src/main/java/org/finos/legend/sdlc/server/project/ProjectFileAccessProvider.java
+++ b/legend-sdlc-project-files/src/main/java/org/finos/legend/sdlc/server/project/ProjectFileAccessProvider.java
@@ -14,13 +14,8 @@
 
 package org.finos.legend.sdlc.server.project;
 
-import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
-import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
-import org.finos.legend.sdlc.server.domain.api.project.source.WorkspaceSourceSpecification;
-import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
-import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.tools.IOTools;
 
 import java.io.IOException;
@@ -32,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -210,86 +204,6 @@ public interface ProjectFileAccessProvider
         return getFileAccessContext(projectId, sourceSpecification, null);
     }
 
-    // Deprecated File Access APIs
-
-    @Deprecated
-    default FileAccessContext getProjectFileAccessContext(String projectId)
-    {
-        return getFileAccessContext(projectId, SourceSpecification.projectSourceSpecification());
-    }
-
-    @Deprecated
-    default FileAccessContext getProjectRevisionFileAccessContext(String projectId, String revisionId)
-    {
-        Objects.requireNonNull(revisionId, "revisionId may not be null");
-        return getFileAccessContext(projectId, SourceSpecification.projectSourceSpecification(), revisionId);
-    }
-
-    @Deprecated
-    default FileAccessContext getWorkspaceFileAccessContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType)
-    {
-        Objects.requireNonNull(workspaceId, "workspaceId may not be null");
-        Objects.requireNonNull(workspaceType, "workspaceType may not be null");
-        Objects.requireNonNull(workspaceAccessType, "workspaceAccessType may not be null");
-        return getFileAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, workspaceType, workspaceAccessType, WorkspaceSource.projectWorkspaceSource())));
-    }
-
-    @Deprecated
-    default FileAccessContext getWorkspaceRevisionFileAccessContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType, String revisionId)
-    {
-        Objects.requireNonNull(workspaceId, "workspaceId may not be null");
-        Objects.requireNonNull(workspaceType, "workspaceType may not be null");
-        Objects.requireNonNull(workspaceAccessType, "workspaceAccessType may not be null");
-        Objects.requireNonNull(revisionId, "revisionId may not be null");
-        return getFileAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, workspaceType, workspaceAccessType, WorkspaceSource.projectWorkspaceSource())), revisionId);
-    }
-
-    @Deprecated
-    default FileAccessContext getFileAccessContext(String projectId, String workspaceId, WorkspaceAccessType workspaceAccessType, String revisionId)
-    {
-        return getFileAccessContext(projectId, workspaceId, WorkspaceType.USER, workspaceAccessType, revisionId);
-    }
-
-    /**
-     * Get a file access context. The project id must always be supplied, but workspace
-     * and revision ids are optional. If workspace is specified, workspace access type is also required
-     * <p>
-     * If a workspace id is supplied, then the access context is for that workspace.
-     * Otherwise, it is for the trunk or master branch of the project.
-     * <p>
-     * If a revision id is supplied, then the access context is for that particular
-     * revision of the project or workspace. Otherwise, the access context is for
-     * the current state of the project or workspace. Note that as the current
-     * state may change over time, calls to the access context may yield different
-     * results over time.
-     *
-     * @param projectId           project id
-     * @param workspaceId         workspace id (optional)
-     * @param workspaceType       type for the workspace (e.g. user, group) (optional)
-     * @param workspaceAccessType access type for the workspace (e.g. conflict resolution, backup) (optional)
-     * @param revisionId          revision id (optional)
-     * @return access context
-     */
-    @Deprecated
-    default FileAccessContext getFileAccessContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType, String revisionId)
-    {
-        return getFileAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, workspaceType, workspaceAccessType), revisionId);
-    }
-
-    /**
-     * Get a file access context for a version of a project. Both the project and
-     * version ids must be supplied.
-     *
-     * @param projectId project id
-     * @param versionId version id
-     * @return access context
-     */
-    @Deprecated
-    default FileAccessContext getFileAccessContext(String projectId, VersionId versionId)
-    {
-        return getFileAccessContext(projectId, SourceSpecification.versionSourceSpecification(versionId));
-    }
-
     // Revision Access Context
 
     interface RevisionAccessContext
@@ -328,109 +242,6 @@ public interface ProjectFileAccessProvider
         return getRevisionAccessContext(projectId, sourceSpecification, null);
     }
 
-    // Deprecated Revision Access APIs
-
-    @Deprecated
-    default RevisionAccessContext getProjectRevisionAccessContext(String projectId)
-    {
-        return getRevisionAccessContext(projectId, SourceSpecification.projectSourceSpecification(), null);
-    }
-
-    @Deprecated
-    default RevisionAccessContext getProjectPathRevisionAccessContext(String projectId, String path)
-    {
-        Objects.requireNonNull(path, "path may not be null");
-        return getRevisionAccessContext(projectId, SourceSpecification.projectSourceSpecification(), Collections.singleton(path));
-    }
-
-    @Deprecated
-    default RevisionAccessContext getWorkspaceRevisionAccessContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType)
-    {
-        Objects.requireNonNull(workspaceId, "workspaceId may not be null");
-        Objects.requireNonNull(workspaceType, "workspaceType may not be null");
-        Objects.requireNonNull(workspaceAccessType, "workspaceAccessType may not be null");
-        return getRevisionAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, workspaceType, workspaceAccessType)), null);
-    }
-
-    @Deprecated
-    default RevisionAccessContext getWorkspaceRevisionAccessContext(String projectId, SourceSpecification sourceSpecification)
-    {
-        if (!(sourceSpecification instanceof WorkspaceSourceSpecification))
-        {
-            throw new IllegalArgumentException("source specification must be a workspace source specification");
-        }
-        return getRevisionAccessContext(projectId, sourceSpecification, null);
-    }
-
-    @Deprecated
-    default RevisionAccessContext getWorkspacePathRevisionAccessContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType, String path)
-    {
-        Objects.requireNonNull(workspaceId, "workspaceId may not be null");
-        Objects.requireNonNull(workspaceType, "workspaceType may not be null");
-        Objects.requireNonNull(workspaceAccessType, "workspaceAccessType may not be null");
-        Objects.requireNonNull(path, "path may not be null");
-        return getRevisionAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, workspaceType, workspaceAccessType)), Collections.singleton(path));
-    }
-
-    @Deprecated
-    default RevisionAccessContext getWorkspacePathsRevisionAccessContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType, Iterable<? extends String> paths)
-    {
-        Objects.requireNonNull(workspaceId, "workspaceId may not be null");
-        Objects.requireNonNull(workspaceAccessType, "workspaceAccessType may not be null");
-        Objects.requireNonNull(paths, "paths may not be null");
-        return getRevisionAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, workspaceType, workspaceAccessType)), paths);
-    }
-
-    @Deprecated
-    default RevisionAccessContext getVersionRevisionAccessContext(String projectId, VersionId versionId)
-    {
-        return getRevisionAccessContext(projectId, SourceSpecification.versionSourceSpecification(versionId), null);
-    }
-
-    @Deprecated
-    default RevisionAccessContext getVersionPathRevisionAccessContext(String projectId, VersionId versionId, String path)
-    {
-        Objects.requireNonNull(path, "path may not be null");
-        return getRevisionAccessContext(projectId, SourceSpecification.versionSourceSpecification(versionId), Collections.singleton(path));
-    }
-
-    @Deprecated
-    default RevisionAccessContext getVersionPathRevisionAccessContext(String projectId, VersionId versionId, Iterable<? extends String> paths)
-    {
-        Objects.requireNonNull(paths, "paths may not be null");
-        return getRevisionAccessContext(projectId, SourceSpecification.versionSourceSpecification(versionId), paths);
-    }
-
-    @Deprecated
-    default RevisionAccessContext getRevisionAccessContext(String projectId, VersionId versionId)
-    {
-        return getRevisionAccessContext(projectId, SourceSpecification.versionSourceSpecification(versionId), null);
-    }
-
-    @Deprecated
-    default RevisionAccessContext getRevisionAccessContext(String projectId, VersionId versionId, String path)
-    {
-        return getRevisionAccessContext(projectId, SourceSpecification.versionSourceSpecification(versionId), (path == null) ? null : Collections.singleton(path));
-    }
-
-    @Deprecated
-    default RevisionAccessContext getRevisionAccessContext(String projectId, VersionId versionId, Iterable<? extends String> paths)
-    {
-        return getRevisionAccessContext(projectId, SourceSpecification.versionSourceSpecification(versionId), paths);
-    }
-
-    @Deprecated
-    default RevisionAccessContext getRevisionAccessContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType)
-    {
-        return getRevisionAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, workspaceType, workspaceAccessType), null);
-    }
-
-    @Deprecated
-    default RevisionAccessContext getRevisionAccessContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType, String path)
-    {
-        return getRevisionAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, workspaceType, workspaceAccessType), (path == null) ? null : Collections.singleton(path));
-    }
-
     // File Modification Context
 
     interface FileModificationContext
@@ -462,50 +273,6 @@ public interface ProjectFileAccessProvider
     default FileModificationContext getFileModificationContext(String projectId, SourceSpecification sourceSpecification)
     {
         return getFileModificationContext(projectId, sourceSpecification, null);
-    }
-
-    @Deprecated
-    default FileModificationContext getProjectFileModificationContext(String projectId)
-    {
-        return getFileModificationContext(projectId, SourceSpecification.projectSourceSpecification(), null);
-    }
-
-    @Deprecated
-    default FileModificationContext getProjectFileModificationContext(String projectId, String revisionId)
-    {
-        Objects.requireNonNull(revisionId, "revisionId may not be null");
-        return getFileModificationContext(projectId, SourceSpecification.projectSourceSpecification(), revisionId);
-    }
-
-    @Deprecated
-    default FileModificationContext getWorkspaceFileModificationContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType)
-    {
-        Objects.requireNonNull(workspaceId, "workspaceId may not be null");
-        Objects.requireNonNull(workspaceType, "workspaceType may not be null");
-        Objects.requireNonNull(workspaceAccessType, "workspaceAccessType may not be null");
-        return getFileModificationContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, workspaceType, workspaceAccessType), null);
-    }
-
-    @Deprecated
-    default FileModificationContext getWorkspaceFileModificationContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType, String revisionId)
-    {
-        Objects.requireNonNull(workspaceId, "workspaceId may not be null");
-        Objects.requireNonNull(workspaceType, "workspaceType may not be null");
-        Objects.requireNonNull(workspaceAccessType, "workspaceAccessType may not be null");
-        Objects.requireNonNull(revisionId, "revisionId may not be null");
-        return getFileModificationContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, workspaceType, workspaceAccessType), revisionId);
-    }
-
-    @Deprecated
-    default FileModificationContext getFileModificationContext(String projectId, String workspaceId, WorkspaceAccessType workspaceAccessType, String revisionId)
-    {
-        return getFileModificationContext(projectId, workspaceId, WorkspaceType.USER, workspaceAccessType, revisionId);
-    }
-
-    @Deprecated
-    default FileModificationContext getFileModificationContext(String projectId, String workspaceId, WorkspaceType workspaceType, WorkspaceAccessType workspaceAccessType, String revisionId)
-    {
-        return getFileModificationContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, workspaceType, workspaceAccessType), revisionId);
     }
 
     enum WorkspaceAccessType

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/dependency/DependenciesApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/dependency/DependenciesApi.java
@@ -18,6 +18,7 @@ import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependenc
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 
 import java.util.Set;
 
@@ -25,17 +26,17 @@ public interface DependenciesApi
 {
     default Set<ProjectDependency> getUserWorkspaceRevisionUpstreamProjects(String projectId, String workspaceId, String revisionId, boolean transitive)
     {
-        return this.getWorkspaceRevisionUpstreamProjects(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId), revisionId, transitive);
+        return getWorkspaceRevisionUpstreamProjects(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER)), revisionId, transitive);
     }
 
     default Set<ProjectDependency> getGroupWorkspaceRevisionUpstreamProjects(String projectId, String workspaceId, String revisionId, boolean transitive)
     {
-        return this.getWorkspaceRevisionUpstreamProjects(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId), revisionId, transitive);
+        return getWorkspaceRevisionUpstreamProjects(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP)), revisionId, transitive);
     }
 
     default Set<ProjectDependency> getWorkspaceRevisionUpstreamProjects(String projectId, String workspaceId, WorkspaceType workspaceType, String revisionId, boolean transitive)
     {
-        return this.getWorkspaceRevisionUpstreamProjects(projectId, SourceSpecification.newSourceSpecification(workspaceId, workspaceType), revisionId, transitive);
+        return getWorkspaceRevisionUpstreamProjects(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, workspaceType)), revisionId, transitive);
     }
 
     // Upstream projects: projects that the project depends on

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/dependency/DependenciesApiImpl.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/dependency/DependenciesApiImpl.java
@@ -24,14 +24,14 @@ import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectApi;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
-import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 
+import javax.inject.Inject;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Set;
-import javax.inject.Inject;
 
 public class DependenciesApiImpl implements DependenciesApi
 {
@@ -57,7 +57,7 @@ public class DependenciesApiImpl implements DependenciesApi
     @Override
     public Set<ProjectDependency> getProjectRevisionUpstreamProjects(String projectId, VersionId patchReleaseVersionId, String revisionId, boolean transitive)
     {
-        ProjectConfiguration projectConfiguration = this.projectConfigurationApi.getProjectRevisionProjectConfiguration(projectId, patchReleaseVersionId, revisionId);
+        ProjectConfiguration projectConfiguration = this.projectConfigurationApi.getProjectConfiguration(projectId, (patchReleaseVersionId == null) ? SourceSpecification.projectSourceSpecification() : SourceSpecification.patchSourceSpecification(patchReleaseVersionId), revisionId);
         return searchUpstream(projectConfiguration, transitive);
     }
 

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/entity/EntityApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/entity/EntityApi.java
@@ -45,7 +45,7 @@ public interface EntityApi
     @Deprecated
     default EntityAccessContext getProjectEntityAccessContext(String projectId, VersionId patchReleaseVersionId)
     {
-        return getEntityAccessContext(projectId, SourceSpecification.newSourceSpecification(patchReleaseVersionId));
+        return getEntityAccessContext(projectId, SourceSpecification.patchSourceSpecification(patchReleaseVersionId));
     }
 
     @Deprecated
@@ -57,7 +57,7 @@ public interface EntityApi
     @Deprecated
     default EntityAccessContext getProjectRevisionEntityAccessContext(String projectId, VersionId patchReleaseVersionId, String revisionId)
     {
-        return getEntityAccessContext(projectId, SourceSpecification.newSourceSpecification(patchReleaseVersionId), revisionId);
+        return getEntityAccessContext(projectId, SourceSpecification.patchSourceSpecification(patchReleaseVersionId), revisionId);
     }
 
     @Deprecated

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/project/ProjectConfigurationApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/project/ProjectConfigurationApi.java
@@ -60,7 +60,7 @@ public interface ProjectConfigurationApi
     @Deprecated
     default ProjectConfiguration getProjectProjectConfiguration(String projectId, VersionId patchReleaseVersionId)
     {
-        return getProjectConfiguration(projectId, SourceSpecification.newSourceSpecification(patchReleaseVersionId));
+        return getProjectConfiguration(projectId, SourceSpecification.patchSourceSpecification(patchReleaseVersionId));
     }
 
     @Deprecated
@@ -78,7 +78,7 @@ public interface ProjectConfigurationApi
     @Deprecated
     default ProjectConfiguration getProjectRevisionProjectConfiguration(String projectId, VersionId patchReleaseVersionId, String revisionId)
     {
-        return getProjectConfiguration(projectId, SourceSpecification.newSourceSpecification(patchReleaseVersionId), revisionId);
+        return getProjectConfiguration(projectId, SourceSpecification.patchSourceSpecification(patchReleaseVersionId), revisionId);
     }
 
     @Deprecated
@@ -252,7 +252,7 @@ public interface ProjectConfigurationApi
     @Deprecated
     default List<ArtifactTypeGenerationConfiguration> getProjectAvailableArtifactGenerations(String projectId, VersionId patchReleaseVersionId)
     {
-        return getAvailableArtifactGenerations(projectId, SourceSpecification.newSourceSpecification(patchReleaseVersionId));
+        return getAvailableArtifactGenerations(projectId, SourceSpecification.patchSourceSpecification(patchReleaseVersionId));
     }
 
     @Deprecated

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/revision/RevisionApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/revision/RevisionApi.java
@@ -77,19 +77,13 @@ public interface RevisionApi
     @Deprecated
     default RevisionAccessContext getUserWorkspaceRevisionContext(String projectId, String workspaceId)
     {
-        return getRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId));
+        return getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER)));
     }
 
     @Deprecated
     default RevisionAccessContext getGroupWorkspaceRevisionContext(String projectId, String workspaceId)
     {
-        return getRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId));
-    }
-
-    @Deprecated
-    default RevisionAccessContext getWorkspaceRevisionContext(String projectId, String workspaceId)
-    {
-        return getRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId));
+        return getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP)));
     }
 
     @Deprecated
@@ -152,13 +146,13 @@ public interface RevisionApi
     @Deprecated
     default RevisionAccessContext getUserWorkspaceEntityRevisionContext(String projectId, String workspaceId, String entityPath)
     {
-        return getEntityRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId), entityPath);
+        return getEntityRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER)), entityPath);
     }
 
     @Deprecated
     default RevisionAccessContext getGroupWorkspaceEntityRevisionContext(String projectId, String workspaceId, String entityPath)
     {
-        return getEntityRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId), entityPath);
+        return getEntityRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP)), entityPath);
     }
 
     @Deprecated
@@ -175,13 +169,13 @@ public interface RevisionApi
     @Deprecated
     default RevisionAccessContext getUserWorkspacePackageRevisionContext(String projectId, String workspaceId, String packagePath)
     {
-        return getPackageRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId), packagePath);
+        return getPackageRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER)), packagePath);
     }
 
     @Deprecated
     default RevisionAccessContext getGroupWorkspacePackageRevisionContext(String projectId, String workspaceId, String packagePath)
     {
-        return getPackageRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId), packagePath);
+        return getPackageRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP)), packagePath);
     }
 
     @Deprecated

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/test/TestModelBuilder.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/test/TestModelBuilder.java
@@ -33,14 +33,16 @@ import org.finos.legend.sdlc.server.domain.api.dependency.DependenciesApi;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.project.source.WorkspaceSourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.tools.StringTools;
 
+import javax.inject.Inject;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.inject.Inject;
 
 public class TestModelBuilder
 {
@@ -69,10 +71,11 @@ public class TestModelBuilder
         DepotProjectId upstreamDepotProjectId = getDepotProjectId(upstreamProjectId);
         DepotProjectId downstreamDepotProjectId = DepotProjectId.parseProjectId(downstreamProjectId);
 
-        Set<ProjectDependency> latestUpstreamLevel1Dependencies = this.dependenciesApi.getWorkspaceRevisionUpstreamProjects(upstreamProjectId, SourceSpecification.newSourceSpecification(upstreamWorkspaceId, type), upstreamRevisionId, false);
+        WorkspaceSourceSpecification workspaceSourceSpecification = SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(upstreamWorkspaceId, type));
+        Set<ProjectDependency> latestUpstreamLevel1Dependencies = this.dependenciesApi.getWorkspaceRevisionUpstreamProjects(upstreamProjectId, workspaceSourceSpecification, upstreamRevisionId, false);
         Set<DepotProjectVersion> dependencies = processDependencies(upstreamDepotProjectId, downstreamDepotProjectId, downstreamVersionId, transformProjectDependencySet(latestUpstreamLevel1Dependencies));
 
-        List<Entity> upstreamProjectWorkspaceEntities = this.entityApi.getWorkspaceRevisionEntityAccessContext(upstreamProjectId, SourceSpecification.newSourceSpecification(upstreamWorkspaceId, type), upstreamRevisionId).getEntities(null, null, null);
+        List<Entity> upstreamProjectWorkspaceEntities = this.entityApi.getWorkspaceRevisionEntityAccessContext(upstreamProjectId, workspaceSourceSpecification, upstreamRevisionId).getEntities(null, null, null);
         return getEntities(downstreamDepotProjectId, downstreamVersionId, dependencies, upstreamProjectWorkspaceEntities);
     }
 

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/workflow/WorkflowApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/workflow/WorkflowApi.java
@@ -32,7 +32,7 @@ public interface WorkflowApi
     @Deprecated
     default WorkflowAccessContext getProjectWorkflowAccessContext(String projectId, VersionId patchReleaseVersionId)
     {
-        return getWorkflowAccessContext(projectId, SourceSpecification.newSourceSpecification(patchReleaseVersionId));
+        return getWorkflowAccessContext(projectId, SourceSpecification.patchSourceSpecification(patchReleaseVersionId));
     }
 
     @Deprecated

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/workflow/WorkflowJobApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/domain/api/workflow/WorkflowJobApi.java
@@ -32,7 +32,7 @@ public interface WorkflowJobApi
     @Deprecated
     default WorkflowJobAccessContext getProjectWorkflowJobAccessContext(String projectId, VersionId patchReleaseVersionId)
     {
-        return getWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(patchReleaseVersionId));
+        return getWorkflowJobAccessContext(projectId, SourceSpecification.patchSourceSpecification(patchReleaseVersionId));
     }
 
     @Deprecated

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabApiWithFileAccess.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabApiWithFileAccess.java
@@ -74,6 +74,8 @@ import org.gitlab4j.api.models.TreeItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.Response.Status.Family;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -91,8 +93,6 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.core.Response.Status.Family;
 
 abstract class GitLabApiWithFileAccess extends BaseGitLabApi
 {
@@ -112,7 +112,7 @@ abstract class GitLabApiWithFileAccess extends BaseGitLabApi
     @Deprecated
     protected ProjectConfiguration getProjectConfiguration(String projectId, VersionId patchReleaseVersionId)
     {
-        return getProjectConfiguration(projectId, SourceSpecification.newSourceSpecification(patchReleaseVersionId));
+        return getProjectConfiguration(projectId, SourceSpecification.patchSourceSpecification(patchReleaseVersionId));
     }
 
     protected ProjectConfiguration getProjectConfiguration(String projectId, SourceSpecification sourceSpecification)

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabBuildApi.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/gitlab/api/GitLabBuildApi.java
@@ -22,6 +22,7 @@ import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.build.BuildAccessContext;
 import org.finos.legend.sdlc.server.domain.api.build.BuildApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.gitlab.GitLabConfiguration;
 import org.finos.legend.sdlc.server.gitlab.GitLabProjectId;
@@ -76,7 +77,7 @@ public class GitLabBuildApi extends GitLabApiWithFileAccess implements BuildApi
             @Override
             protected ProjectFileAccessProvider.RevisionAccessContext getRevisionAccessContext()
             {
-                return getProjectFileAccessProvider().getProjectRevisionAccessContext(projectId);
+                return getProjectFileAccessProvider().getRevisionAccessContext(projectId, SourceSpecification.projectSourceSpecification(), null);
             }
         };
     }
@@ -92,7 +93,7 @@ public class GitLabBuildApi extends GitLabApiWithFileAccess implements BuildApi
             @Override
             protected String getRef()
             {
-                return getBranchName(gitLabProjectId, SourceSpecification.newSourceSpecification(workspaceId, workspaceType, workspaceAccessType));
+                return getBranchName(gitLabProjectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, workspaceType, workspaceAccessType)));
             }
 
             @Override
@@ -104,7 +105,7 @@ public class GitLabBuildApi extends GitLabApiWithFileAccess implements BuildApi
             @Override
             protected ProjectFileAccessProvider.RevisionAccessContext getRevisionAccessContext()
             {
-                return getProjectFileAccessProvider().getWorkspaceRevisionAccessContext(projectId, workspaceId, workspaceType, workspaceAccessType);
+                return getProjectFileAccessProvider().getRevisionAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, workspaceType, workspaceAccessType)), null);
             }
         };
     }
@@ -131,7 +132,7 @@ public class GitLabBuildApi extends GitLabApiWithFileAccess implements BuildApi
             @Override
             protected ProjectFileAccessProvider.RevisionAccessContext getRevisionAccessContext()
             {
-                return getProjectFileAccessProvider().getVersionRevisionAccessContext(projectId, versionId);
+                return getProjectFileAccessProvider().getRevisionAccessContext(projectId, SourceSpecification.versionSourceSpecification(versionId), null);
             }
         };
     }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructure.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/project/ProjectStructure.java
@@ -48,7 +48,11 @@ import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.serialization.EntitySerializer;
 import org.finos.legend.sdlc.serialization.EntitySerializers;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationUpdater;
+import org.finos.legend.sdlc.server.domain.api.project.source.PatchSourceSpecification;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificationConsumer;
+import org.finos.legend.sdlc.server.domain.api.project.source.VersionSourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.project.source.WorkspaceSourceSpecification;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.FileAccessContext;
@@ -59,6 +63,8 @@ import org.finos.legend.sdlc.server.project.extension.ProjectStructureExtensionP
 import org.finos.legend.sdlc.server.tools.StringTools;
 import org.finos.legend.sdlc.tools.entity.EntityPaths;
 
+import javax.lang.model.SourceVersion;
+import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -75,8 +81,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import javax.lang.model.SourceVersion;
-import javax.ws.rs.core.Response.Status;
 
 public abstract class ProjectStructure
 {
@@ -342,7 +346,7 @@ public abstract class ProjectStructure
     @Deprecated
     public static ProjectConfiguration getProjectConfiguration(String projectId, String workspaceId, String revisionId, ProjectFileAccessProvider projectFileAccessProvider, WorkspaceAccessType workspaceAccessType)
     {
-        return getProjectConfiguration(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, workspaceAccessType), revisionId, projectFileAccessProvider);
+        return getProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, workspaceAccessType)), revisionId, projectFileAccessProvider);
     }
 
     public static ProjectConfiguration getProjectConfiguration(String projectId, SourceSpecification sourceSpecification, String revisionId, ProjectFileAccessProvider projectFileAccessProvider)
@@ -352,7 +356,7 @@ public abstract class ProjectStructure
 
     public static ProjectConfiguration getProjectConfiguration(String projectId, VersionId versionId, ProjectFileAccessProvider projectFileAccessProvider)
     {
-        return getProjectConfiguration(projectFileAccessProvider.getFileAccessContext(projectId, versionId));
+        return getProjectConfiguration(projectFileAccessProvider.getFileAccessContext(projectId, SourceSpecification.versionSourceSpecification(versionId)));
     }
 
     public static ProjectConfiguration getProjectConfiguration(FileAccessContext fileAccessContext)
@@ -399,17 +403,14 @@ public abstract class ProjectStructure
     private static Revision updateProjectConfiguration(UpdateBuilder updateBuilder, boolean requireRevisionId)
     {
         String projectId = updateBuilder.getProjectId();
-        String workspaceId = updateBuilder.getSourceSpecification().getWorkspaceId();
-        VersionId patchReleaseVersionId = updateBuilder.getSourceSpecification().getPatchReleaseVersionId();
-        WorkspaceType workspaceType = updateBuilder.getSourceSpecification().getWorkspaceType();
-        WorkspaceAccessType workspaceAccessType = updateBuilder.getSourceSpecification().getWorkspaceAccessType();
+        SourceSpecification sourceSpecification = updateBuilder.getSourceSpecification();
         ProjectFileAccessProvider projectFileAccessProvider = updateBuilder.getProjectFileAccessProvider();
 
         String revisionId;
         if (updateBuilder.getRevisionId() == null)
         {
             // if revisionId not specified, get the current revision
-            Revision currentRevision = projectFileAccessProvider.getRevisionAccessContext(projectId, workspaceId, workspaceType, workspaceAccessType).getCurrentRevision();
+            Revision currentRevision = projectFileAccessProvider.getRevisionAccessContext(projectId, sourceSpecification, null).getCurrentRevision();
             if (currentRevision != null)
             {
                 revisionId = currentRevision.getId();
@@ -417,10 +418,27 @@ public abstract class ProjectStructure
             else if (requireRevisionId)
             {
                 StringBuilder builder = new StringBuilder("Could not find current revision for ");
-                if (workspaceId != null)
+                sourceSpecification.visit(new SourceSpecificationConsumer()
                 {
-                    builder.append(workspaceType.getLabel()).append(" ").append(workspaceAccessType.getLabel()).append(" ").append(workspaceId).append("in ");
-                }
+                    @Override
+                    protected void accept(VersionSourceSpecification sourceSpec)
+                    {
+                        sourceSpec.getVersionId().appendVersionIdString(builder.append("version ")).append(" of ");
+                    }
+
+                    @Override
+                    protected void accept(PatchSourceSpecification sourceSpec)
+                    {
+                        sourceSpec.getVersionId().appendVersionIdString(builder.append("patch version ")).append(" of ");
+                    }
+
+                    @Override
+                    protected void accept(WorkspaceSourceSpecification sourceSpec)
+                    {
+                        WorkspaceSpecification workspaceSpec = sourceSpec.getWorkspaceSpecification();
+                        builder.append(workspaceSpec.getType().getLabel()).append(" ").append(workspaceSpec.getAccessType().getLabel()).append(" ").append(workspaceSpec.getId()).append("in ");
+                    }
+                });
                 builder.append("project ").append(projectId).append(": it may be corrupt");
                 throw new LegendSDLCServerException(builder.toString());
             }
@@ -434,7 +452,7 @@ public abstract class ProjectStructure
             revisionId = updateBuilder.getRevisionId();
         }
 
-        FileAccessContext fileAccessContext = CachingFileAccessContext.wrap(projectFileAccessProvider.getFileAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, workspaceType, workspaceAccessType, patchReleaseVersionId), revisionId));
+        FileAccessContext fileAccessContext = CachingFileAccessContext.wrap(projectFileAccessProvider.getFileAccessContext(projectId, sourceSpecification, revisionId));
 
         ProjectFile configFile = getProjectConfigurationFile(fileAccessContext);
         ProjectConfiguration currentConfig = (configFile == null) ? getDefaultProjectConfiguration(projectId) : readProjectConfiguration(configFile);
@@ -565,7 +583,7 @@ public abstract class ProjectStructure
         }
 
         // Submit changes
-        return projectFileAccessProvider.getFileModificationContext(projectId, workspaceId, workspaceType, workspaceAccessType, revisionId).submit(updateBuilder.getMessage(), operations);
+        return projectFileAccessProvider.getFileModificationContext(projectId, sourceSpecification, revisionId).submit(updateBuilder.getMessage(), operations);
     }
 
     private static void validateProjectConfiguration(ProjectConfiguration config)
@@ -680,7 +698,7 @@ public abstract class ProjectStructure
         {
             try
             {
-                ProjectConfiguration dependencyConfig = getProjectConfiguration(projectFileAccessProvider.getFileAccessContext(dep.getProjectId(), VersionId.parseVersionId(dep.getVersionId())));
+                ProjectConfiguration dependencyConfig = getProjectConfiguration(projectFileAccessProvider.getFileAccessContext(dep.getProjectId(), SourceSpecification.versionSourceSpecification(VersionId.parseVersionId(dep.getVersionId()))));
                 if ((dependencyConfig == null) || (dependencyConfig.getArtifactId() == null) || (dependencyConfig.getGroupId() == null))
                 {
                     unknownDependencies.add(dep);

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceEntitiesResource.java
@@ -25,6 +25,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -88,7 +89,7 @@ public class BackupPatchesGroupWorkspaceEntitiesResource extends EntityAccessRes
         }
         return executeWithLogging(
                 "getting entities in backup group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -109,7 +110,7 @@ public class BackupPatchesGroupWorkspaceEntitiesResource extends EntityAccessRes
         }
         return executeWithLogging(
                 "getting entity " + path + " in backup group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
+                () -> this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceEntitiesResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -85,7 +88,7 @@ public class BackupPatchesGroupWorkspaceEntitiesResource extends EntityAccessRes
         }
         return executeWithLogging(
                 "getting entities in backup group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -106,7 +109,7 @@ public class BackupPatchesGroupWorkspaceEntitiesResource extends EntityAccessRes
         }
         return executeWithLogging(
                 "getting entity " + path + " in backup group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).getEntity(path)
+                () -> this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceEntityPathsResource.java
@@ -17,10 +17,14 @@ package org.finos.legend.sdlc.server.resources.backup.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -81,7 +85,7 @@ public class BackupPatchesGroupWorkspaceEntityPathsResource extends EntityAccess
         }
         return executeWithLogging(
                 "getting entity paths in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceProjectConfigurationResource.java
@@ -17,10 +17,14 @@ package org.finos.legend.sdlc.server.resources.backup.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -62,7 +66,7 @@ public class BackupPatchesGroupWorkspaceProjectConfigurationResource extends Bas
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in backup group workspace " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getBackupWorkspaceProjectConfiguration(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.projectConfigurationApi.getProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceResource.java
@@ -18,11 +18,14 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.backup.BackupApi;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
-import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -69,7 +72,7 @@ public class BackupPatchesGroupWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "getting backup group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workspaceApi.getBackupWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.getWorkspace(projectId, WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))
         );
     }
 
@@ -90,7 +93,7 @@ public class BackupPatchesGroupWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "checking if backup group workspace " + workspaceId + " of project " + projectId + " for patch release version " + patchReleaseVersionId + " is outdated",
-                () -> this.workspaceApi.isBackupWorkspaceOutdated(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.isWorkspaceOutdated(projectId, WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))
         );
     }
 
@@ -110,7 +113,7 @@ public class BackupPatchesGroupWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 "discarding backup group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.backupApi.discardBackupWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.backupApi.discardBackupWorkspace(projectId, WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))
         );
     }
 
@@ -133,8 +136,8 @@ public class BackupPatchesGroupWorkspaceResource extends BaseResource
             throw new LegendSDLCServerException(e.getMessage(), Response.Status.BAD_REQUEST, e);
         }
         executeWithLogging(
-                forceRecovery ? "force " : "" + "recovering group workspace " + workspaceId + " from backup in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.backupApi.recoverBackupWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), forceRecovery)
+                forceRecovery ? "force " : "recovering group workspace " + workspaceId + " from backup in project " + projectId + " for patch release version " + patchReleaseVersionId,
+                () -> this.backupApi.recoverBackupWorkspace(projectId, WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)), forceRecovery)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceRevisionEntitiesResource.java
@@ -18,10 +18,14 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -87,7 +91,7 @@ public class BackupPatchesGroupWorkspaceRevisionEntitiesResource extends EntityA
         }
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of backup group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -108,7 +112,7 @@ public class BackupPatchesGroupWorkspaceRevisionEntitiesResource extends EntityA
         }
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of backup group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId).getEntity(path)
+                () -> this.entityApi.getEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceRevisionEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceRevisionEntityPathsResource.java
@@ -17,10 +17,14 @@ package org.finos.legend.sdlc.server.resources.backup.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -82,7 +86,7 @@ public class BackupPatchesGroupWorkspaceRevisionEntityPathsResource extends Enti
         }
         return executeWithLogging(
                 "getting entity paths in revision " + revisionId + " of backup group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceRevisionProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceRevisionProjectConfigurationResource.java
@@ -18,10 +18,14 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -66,7 +70,7 @@ public class BackupPatchesGroupWorkspaceRevisionProjectConfigurationResource ext
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in backup group workspace " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getBackupWorkspaceRevisionProjectConfiguration(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId)
+                () -> this.projectConfigurationApi.getProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/group/BackupPatchesGroupWorkspaceRevisionsResource.java
@@ -17,11 +17,15 @@ package org.finos.legend.sdlc.server.resources.backup.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
-import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
 import org.finos.legend.sdlc.server.time.ResolvedInstant;
@@ -73,7 +77,7 @@ public class BackupPatchesGroupWorkspaceRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision for group backup workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getBackupWorkspaceRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -97,7 +101,7 @@ public class BackupPatchesGroupWorkspaceRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for backup group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getBackupWorkspaceRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).getRevision(revisionId)
+                () -> this.revisionApi.getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceEntitiesResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -85,7 +88,7 @@ public class BackupPatchesWorkspaceEntitiesResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "getting entities in backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -106,7 +109,7 @@ public class BackupPatchesWorkspaceEntitiesResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "getting entity " + path + " in backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).getEntity(path)
+                () -> this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceEntitiesResource.java
@@ -25,6 +25,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -88,7 +89,7 @@ public class BackupPatchesWorkspaceEntitiesResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "getting entities in backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -109,7 +110,7 @@ public class BackupPatchesWorkspaceEntitiesResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "getting entity " + path + " in backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
+                () -> this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceEntityPathsResource.java
@@ -24,6 +24,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -84,7 +85,7 @@ public class BackupPatchesWorkspaceEntityPathsResource extends EntityAccessResou
         }
         return executeWithLogging(
                 "getting entity paths in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceEntityPathsResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.backup.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -81,7 +84,7 @@ public class BackupPatchesWorkspaceEntityPathsResource extends EntityAccessResou
         }
         return executeWithLogging(
                 "getting entity paths in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getBackupWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceProjectConfigurationResource.java
@@ -24,6 +24,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -65,7 +66,7 @@ public class BackupPatchesWorkspaceProjectConfigurationResource extends BaseReso
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in backup user workspace " + workspaceId,
-                () -> this.projectConfigurationApi.getBackupWorkspaceProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.projectConfigurationApi.getBackupWorkspaceProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceProjectConfigurationResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.backup.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -62,7 +65,7 @@ public class BackupPatchesWorkspaceProjectConfigurationResource extends BaseReso
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in backup user workspace " + workspaceId,
-                () -> this.projectConfigurationApi.getBackupWorkspaceProjectConfiguration(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.projectConfigurationApi.getBackupWorkspaceProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceResource.java
@@ -21,11 +21,12 @@ import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.backup.BackupApi;
-import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -72,7 +73,7 @@ public class BackupPatchesWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "getting backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workspaceApi.getBackupWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.workspaceApi.getBackupWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -93,7 +94,7 @@ public class BackupPatchesWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "checking if backup user workspace " + workspaceId + " of project " + projectId + " for patch release version " + patchReleaseVersionId + " is outdated",
-                () -> this.workspaceApi.isBackupWorkspaceOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.workspaceApi.isBackupWorkspaceOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -113,7 +114,7 @@ public class BackupPatchesWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 "discarding backup user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.backupApi.discardBackupWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.backupApi.discardBackupWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -137,7 +138,7 @@ public class BackupPatchesWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 forceRecovery ? "force " : "" + "recovering user workspace " + workspaceId + " from backup in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.backupApi.recoverBackupWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), forceRecovery)
+                () -> this.backupApi.recoverBackupWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))), forceRecovery)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceResource.java
@@ -18,10 +18,13 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.backup.BackupApi;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -69,7 +72,7 @@ public class BackupPatchesWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "getting backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workspaceApi.getBackupWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.getBackupWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -90,7 +93,7 @@ public class BackupPatchesWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "checking if backup user workspace " + workspaceId + " of project " + projectId + " for patch release version " + patchReleaseVersionId + " is outdated",
-                () -> this.workspaceApi.isBackupWorkspaceOutdated(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.isBackupWorkspaceOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -110,7 +113,7 @@ public class BackupPatchesWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 "discarding backup user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.backupApi.discardBackupWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.backupApi.discardBackupWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -134,7 +137,7 @@ public class BackupPatchesWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 forceRecovery ? "force " : "" + "recovering user workspace " + workspaceId + " from backup in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.backupApi.recoverBackupWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), forceRecovery)
+                () -> this.backupApi.recoverBackupWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), forceRecovery)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionEntitiesResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -86,7 +89,7 @@ public class BackupPatchesWorkspaceRevisionEntitiesResource extends EntityAccess
         }
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -107,7 +110,7 @@ public class BackupPatchesWorkspaceRevisionEntitiesResource extends EntityAccess
         }
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId).getEntity(path)
+                () -> this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionEntitiesResource.java
@@ -25,6 +25,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -89,7 +90,7 @@ public class BackupPatchesWorkspaceRevisionEntitiesResource extends EntityAccess
         }
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -110,7 +111,7 @@ public class BackupPatchesWorkspaceRevisionEntitiesResource extends EntityAccess
         }
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
+                () -> this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionEntityPathsResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.backup.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -82,7 +85,7 @@ public class BackupPatchesWorkspaceRevisionEntityPathsResource extends EntityAcc
         }
         return executeWithLogging(
                 "getting entity paths in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionEntityPathsResource.java
@@ -24,6 +24,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -85,7 +86,7 @@ public class BackupPatchesWorkspaceRevisionEntityPathsResource extends EntityAcc
         }
         return executeWithLogging(
                 "getting entity paths in revision " + revisionId + " of backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getBackupWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionProjectConfigurationResource.java
@@ -25,6 +25,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -69,7 +70,7 @@ public class BackupPatchesWorkspaceRevisionProjectConfigurationResource extends 
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in backup user workspace " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getBackupWorkspaceRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
+                () -> this.projectConfigurationApi.getBackupWorkspaceRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionProjectConfigurationResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -66,7 +69,7 @@ public class BackupPatchesWorkspaceRevisionProjectConfigurationResource extends 
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in backup user workspace " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getBackupWorkspaceRevisionProjectConfiguration(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId)
+                () -> this.projectConfigurationApi.getBackupWorkspaceRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionsResource.java
@@ -20,11 +20,12 @@ import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
-import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
 import org.finos.legend.sdlc.server.time.ResolvedInstant;
@@ -76,7 +77,7 @@ public class BackupPatchesWorkspaceRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision for user backup workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -100,7 +101,7 @@ public class BackupPatchesWorkspaceRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
+                () -> this.revisionApi.getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.BACKUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/backup/patch/user/BackupPatchesWorkspaceRevisionsResource.java
@@ -17,10 +17,13 @@ package org.finos.legend.sdlc.server.resources.backup.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
@@ -73,7 +76,7 @@ public class BackupPatchesWorkspaceRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision for user backup workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getBackupWorkspaceRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -97,7 +100,7 @@ public class BackupPatchesWorkspaceRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for backup user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getBackupWorkspaceRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).getRevision(revisionId)
+                () -> this.revisionApi.getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/comparison/patch/group/PatchesGroupComparisonWorkspaceResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/comparison/patch/group/PatchesGroupComparisonWorkspaceResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.comparison.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.comparison.Comparison;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.comparison.ComparisonApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -63,7 +66,7 @@ public class PatchesGroupComparisonWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "getting comparison between current group workspace revision and project revision at workspace creation, for group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.comparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.comparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -84,7 +87,7 @@ public class PatchesGroupComparisonWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "getting comparison between current group workspace revision and current project revision, for group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.comparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.comparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/comparison/patch/user/ComparisonPatchesWorkspaceResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/comparison/patch/user/ComparisonPatchesWorkspaceResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.comparison.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.comparison.Comparison;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.comparison.ComparisonApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -63,7 +66,7 @@ public class ComparisonPatchesWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "getting comparison between current user workspace revision and project revision at workspace creation, for user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.comparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.comparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -84,7 +87,7 @@ public class ComparisonPatchesWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "getting comparison between current user workspace revision and current project revision, for user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.comparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.comparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceEntitiesResource.java
@@ -25,10 +25,9 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
-import java.util.List;
-import java.util.Set;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
@@ -39,6 +38,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Set;
 
 @Path("/projects/{projectId}/patches/{patchReleaseVersionId}/groupWorkspaces/{workspaceId}/conflictResolution/entities")
 @Api("Conflict Resolution")
@@ -88,7 +89,7 @@ public class ConflictResolutionPatchesGroupWorkspaceEntitiesResource extends Ent
         }
         return executeWithLogging(
                 "getting entities in group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -109,7 +110,7 @@ public class ConflictResolutionPatchesGroupWorkspaceEntitiesResource extends Ent
         }
         return executeWithLogging(
                 "getting entity " + path + " in group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
+                () -> this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceEntitiesResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -85,7 +88,7 @@ public class ConflictResolutionPatchesGroupWorkspaceEntitiesResource extends Ent
         }
         return executeWithLogging(
                 "getting entities in group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -106,7 +109,7 @@ public class ConflictResolutionPatchesGroupWorkspaceEntitiesResource extends Ent
         }
         return executeWithLogging(
                 "getting entity " + path + " in group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).getEntity(path)
+                () -> this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceEntityPathsResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.conflictResolution.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -81,7 +84,7 @@ public class ConflictResolutionPatchesGroupWorkspaceEntityPathsResource extends 
         }
         return executeWithLogging(
                 "getting entity paths in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceEntityPathsResource.java
@@ -24,6 +24,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -84,7 +85,7 @@ public class ConflictResolutionPatchesGroupWorkspaceEntityPathsResource extends 
         }
         return executeWithLogging(
                 "getting entity paths in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceProjectConfigurationResource.java
@@ -24,6 +24,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -65,7 +66,7 @@ public class ConflictResolutionPatchesGroupWorkspaceProjectConfigurationResource
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in group workspace with conflict resolution " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceProjectConfigurationResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.conflictResolution.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -62,7 +65,7 @@ public class ConflictResolutionPatchesGroupWorkspaceProjectConfigurationResource
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in group workspace with conflict resolution " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionProjectConfiguration(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceResource.java
@@ -17,11 +17,14 @@ package org.finos.legend.sdlc.server.resources.conflictResolution.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.application.entity.PerformChangesCommand;
 import org.finos.legend.sdlc.server.domain.api.conflictResolution.ConflictResolutionApi;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -68,7 +71,7 @@ public class ConflictResolutionPatchesGroupWorkspaceResource extends BaseResourc
         }
         return executeWithLogging(
                 "getting group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workspaceApi.getWorkspaceWithConflictResolution(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.getWorkspaceWithConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -89,7 +92,7 @@ public class ConflictResolutionPatchesGroupWorkspaceResource extends BaseResourc
         }
         return executeWithLogging(
                 "checking if group workspace with conflict resolution " + workspaceId + " of project " + projectId + " for patch release version " + patchReleaseVersionId + " is outdated",
-                () -> this.workspaceApi.isWorkspaceWithConflictResolutionOutdated(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.isWorkspaceWithConflictResolutionOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -109,7 +112,7 @@ public class ConflictResolutionPatchesGroupWorkspaceResource extends BaseResourc
         }
         executeWithLogging(
                 "discarding conflict resolution for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -130,7 +133,7 @@ public class ConflictResolutionPatchesGroupWorkspaceResource extends BaseResourc
         }
         executeWithLogging(
                 "discarding all conflict resolution changes for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -152,7 +155,7 @@ public class ConflictResolutionPatchesGroupWorkspaceResource extends BaseResourc
         }
         executeWithLogging(
                 "accept conflict resolution for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.acceptConflictResolution(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), command)
+                () -> this.conflictResolutionApi.acceptConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), command)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceResource.java
@@ -21,11 +21,12 @@ import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.application.entity.PerformChangesCommand;
 import org.finos.legend.sdlc.server.domain.api.conflictResolution.ConflictResolutionApi;
-import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -71,7 +72,7 @@ public class ConflictResolutionPatchesGroupWorkspaceResource extends BaseResourc
         }
         return executeWithLogging(
                 "getting group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workspaceApi.getWorkspaceWithConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.workspaceApi.getWorkspaceWithConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -92,7 +93,7 @@ public class ConflictResolutionPatchesGroupWorkspaceResource extends BaseResourc
         }
         return executeWithLogging(
                 "checking if group workspace with conflict resolution " + workspaceId + " of project " + projectId + " for patch release version " + patchReleaseVersionId + " is outdated",
-                () -> this.workspaceApi.isWorkspaceWithConflictResolutionOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.workspaceApi.isWorkspaceWithConflictResolutionOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -112,7 +113,7 @@ public class ConflictResolutionPatchesGroupWorkspaceResource extends BaseResourc
         }
         executeWithLogging(
                 "discarding conflict resolution for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -133,7 +134,7 @@ public class ConflictResolutionPatchesGroupWorkspaceResource extends BaseResourc
         }
         executeWithLogging(
                 "discarding all conflict resolution changes for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -155,7 +156,7 @@ public class ConflictResolutionPatchesGroupWorkspaceResource extends BaseResourc
         }
         executeWithLogging(
                 "accept conflict resolution for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.acceptConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), command)
+                () -> this.conflictResolutionApi.acceptConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))), command)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionEntitiesResource.java
@@ -25,6 +25,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -90,7 +91,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionEntitiesResource ext
         }
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -116,7 +117,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionEntitiesResource ext
         }
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
+                () -> this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionEntitiesResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -87,7 +90,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionEntitiesResource ext
         }
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -113,7 +116,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionEntitiesResource ext
         }
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId).getEntity(path)
+                () -> this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionEntityPathsResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.conflictResolution.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -82,7 +85,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionEntityPathsResource 
         }
         return executeWithLogging(
                 "getting entity paths in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionEntityPathsResource.java
@@ -24,6 +24,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -85,7 +86,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionEntityPathsResource 
         }
         return executeWithLogging(
                 "getting entity paths in revision " + revisionId + " of group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionProjectConfigurationResource.java
@@ -25,6 +25,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -69,7 +70,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionProjectConfiguration
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in group workspace with conflict resolution " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
+                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionProjectConfigurationResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -66,7 +69,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionProjectConfiguration
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in group workspace with conflict resolution " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionRevisionProjectConfiguration(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId)
+                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionsResource.java
@@ -17,10 +17,13 @@ package org.finos.legend.sdlc.server.resources.conflictResolution.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
@@ -73,7 +76,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionsResource extends Ba
         }
         return executeWithLogging(
                 "getting revision for group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -97,7 +100,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionsResource extends Ba
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).getRevision(revisionId)
+                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/group/ConflictResolutionPatchesGroupWorkspaceRevisionsResource.java
@@ -20,11 +20,12 @@ import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
-import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
 import org.finos.legend.sdlc.server.time.ResolvedInstant;
@@ -76,7 +77,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionsResource extends Ba
         }
         return executeWithLogging(
                 "getting revision for group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -100,7 +101,7 @@ public class ConflictResolutionPatchesGroupWorkspaceRevisionsResource extends Ba
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for group workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
+                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceEntitiesResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -85,7 +88,7 @@ public class ConflictResolutionPatchesWorkspaceEntitiesResource extends EntityAc
         }
         return executeWithLogging(
                 "getting entities in user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -106,7 +109,7 @@ public class ConflictResolutionPatchesWorkspaceEntitiesResource extends EntityAc
         }
         return executeWithLogging(
                 "getting entity " + path + " in user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).getEntity(path)
+                () -> this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceEntitiesResource.java
@@ -25,10 +25,9 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
-import java.util.List;
-import java.util.Set;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
@@ -39,6 +38,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Set;
 
 @Path("/projects/{projectId}/patches/{patchReleaseVersionId}/workspaces/{workspaceId}/conflictResolution/entities")
 @Api("Conflict Resolution")
@@ -88,7 +89,7 @@ public class ConflictResolutionPatchesWorkspaceEntitiesResource extends EntityAc
         }
         return executeWithLogging(
                 "getting entities in user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -109,7 +110,7 @@ public class ConflictResolutionPatchesWorkspaceEntitiesResource extends EntityAc
         }
         return executeWithLogging(
                 "getting entity " + path + " in user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
+                () -> this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceEntityPathsResource.java
@@ -24,6 +24,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -84,7 +85,7 @@ public class ConflictResolutionPatchesWorkspaceEntityPathsResource extends Entit
         }
         return executeWithLogging(
                 "getting entity paths in user workspace " + workspaceId + " for project " + projectId +  " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceEntityPathsResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.conflictResolution.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -81,7 +84,7 @@ public class ConflictResolutionPatchesWorkspaceEntityPathsResource extends Entit
         }
         return executeWithLogging(
                 "getting entity paths in user workspace " + workspaceId + " for project " + projectId +  " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceProjectConfigurationResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.conflictResolution.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -62,7 +65,7 @@ public class ConflictResolutionPatchesWorkspaceProjectConfigurationResource exte
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in user workspace with conflict resolution " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionProjectConfiguration(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceProjectConfigurationResource.java
@@ -24,6 +24,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -65,7 +66,7 @@ public class ConflictResolutionPatchesWorkspaceProjectConfigurationResource exte
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in user workspace with conflict resolution " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceResource.java
@@ -21,11 +21,12 @@ import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.application.entity.PerformChangesCommand;
 import org.finos.legend.sdlc.server.domain.api.conflictResolution.ConflictResolutionApi;
-import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -71,7 +72,7 @@ public class ConflictResolutionPatchesWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "getting user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workspaceApi.getWorkspaceWithConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.workspaceApi.getWorkspaceWithConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -92,7 +93,7 @@ public class ConflictResolutionPatchesWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "checking if user workspace with conflict resolution " + workspaceId + " of project " + projectId + " for patch release version " + patchReleaseVersionId + " is outdated",
-                () -> this.workspaceApi.isWorkspaceWithConflictResolutionOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.workspaceApi.isWorkspaceWithConflictResolutionOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -112,7 +113,7 @@ public class ConflictResolutionPatchesWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 "discarding conflict resolution for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -133,7 +134,7 @@ public class ConflictResolutionPatchesWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 "discarding all conflict resolution changes for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
+                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -155,7 +156,7 @@ public class ConflictResolutionPatchesWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 "accept conflict resolution for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.acceptConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), command)
+                () -> this.conflictResolutionApi.acceptConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))), command)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceResource.java
@@ -17,11 +17,14 @@ package org.finos.legend.sdlc.server.resources.conflictResolution.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.application.entity.PerformChangesCommand;
 import org.finos.legend.sdlc.server.domain.api.conflictResolution.ConflictResolutionApi;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -68,7 +71,7 @@ public class ConflictResolutionPatchesWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "getting user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workspaceApi.getWorkspaceWithConflictResolution(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.getWorkspaceWithConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -89,7 +92,7 @@ public class ConflictResolutionPatchesWorkspaceResource extends BaseResource
         }
         return executeWithLogging(
                 "checking if user workspace with conflict resolution " + workspaceId + " of project " + projectId + " for patch release version " + patchReleaseVersionId + " is outdated",
-                () -> this.workspaceApi.isWorkspaceWithConflictResolutionOutdated(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.isWorkspaceWithConflictResolutionOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -109,7 +112,7 @@ public class ConflictResolutionPatchesWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 "discarding conflict resolution for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -130,7 +133,7 @@ public class ConflictResolutionPatchesWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 "discarding all conflict resolution changes for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.conflictResolutionApi.discardConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -152,7 +155,7 @@ public class ConflictResolutionPatchesWorkspaceResource extends BaseResource
         }
         executeWithLogging(
                 "accept conflict resolution for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.conflictResolutionApi.acceptConflictResolution(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), command)
+                () -> this.conflictResolutionApi.acceptConflictResolution(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), command)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionEntitiesResource.java
@@ -25,6 +25,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -90,7 +91,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionEntitiesResource extends 
         }
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -116,7 +117,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionEntitiesResource extends 
         }
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
+                () -> this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionEntitiesResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -87,7 +90,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionEntitiesResource extends 
         }
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -113,7 +116,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionEntitiesResource extends 
         }
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId).getEntity(path)
+                () -> this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionEntityPathsResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.conflictResolution.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -82,7 +85,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionEntityPathsResource exten
         }
         return executeWithLogging(
                 "getting entity paths in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionEntityPathsResource.java
@@ -24,6 +24,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
 import javax.inject.Inject;
@@ -85,7 +86,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionEntityPathsResource exten
         }
         return executeWithLogging(
                 "getting entity paths in revision " + revisionId + " of user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceWithConflictResolutionRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionProjectConfigurationResource.java
@@ -25,6 +25,7 @@ import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecificatio
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
 import javax.inject.Inject;
@@ -69,7 +70,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionProjectConfigurationResou
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in user workspace with conflict resolution " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
+                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionProjectConfigurationResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -66,7 +69,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionProjectConfigurationResou
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in user workspace with conflict resolution " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionRevisionProjectConfiguration(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId)
+                () -> this.projectConfigurationApi.getWorkspaceWithConflictResolutionRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionsResource.java
@@ -17,10 +17,13 @@ package org.finos.legend.sdlc.server.resources.conflictResolution.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
@@ -73,7 +76,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionsResource extends BaseRes
         }
         return executeWithLogging(
                 "getting revision for user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -97,7 +100,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionsResource extends BaseRes
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).getRevision(revisionId)
+                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/conflictResolution/patch/user/ConflictResolutionPatchesWorkspaceRevisionsResource.java
@@ -20,11 +20,12 @@ import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
-import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
+import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider.WorkspaceAccessType;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
 import org.finos.legend.sdlc.server.time.ResolvedInstant;
@@ -76,7 +77,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionsResource extends BaseRes
         }
         return executeWithLogging(
                 "getting revision for user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -100,7 +101,7 @@ public class ConflictResolutionPatchesWorkspaceRevisionsResource extends BaseRes
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for user workspace with conflict resolution " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
+                () -> this.revisionApi.getWorkspaceWithConflictResolutionRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceAccessType.CONFLICT_RESOLUTION, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/dependency/patch/group/PatchesGroupWorkspaceRevisionDependenciesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/dependency/patch/group/PatchesGroupWorkspaceRevisionDependenciesResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.dependency.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.dependency.DependenciesApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -69,7 +72,7 @@ public class PatchesGroupWorkspaceRevisionDependenciesResource extends BaseResou
         }
         return executeWithLogging(
                 "getting upstream dependencies of project " + projectId + " for patch release version " + patchReleaseVersionId + ", group workspace " + workspaceId + ", revision " + revisionId + " (fetch transitively = " + transitive + ")",
-                () -> this.dependenciesApi.getWorkspaceRevisionUpstreamProjects(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId, transitive)
+                () -> this.dependenciesApi.getWorkspaceRevisionUpstreamProjects(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId, transitive)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/dependency/patch/user/PatchesWorkspaceRevisionDependenciesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/dependency/patch/user/PatchesWorkspaceRevisionDependenciesResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.dependency.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.dependency.DependenciesApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -69,7 +72,7 @@ public class PatchesWorkspaceRevisionDependenciesResource extends BaseResource
         }
         return executeWithLogging(
                 "getting upstream dependencies of project " + projectId + " for patch release version " + patchReleaseVersionId + ", user workspace " + workspaceId + ", revision " + revisionId + " (fetch transitively = " + transitive + ")",
-                () -> this.dependenciesApi.getWorkspaceRevisionUpstreamProjects(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId, transitive)
+                () -> this.dependenciesApi.getWorkspaceRevisionUpstreamProjects(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId, transitive)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/group/PatchesGroupWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/group/PatchesGroupWorkspaceEntitiesResource.java
@@ -18,6 +18,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.application.entity.CreateOrUpdateEntityCommand;
@@ -26,6 +27,8 @@ import org.finos.legend.sdlc.server.application.entity.DeleteEntityCommand;
 import org.finos.legend.sdlc.server.application.entity.UpdateEntitiesCommand;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -94,7 +97,7 @@ public class PatchesGroupWorkspaceEntitiesResource extends EntityAccessResource
         return execute(
                 "getting entities in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
                 "get entities of the group workspace",
-                () -> getEntities(this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -116,11 +119,11 @@ public class PatchesGroupWorkspaceEntitiesResource extends EntityAccessResource
         return (entityPathsToDelete == null) ?
                 executeWithLogging(
                         "deleting all entities in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                        () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).deleteAllEntities(command.getMessage())
+                        () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).deleteAllEntities(command.getMessage())
                 ) :
                 executeWithLogging(
                         "deleting " + entityPathsToDelete.size() + " entities in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                        () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).deleteEntities(entityPathsToDelete, command.getMessage())
+                        () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).deleteEntities(entityPathsToDelete, command.getMessage())
                 );
     }
 
@@ -142,7 +145,7 @@ public class PatchesGroupWorkspaceEntitiesResource extends EntityAccessResource
         return execute(
                 "updating entities in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
                 "update entities",
-                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).updateEntities(command.getEntities(), command.isReplace(), command.getMessage())
+                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).updateEntities(command.getEntities(), command.isReplace(), command.getMessage())
         );
     }
 
@@ -163,7 +166,7 @@ public class PatchesGroupWorkspaceEntitiesResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "getting entity " + path + " in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).getEntity(path)
+                () -> this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
         );
     }
 
@@ -185,7 +188,7 @@ public class PatchesGroupWorkspaceEntitiesResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "Creating or updating entity " + path + " in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).createOrUpdateEntity(path, command.getClassifierPath(), command.getContent(), command.getMessage())
+                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).createOrUpdateEntity(path, command.getClassifierPath(), command.getContent(), command.getMessage())
         );
     }
 
@@ -207,7 +210,7 @@ public class PatchesGroupWorkspaceEntitiesResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "deleting entity " + path + " in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).deleteEntity(path, command.getMessage())
+                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).deleteEntity(path, command.getMessage())
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/group/PatchesGroupWorkspaceEntityChangesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/group/PatchesGroupWorkspaceEntityChangesResource.java
@@ -16,11 +16,14 @@ package org.finos.legend.sdlc.server.resources.entity.patch.group;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.application.entity.PerformChangesCommand;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -64,7 +67,7 @@ public class PatchesGroupWorkspaceEntityChangesResource extends BaseResource
         }
         return executeWithLogging(
                 "performing changes in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).performChanges(command.getEntityChanges(), command.getRevisionId(), command.getMessage())
+                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).performChanges(command.getEntityChanges(), command.getRevisionId(), command.getMessage())
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/group/PatchesGroupWorkspaceEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/group/PatchesGroupWorkspaceEntityPathsResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.entity.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -81,7 +84,7 @@ public class PatchesGroupWorkspaceEntityPathsResource extends EntityAccessResour
         }
         return executeWithLogging(
                 "getting entity paths in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/group/PatchesGroupWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/group/PatchesGroupWorkspaceRevisionEntitiesResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -87,7 +90,7 @@ public class PatchesGroupWorkspaceRevisionEntitiesResource extends EntityAccessR
         }
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -113,7 +116,7 @@ public class PatchesGroupWorkspaceRevisionEntitiesResource extends EntityAccessR
         }
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of group workspace " + workspaceId + " for project " + projectId,
-                () -> this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId).getEntity(path)
+                () -> this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/group/PatchesGroupWorkspaceRevisionEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/group/PatchesGroupWorkspaceRevisionEntityPathsResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.entity.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -82,7 +85,7 @@ public class PatchesGroupWorkspaceRevisionEntityPathsResource extends EntityAcce
         }
         return executeWithLogging(
                 "getting entity paths in revision " + revisionId + " of group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/user/PatchesWorkspaceEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/user/PatchesWorkspaceEntitiesResource.java
@@ -18,6 +18,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.application.entity.CreateOrUpdateEntityCommand;
@@ -26,6 +27,8 @@ import org.finos.legend.sdlc.server.application.entity.DeleteEntityCommand;
 import org.finos.legend.sdlc.server.application.entity.UpdateEntitiesCommand;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -93,7 +96,7 @@ public class PatchesWorkspaceEntitiesResource extends EntityAccessResource
         return execute(
                 "getting entities in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
                 "get entities of the user workspace",
-                () -> getEntities(this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -115,11 +118,11 @@ public class PatchesWorkspaceEntitiesResource extends EntityAccessResource
         return (entityPathsToDelete == null) ?
                 executeWithLogging(
                         "deleting all entities in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                        () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).deleteAllEntities(command.getMessage())
+                        () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).deleteAllEntities(command.getMessage())
                 ) :
                 executeWithLogging(
                         "deleting " + entityPathsToDelete.size() + " entities in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                        () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).deleteEntities(entityPathsToDelete, command.getMessage())
+                        () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).deleteEntities(entityPathsToDelete, command.getMessage())
                 );
     }
 
@@ -141,7 +144,7 @@ public class PatchesWorkspaceEntitiesResource extends EntityAccessResource
         return execute(
                 "updating entities in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
                 "update entities",
-                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).updateEntities(command.getEntities(), command.isReplace(), command.getMessage())
+                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).updateEntities(command.getEntities(), command.isReplace(), command.getMessage())
         );
     }
 
@@ -162,7 +165,7 @@ public class PatchesWorkspaceEntitiesResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "getting entity " + path + " in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).getEntity(path)
+                () -> this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getEntity(path)
         );
     }
 
@@ -184,7 +187,7 @@ public class PatchesWorkspaceEntitiesResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "Creating or updating entity " + path + " in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).createOrUpdateEntity(path, command.getClassifierPath(), command.getContent(), command.getMessage())
+                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).createOrUpdateEntity(path, command.getClassifierPath(), command.getContent(), command.getMessage())
         );
     }
 
@@ -206,7 +209,7 @@ public class PatchesWorkspaceEntitiesResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "deleting entity " + path + " in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).deleteEntity(path, command.getMessage())
+                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).deleteEntity(path, command.getMessage())
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/user/PatchesWorkspaceEntityChangesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/user/PatchesWorkspaceEntityChangesResource.java
@@ -16,11 +16,14 @@ package org.finos.legend.sdlc.server.resources.entity.patch.user;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.application.entity.PerformChangesCommand;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -64,7 +67,7 @@ public class PatchesWorkspaceEntityChangesResource extends BaseResource
         }
         return executeWithLogging(
                 "performing changes in workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).performChanges(command.getEntityChanges(), command.getRevisionId(), command.getMessage())
+                () -> this.entityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).performChanges(command.getEntityChanges(), command.getRevisionId(), command.getMessage())
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/user/PatchesWorkspaceEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/user/PatchesWorkspaceEntityPathsResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.entity.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -81,7 +84,7 @@ public class PatchesWorkspaceEntityPathsResource extends EntityAccessResource
         }
         return executeWithLogging(
                 "getting entity paths in workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/user/PatchesWorkspaceRevisionEntitiesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/user/PatchesWorkspaceRevisionEntitiesResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.entity.Entity;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -87,7 +90,7 @@ public class PatchesWorkspaceRevisionEntitiesResource extends EntityAccessResour
         }
         return executeWithLogging(
                 "getting entities in revision " + revisionId + " of workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntities(this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
+                () -> getEntities(this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes, excludeInvalid)
         );
     }
 
@@ -113,7 +116,7 @@ public class PatchesWorkspaceRevisionEntitiesResource extends EntityAccessResour
         }
         return executeWithLogging(
                 "getting entity " + path + " in revision " + revisionId + " of workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId).getEntity(path)
+                () -> this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId).getEntity(path)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/user/PatchesWorkspaceRevisionEntityPathsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/entity/patch/user/PatchesWorkspaceRevisionEntityPathsResource.java
@@ -17,9 +17,12 @@ package org.finos.legend.sdlc.server.resources.entity.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.EntityAccessResource;
 
@@ -82,7 +85,7 @@ public class PatchesWorkspaceRevisionEntityPathsResource extends EntityAccessRes
         }
         return executeWithLogging(
                 "getting entity paths in revision " + revisionId + " of workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> getEntityPaths(this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
+                () -> getEntityPaths(this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId), classifierPaths, packages, includeSubPackages, nameRegex, stereotypes, taggedValueRegexes)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/pmcd/patch/group/PatchesGroupWorkspacePureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/pmcd/patch/group/PatchesGroupWorkspacePureModelContextDataResource.java
@@ -17,11 +17,14 @@ package org.finos.legend.sdlc.server.resources.pmcd.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.PureModelContextDataResource;
 
@@ -68,12 +71,12 @@ public class PatchesGroupWorkspacePureModelContextDataResource extends PureModel
                 "getting Pure model context data for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
                 () ->
                 {
-                    Revision revision = this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).getCurrentRevision();
+                    Revision revision = this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getCurrentRevision();
                     if (revision == null)
                     {
                         throw new LegendSDLCServerException("Could not find latest revision for group workspace " + workspaceId + " in project " + projectId + "; project may be corrupt");
                     }
-                    return getPureModelContextData(projectId, revision.getId(), this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)));
+                    return getPureModelContextData(projectId, revision.getId(), this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))));
                 });
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/pmcd/patch/group/PatchesGroupWorkspaceRevisionPureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/pmcd/patch/group/PatchesGroupWorkspaceRevisionPureModelContextDataResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.PureModelContextDataResource;
 
@@ -66,7 +69,7 @@ public class PatchesGroupWorkspaceRevisionPureModelContextDataResource extends P
         }
         return executeWithLogging(
                 "getting Pure model context data for group workspace " + workspaceId + " in project " + projectId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> getPureModelContextData(projectId, revisionId, this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId))
+                () -> getPureModelContextData(projectId, revisionId, this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/pmcd/patch/user/PatchesWorkspacePureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/pmcd/patch/user/PatchesWorkspacePureModelContextDataResource.java
@@ -17,11 +17,14 @@ package org.finos.legend.sdlc.server.resources.pmcd.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.PureModelContextDataResource;
 
@@ -68,12 +71,12 @@ public class PatchesWorkspacePureModelContextDataResource extends PureModelConte
                 "getting Pure model context data for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
                 () ->
                 {
-                    Revision revision = this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).getCurrentRevision();
+                    Revision revision = this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getCurrentRevision();
                     if (revision == null)
                     {
                         throw new LegendSDLCServerException("Could not find latest revision for user workspace " + workspaceId + " in project " + projectId + "; project may be corrupt" + " for patch release version " + patchReleaseVersionId);
                     }
-                    return getPureModelContextData(projectId, revision.getId(), this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)));
+                    return getPureModelContextData(projectId, revision.getId(), this.entityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))));
                 });
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/pmcd/patch/user/PatchesWorkspaceRevisionPureModelContextDataResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/pmcd/patch/user/PatchesWorkspaceRevisionPureModelContextDataResource.java
@@ -18,9 +18,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.engine.protocol.pure.v1.model.context.PureModelContextData;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.entity.EntityApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.PureModelContextDataResource;
 
@@ -66,7 +69,7 @@ public class PatchesWorkspaceRevisionPureModelContextDataResource extends PureMo
         }
         return executeWithLogging(
                 "getting Pure model context data for user workspace " + workspaceId + " in project " + projectId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> getPureModelContextData(projectId, revisionId, this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId))
+                () -> getPureModelContextData(projectId, revisionId, this.entityApi.getWorkspaceRevisionEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/project/patch/group/PatchesGroupWorkspaceProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/project/patch/group/PatchesGroupWorkspaceProjectConfigurationResource.java
@@ -18,11 +18,14 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactTypeGenerationConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.application.project.UpdateProjectConfigurationCommand;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -67,7 +70,7 @@ public class PatchesGroupWorkspaceProjectConfigurationResource extends BaseResou
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in group workspace " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceProjectConfiguration(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.projectConfigurationApi.getWorkspaceProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -88,7 +91,7 @@ public class PatchesGroupWorkspaceProjectConfigurationResource extends BaseResou
         }
         return executeWithLogging(
                 "updating configuration for project " + projectId + " in group workspace " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.updateProjectConfiguration(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), command.getMessage(), command.getProjectConfigurationUpdater())
+                () -> this.projectConfigurationApi.updateProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), command.getMessage(), command.getProjectConfigurationUpdater())
         );
     }
 
@@ -109,7 +112,7 @@ public class PatchesGroupWorkspaceProjectConfigurationResource extends BaseResou
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in group workspace " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceAvailableArtifactGenerations(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.projectConfigurationApi.getWorkspaceAvailableArtifactGenerations(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/project/patch/group/PatchesGroupWorkspaceRevisionProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/project/patch/group/PatchesGroupWorkspaceRevisionProjectConfigurationResource.java
@@ -19,9 +19,12 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactTypeGenerationConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -68,7 +71,7 @@ public class PatchesGroupWorkspaceRevisionProjectConfigurationResource extends B
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in group workspace " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceRevisionProjectConfiguration(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId)
+                () -> this.projectConfigurationApi.getWorkspaceRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 
@@ -92,7 +95,7 @@ public class PatchesGroupWorkspaceRevisionProjectConfigurationResource extends B
         }
         return executeWithLogging(
                 "getting project " + projectId + " available generations in group workspace " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceRevisionAvailableArtifactGenerations(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), revisionId)
+                () -> this.projectConfigurationApi.getWorkspaceRevisionAvailableArtifactGenerations(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/project/patch/user/PatchesWorkspaceProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/project/patch/user/PatchesWorkspaceProjectConfigurationResource.java
@@ -18,11 +18,14 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactTypeGenerationConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.application.project.UpdateProjectConfigurationCommand;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -67,7 +70,7 @@ public class PatchesWorkspaceProjectConfigurationResource extends BaseResource
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in workspace " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceProjectConfiguration(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.projectConfigurationApi.getWorkspaceProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -88,7 +91,7 @@ public class PatchesWorkspaceProjectConfigurationResource extends BaseResource
         }
         return executeWithLogging(
                 "updating configuration for project " + projectId + " in workspace " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.updateProjectConfiguration(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), command.getMessage(), command.getProjectConfigurationUpdater())
+                () -> this.projectConfigurationApi.updateProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), command.getMessage(), command.getProjectConfigurationUpdater())
         );
     }
 
@@ -109,7 +112,7 @@ public class PatchesWorkspaceProjectConfigurationResource extends BaseResource
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in workspace " + workspaceId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceAvailableArtifactGenerations(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.projectConfigurationApi.getWorkspaceAvailableArtifactGenerations(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/project/patch/user/PatchesWorkspaceRevisionProjectConfigurationResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/project/patch/user/PatchesWorkspaceRevisionProjectConfigurationResource.java
@@ -19,9 +19,12 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactTypeGenerationConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.ProjectConfigurationApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -68,7 +71,7 @@ public class PatchesWorkspaceRevisionProjectConfigurationResource extends BaseRe
         }
         return executeWithLogging(
                 "getting project " + projectId + " configuration in workspace " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceRevisionProjectConfiguration(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId)
+                () -> this.projectConfigurationApi.getWorkspaceRevisionProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 
@@ -92,7 +95,7 @@ public class PatchesWorkspaceRevisionProjectConfigurationResource extends BaseRe
         }
         return executeWithLogging(
                 "getting project " + projectId + " available generations in workspace " + workspaceId + " at revision " + revisionId + " for patch release version " + patchReleaseVersionId,
-                () -> this.projectConfigurationApi.getWorkspaceRevisionAvailableArtifactGenerations(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), revisionId)
+                () -> this.projectConfigurationApi.getWorkspaceRevisionAvailableArtifactGenerations(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/review/patch/PatchReviewsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/review/patch/PatchReviewsResource.java
@@ -27,16 +27,14 @@ import org.finos.legend.sdlc.server.application.review.CreateReviewCommand;
 import org.finos.legend.sdlc.server.application.review.EditReviewCommand;
 import org.finos.legend.sdlc.server.domain.api.review.ReviewApi;
 import org.finos.legend.sdlc.server.domain.api.review.ReviewApi.ReviewUpdateStatus;
-import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.ReviewFilterResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
 import org.finos.legend.sdlc.server.time.ResolvedInstant;
 import org.finos.legend.sdlc.server.time.StartInstant;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -47,6 +45,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 @Path("/projects/{projectId}/patches/{patchReleaseVersionId}/reviews")
 @Api("Reviews")
@@ -86,7 +87,7 @@ public class PatchReviewsResource extends ReviewFilterResource
         }
         return executeWithLogging(
                 (state == null) ? ("getting reviews for project " + projectId) : ("getting reviews for project " + projectId + " for patch release version " + patchReleaseVersionId + " with state " + state),
-                () -> this.reviewApi.getReviews(projectId, versionId, state, revisionIds, this.getWorkspaceIdAndTypePredicate(workspaceIdRegex, workspaceTypes), ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.reviewApi.getReviews(projectId, versionId, state, revisionIds, getWorkspaceIdAndTypePredicate(workspaceIdRegex, workspaceTypes), ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -161,7 +162,12 @@ public class PatchReviewsResource extends ReviewFilterResource
         return execute(
                 "creating review \"" + command.getTitle() + "\" in project " + projectId + " for patch release version " + patchReleaseVersionId,
                 "create a review",
-                () -> this.reviewApi.createReview(projectId, SourceSpecification.newSourceSpecification(command.getWorkspaceId(), Optional.ofNullable(command.getWorkspaceType()).orElse(WorkspaceType.USER), null, versionId), command.getTitle(), command.getDescription(), command.getLabels())
+                () ->
+                {
+                    WorkspaceSource workspaceSource = WorkspaceSource.patchWorkspaceSource(versionId);
+                    WorkspaceSpecification workspaceSpecification = WorkspaceSpecification.newWorkspaceSpecification(command.getWorkspaceId(), Optional.ofNullable(command.getWorkspaceType()).orElse(WorkspaceType.USER), null, workspaceSource);
+                    return this.reviewApi.createReview(projectId, workspaceSpecification, command.getTitle(), command.getDescription(), command.getLabels());
+                }
         );
     }
 

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/group/PatchesGroupWorkspaceEntityRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/group/PatchesGroupWorkspaceEntityRevisionsResource.java
@@ -17,10 +17,13 @@ package org.finos.legend.sdlc.server.resources.revision.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
@@ -74,7 +77,7 @@ public class PatchesGroupWorkspaceEntityRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revisions for entity " + path + " in group workspace " + workspaceId + " for project " + projectId +  " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceEntityRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), path).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getWorkspaceEntityRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), path).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -99,7 +102,7 @@ public class PatchesGroupWorkspaceEntityRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for entity " + path + " in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceEntityRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), path).getRevision(revisionId)
+                () -> this.revisionApi.getWorkspaceEntityRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), path).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/group/PatchesGroupWorkspacePackageRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/group/PatchesGroupWorkspacePackageRevisionsResource.java
@@ -17,10 +17,13 @@ package org.finos.legend.sdlc.server.resources.revision.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
@@ -74,7 +77,7 @@ public class PatchesGroupWorkspacePackageRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revisions for package " + path + " in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspacePackageRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), path).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getWorkspacePackageRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), path).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -99,7 +102,7 @@ public class PatchesGroupWorkspacePackageRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for package " + path + " in group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspacePackageRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId), path).getRevision(revisionId)
+                () -> this.revisionApi.getWorkspacePackageRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))), path).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/group/PatchesGroupWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/group/PatchesGroupWorkspaceRevisionsResource.java
@@ -17,10 +17,13 @@ package org.finos.legend.sdlc.server.resources.revision.patch.group;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
@@ -73,7 +76,7 @@ public class PatchesGroupWorkspaceRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision for group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -97,7 +100,7 @@ public class PatchesGroupWorkspaceRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for group workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId)).getRevision(revisionId)
+                () -> this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/user/PatchesWorkspaceEntityRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/user/PatchesWorkspaceEntityRevisionsResource.java
@@ -17,10 +17,13 @@ package org.finos.legend.sdlc.server.resources.revision.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
@@ -74,7 +77,7 @@ public class PatchesWorkspaceEntityRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revisions for entity " + path + " in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceEntityRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), path).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getWorkspaceEntityRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), path).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -99,7 +102,7 @@ public class PatchesWorkspaceEntityRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for entity " + path + " in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceEntityRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), path).getRevision(revisionId)
+                () -> this.revisionApi.getWorkspaceEntityRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), path).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/user/PatchesWorkspacePackageRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/user/PatchesWorkspacePackageRevisionsResource.java
@@ -17,10 +17,13 @@ package org.finos.legend.sdlc.server.resources.revision.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
@@ -74,7 +77,7 @@ public class PatchesWorkspacePackageRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revisions for package " + path + " in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspacePackageRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), path).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getWorkspacePackageRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), path).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -99,7 +102,7 @@ public class PatchesWorkspacePackageRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for package " + path + " in user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspacePackageRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId), path).getRevision(revisionId)
+                () -> this.revisionApi.getWorkspacePackageRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))), path).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/user/PatchesWorkspaceRevisionsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/revision/patch/user/PatchesWorkspaceRevisionsResource.java
@@ -17,10 +17,13 @@ package org.finos.legend.sdlc.server.resources.revision.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.revision.RevisionApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 import org.finos.legend.sdlc.server.time.EndInstant;
@@ -73,7 +76,7 @@ public class PatchesWorkspaceRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision for user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
+                () -> this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevisions(null, ResolvedInstant.getResolvedInstantIfNonNull(since), ResolvedInstant.getResolvedInstantIfNonNull(until), limit)
         );
     }
 
@@ -97,7 +100,7 @@ public class PatchesWorkspaceRevisionsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting revision " + revisionId + " for user workspace " + workspaceId + " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId)).getRevision(revisionId)
+                () -> this.revisionApi.getWorkspaceRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))).getRevision(revisionId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workflow/patch/group/PatchesGroupWorkspaceWorkflowJobsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workflow/patch/group/PatchesGroupWorkspaceWorkflowJobsResource.java
@@ -21,14 +21,14 @@ import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.domain.model.workflow.WorkflowJob;
 import org.finos.legend.sdlc.domain.model.workflow.WorkflowJobStatus;
-import org.finos.legend.sdlc.server.domain.api.workflow.WorkflowJobApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workflow.WorkflowJobApi;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
-import java.util.List;
-import java.util.Set;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -40,6 +40,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Set;
 
 @Path("/projects/{projectId}/patches/{patchReleaseVersionId}/groupWorkspaces/{workspaceId}/workflows/{workflowId}/jobs")
 @Api("Workflows")
@@ -75,7 +77,7 @@ public class PatchesGroupWorkspaceWorkflowJobsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting workflow jobs for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).getWorkflowJobs(workflowId, statuses)
+                () -> this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).getWorkflowJobs(workflowId, statuses)
         );
     }
 
@@ -100,7 +102,7 @@ public class PatchesGroupWorkspaceWorkflowJobsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting workflow job " + workflowJobId + " for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).getWorkflowJob(workflowId, workflowJobId)
+                () -> this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).getWorkflowJob(workflowId, workflowJobId)
         );
     }
 
@@ -128,7 +130,7 @@ public class PatchesGroupWorkspaceWorkflowJobsResource extends BaseResource
                 "getting workflow job logs " + workflowJobId + " for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
                 () ->
                 {
-                    String logs = this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).getWorkflowJobLog(workflowId, workflowJobId);
+                    String logs = this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).getWorkflowJobLog(workflowId, workflowJobId);
                     return Response.ok(logs)
                             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + workflowJobId + ".log\"")
                             .build();
@@ -157,7 +159,7 @@ public class PatchesGroupWorkspaceWorkflowJobsResource extends BaseResource
         }
         return executeWithLogging(
                 "running workflow job " + workflowJobId + " for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).runWorkflowJob(workflowId, workflowJobId)
+                () -> this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).runWorkflowJob(workflowId, workflowJobId)
         );
     }
 
@@ -182,7 +184,7 @@ public class PatchesGroupWorkspaceWorkflowJobsResource extends BaseResource
         }
         return executeWithLogging(
                 "retrying workflow job " + workflowJobId + " for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).retryWorkflowJob(workflowId, workflowJobId)
+                () -> this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).retryWorkflowJob(workflowId, workflowJobId)
         );
     }
 
@@ -208,7 +210,7 @@ public class PatchesGroupWorkspaceWorkflowJobsResource extends BaseResource
         }
         return executeWithLogging(
                 "canceling workflow job " + workflowJobId + " for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).cancelWorkflowJob(workflowId, workflowJobId)
+                () -> this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).cancelWorkflowJob(workflowId, workflowJobId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workflow/patch/group/PatchesGroupWorkspaceWorkflowsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workflow/patch/group/PatchesGroupWorkspaceWorkflowsResource.java
@@ -23,6 +23,8 @@ import org.finos.legend.sdlc.domain.model.workflow.WorkflowStatus;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.server.domain.api.workflow.WorkflowApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider;
 import org.finos.legend.sdlc.server.resources.BaseResource;
@@ -77,7 +79,7 @@ public class PatchesGroupWorkspaceWorkflowsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting workflows for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowApi.getWorkspaceWorkflowAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).getWorkflows(revisionIds, statuses, limit)
+                () -> this.workflowApi.getWorkflowAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).getWorkflows(revisionIds, statuses, limit)
         );
     }
 
@@ -98,7 +100,7 @@ public class PatchesGroupWorkspaceWorkflowsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting workflow " + workflowId + " for group workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowApi.getWorkspaceWorkflowAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).getWorkflow(workflowId)
+                () -> this.workflowApi.getWorkflowAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).getWorkflow(workflowId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workflow/patch/user/PatchesWorkspaceWorkflowJobsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workflow/patch/user/PatchesWorkspaceWorkflowJobsResource.java
@@ -21,14 +21,14 @@ import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.domain.model.workflow.WorkflowJob;
 import org.finos.legend.sdlc.domain.model.workflow.WorkflowJobStatus;
-import org.finos.legend.sdlc.server.domain.api.workflow.WorkflowJobApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workflow.WorkflowJobApi;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
-import java.util.List;
-import java.util.Set;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -40,6 +40,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.Set;
 
 @Path("/projects/{projectId}/patches/{patchReleaseVersionId}/workspaces/{workspaceId}/workflows/{workflowId}/jobs")
 @Api("Workflows")
@@ -75,7 +77,7 @@ public class PatchesWorkspaceWorkflowJobsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting workflow jobs for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).getWorkflowJobs(workflowId, statuses)
+                () -> this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).getWorkflowJobs(workflowId, statuses)
         );
     }
 
@@ -100,7 +102,7 @@ public class PatchesWorkspaceWorkflowJobsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting workflow job " + workflowJobId + " for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).getWorkflowJob(workflowId, workflowJobId)
+                () -> this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).getWorkflowJob(workflowId, workflowJobId)
         );
     }
 
@@ -128,7 +130,7 @@ public class PatchesWorkspaceWorkflowJobsResource extends BaseResource
                 "getting workflow job logs " + workflowJobId + " for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
                 () ->
                 {
-                    String logs = this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).getWorkflowJobLog(workflowId, workflowJobId);
+                    String logs = this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).getWorkflowJobLog(workflowId, workflowJobId);
                     return Response.ok(logs)
                             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + workflowJobId + ".log\"")
                             .build();
@@ -157,7 +159,7 @@ public class PatchesWorkspaceWorkflowJobsResource extends BaseResource
         }
         return executeWithLogging(
                 "running workflow job " + workflowJobId + " for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).runWorkflowJob(workflowId, workflowJobId)
+                () -> this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).runWorkflowJob(workflowId, workflowJobId)
         );
     }
 
@@ -182,7 +184,7 @@ public class PatchesWorkspaceWorkflowJobsResource extends BaseResource
         }
         return executeWithLogging(
                 "retrying workflow job " + workflowJobId + " for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).retryWorkflowJob(workflowId, workflowJobId)
+                () -> this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).retryWorkflowJob(workflowId, workflowJobId)
         );
     }
 
@@ -208,7 +210,7 @@ public class PatchesWorkspaceWorkflowJobsResource extends BaseResource
         }
         return executeWithLogging(
                 "canceling workflow job " + workflowJobId + " for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowJobApi.getWorkspaceWorkflowJobAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).cancelWorkflowJob(workflowId, workflowJobId)
+                () -> this.workflowJobApi.getWorkflowJobAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).cancelWorkflowJob(workflowId, workflowJobId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workflow/patch/user/PatchesWorkspaceWorkflowsResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workflow/patch/user/PatchesWorkspaceWorkflowsResource.java
@@ -17,12 +17,14 @@ package org.finos.legend.sdlc.server.resources.workflow.patch.user;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.domain.model.workflow.Workflow;
 import org.finos.legend.sdlc.domain.model.workflow.WorkflowStatus;
-import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
-import org.finos.legend.sdlc.server.domain.api.workflow.WorkflowApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workflow.WorkflowApi;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider;
 import org.finos.legend.sdlc.server.resources.BaseResource;
@@ -77,7 +79,7 @@ public class PatchesWorkspaceWorkflowsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting workflows for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowApi.getWorkspaceWorkflowAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).getWorkflows(revisionIds, statuses, limit)
+                () -> this.workflowApi.getWorkflowAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).getWorkflows(revisionIds, statuses, limit)
         );
     }
 
@@ -98,7 +100,7 @@ public class PatchesWorkspaceWorkflowsResource extends BaseResource
         }
         return executeWithLogging(
                 "getting workflow " + workflowId + " for user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workflowApi.getWorkspaceWorkflowAccessContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, versionId)).getWorkflow(workflowId)
+                () -> this.workflowApi.getWorkflowAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, WorkspaceSource.patchWorkspaceSource(versionId)))).getWorkflow(workflowId)
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workspace/patch/group/PatchesGroupWorkspacesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workspace/patch/group/PatchesGroupWorkspacesResource.java
@@ -22,6 +22,8 @@ import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -95,7 +97,7 @@ public class PatchesGroupWorkspacesResource extends BaseResource
         }
         return executeWithLogging(
                 "getting group workspace " + workspaceId + " for patch release " + patchReleaseVersionId +  " for project " + projectId + " for patch release version " + patchReleaseVersionId,
-                () -> this.workspaceApi.getWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.getWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -116,7 +118,7 @@ public class PatchesGroupWorkspacesResource extends BaseResource
         }
         return executeWithLogging(
                 "checking if group workspace " + workspaceId + " for patch release " + patchReleaseVersionId + " of project " + projectId + " for patch release version " + patchReleaseVersionId + " is outdated",
-                () -> this.workspaceApi.isWorkspaceOutdated(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.isWorkspaceOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -137,7 +139,7 @@ public class PatchesGroupWorkspacesResource extends BaseResource
         }
         return executeWithLogging(
                 "checking if group workspace " + workspaceId + " for patch release " + patchReleaseVersionId + " of project " + projectId + " for patch release version " + patchReleaseVersionId + " is in conflict resolution mode",
-                () -> this.workspaceApi.isWorkspaceInConflictResolutionMode(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.isWorkspaceInConflictResolutionMode(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -158,7 +160,7 @@ public class PatchesGroupWorkspacesResource extends BaseResource
         }
         return executeWithLogging(
                 "creating new group workspace " + workspaceId + " for patch release " + patchReleaseVersionId + " for project " + projectId,
-                () -> this.workspaceApi.newWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.newWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
 
         );
     }
@@ -180,7 +182,7 @@ public class PatchesGroupWorkspacesResource extends BaseResource
         }
         executeWithLogging(
                 "deleting group workspace " + workspaceId + " for patch release " + patchReleaseVersionId + " for project " + projectId,
-                () -> this.workspaceApi.deleteWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.deleteWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 
@@ -201,7 +203,7 @@ public class PatchesGroupWorkspacesResource extends BaseResource
         }
         return executeWithLogging(
                 "updating user workspace " + workspaceId + " in project " + projectId + " for patch release version " + patchReleaseVersionId + " to latest revision",
-                () -> this.workspaceApi.updateWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.updateWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(versionId))))
         );
     }
 }

--- a/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workspace/patch/user/PatchesWorkspacesResource.java
+++ b/legend-sdlc-server/src/main/java/org/finos/legend/sdlc/server/resources/workspace/patch/user/PatchesWorkspacesResource.java
@@ -21,7 +21,8 @@ import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceApi;
-import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.error.LegendSDLCServerException;
 import org.finos.legend.sdlc.server.resources.BaseResource;
 
@@ -96,7 +97,7 @@ public class PatchesWorkspacesResource extends BaseResource
         }
         return executeWithLogging(
                 "getting user workspace " + workspaceId + " for patch release " + patchReleaseVersionId +  " for project " + projectId,
-                () -> this.workspaceApi.getWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.getWorkspace(projectId, WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))
         );
     }
 
@@ -117,7 +118,7 @@ public class PatchesWorkspacesResource extends BaseResource
         }
         return executeWithLogging(
                 "checking if user workspace " + workspaceId + " for patch release " + patchReleaseVersionId + " of project " + projectId + " is outdated",
-                () -> this.workspaceApi.isWorkspaceOutdated(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.isWorkspaceOutdated(projectId, WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))
         );
     }
 
@@ -138,7 +139,7 @@ public class PatchesWorkspacesResource extends BaseResource
         }
         return executeWithLogging(
                 "checking if user workspace " + workspaceId + " for patch release " + patchReleaseVersionId + " of project " + projectId + " is in conflict resolution mode",
-                () -> this.workspaceApi.isWorkspaceInConflictResolutionMode(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.isWorkspaceInConflictResolutionMode(projectId, WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))
         );
     }
 
@@ -159,7 +160,7 @@ public class PatchesWorkspacesResource extends BaseResource
         }
         return executeWithLogging(
                 "creating new user workspace " + workspaceId + " for patch release " + patchReleaseVersionId + " for project " + projectId,
-                () -> this.workspaceApi.newWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.newWorkspace(projectId, workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId))
 
         );
     }
@@ -181,7 +182,7 @@ public class PatchesWorkspacesResource extends BaseResource
         }
         executeWithLogging(
                 "deleting user workspace " + workspaceId + " for patch release " + patchReleaseVersionId + " for project " + projectId,
-                () -> this.workspaceApi.deleteWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.deleteWorkspace(projectId, WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))
         );
     }
 
@@ -202,7 +203,7 @@ public class PatchesWorkspacesResource extends BaseResource
         }
         return executeWithLogging(
                 "updating user workspace " + workspaceId + " in project " + projectId + " to latest revision",
-                () -> this.workspaceApi.updateWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, versionId))
+                () -> this.workspaceApi.updateWorkspace(projectId, WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(versionId)))
         );
     }
 }

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabComparisonApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabComparisonApiTestResource.java
@@ -24,11 +24,14 @@ import org.finos.legend.sdlc.domain.model.patch.Patch;
 import org.finos.legend.sdlc.domain.model.project.Project;
 import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.Version;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.version.NewVersionType;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.gitlab.api.server.AbstractGitLabServerApiTest;
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -221,7 +224,7 @@ public class GitLabComparisonApiTestResource
         Version version = gitlabVersionApi.newVersion(projectId, NewVersionType.PATCH, gitLabRevisionApi.getProjectRevisionContext(projectId).getCurrentRevision().getId(), "");
         Patch patch = gitlabPatchApi.newPatch(projectId, version.getId());
         VersionId patchReleaseVersionId = patch.getPatchReleaseVersionId();
-        SourceSpecification sourceSpecification = SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId);
+        SourceSpecification sourceSpecification = SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)));
 
         Workspace createdWorkspaceOne = gitLabWorkspaceApi.newWorkspace(projectId, sourceSpecification);
         Revision fromRevision = gitLabRevisionApi.getWorkspaceRevisionContext(projectId, sourceSpecification).getCurrentRevision();
@@ -249,9 +252,9 @@ public class GitLabComparisonApiTestResource
         Assert.assertEquals(initalEntity.getContent(), entityContentMap);
 
         Revision toRevision = gitLabRevisionApi.getWorkspaceRevisionContext(projectId, sourceSpecification).getCurrentRevision();
-        List<EntityDiff> entityDiffs = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getEntityDiffs();
-        String fromRevisionId = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getFromRevisionId();
-        String toRevisionId = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getToRevisionId();
+        List<EntityDiff> entityDiffs = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntityDiffs();
+        String fromRevisionId = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getFromRevisionId();
+        String toRevisionId = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getToRevisionId();
 
         Assert.assertNotNull(fromRevision);
         Assert.assertNotNull(toRevision);
@@ -263,9 +266,9 @@ public class GitLabComparisonApiTestResource
 
         Revision projectFromRevision = gitLabRevisionApi.getProjectRevisionContext(projectId, patchReleaseVersionId).getCurrentRevision();
         Revision projectToRevision = gitLabRevisionApi.getWorkspaceRevisionContext(projectId, sourceSpecification).getCurrentRevision();
-        List<EntityDiff> projectEntityDiffs = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getEntityDiffs();
-        String projectFromRevisionId = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getFromRevisionId();
-        String projectToRevisionId = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getToRevisionId();
+        List<EntityDiff> projectEntityDiffs = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntityDiffs();
+        String projectFromRevisionId = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getFromRevisionId();
+        String projectToRevisionId = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getToRevisionId();
 
         Assert.assertNotNull(projectFromRevision);
         Assert.assertEquals(projectFromRevision.getId(), projectFromRevisionId);
@@ -295,7 +298,7 @@ public class GitLabComparisonApiTestResource
         Version version = gitlabVersionApi.newVersion(projectId, NewVersionType.PATCH, gitLabRevisionApi.getProjectRevisionContext(projectId).getCurrentRevision().getId(), "");
         Patch patch = gitlabPatchApi.newPatch(projectId, version.getId());
         VersionId patchReleaseVersionId = patch.getPatchReleaseVersionId();
-        SourceSpecification sourceSpecification = SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId);
+        SourceSpecification sourceSpecification = SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)));
 
         Workspace createdWorkspaceOne = gitLabWorkspaceApi.newWorkspace(projectId, sourceSpecification);
         Revision fromRevision = gitLabRevisionApi.getWorkspaceRevisionContext(projectId, sourceSpecification).getCurrentRevision();
@@ -323,9 +326,9 @@ public class GitLabComparisonApiTestResource
         Assert.assertEquals(initalEntity.getContent(), entityContentMap);
 
         Revision toRevision = gitLabRevisionApi.getWorkspaceRevisionContext(projectId, sourceSpecification).getCurrentRevision();
-        List<EntityDiff> entityDiffs = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getEntityDiffs();
-        String fromRevisionId = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getFromRevisionId();
-        String toRevisionId = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getToRevisionId();
+        List<EntityDiff> entityDiffs = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntityDiffs();
+        String fromRevisionId = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getFromRevisionId();
+        String toRevisionId = gitLabComparisonApi.getWorkspaceCreationComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getToRevisionId();
 
         Assert.assertNotNull(fromRevision);
         Assert.assertNotNull(toRevision);
@@ -337,9 +340,9 @@ public class GitLabComparisonApiTestResource
 
         Revision projectFromRevision = gitLabRevisionApi.getProjectRevisionContext(projectId, patchReleaseVersionId).getCurrentRevision();
         Revision projectToRevision = gitLabRevisionApi.getWorkspaceRevisionContext(projectId, sourceSpecification).getCurrentRevision();
-        List<EntityDiff> projectEntityDiffs = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getEntityDiffs();
-        String projectFromRevisionId = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getFromRevisionId();
-        String projectToRevisionId = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId)).getToRevisionId();
+        List<EntityDiff> projectEntityDiffs = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntityDiffs();
+        String projectFromRevisionId = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getFromRevisionId();
+        String projectToRevisionId = gitLabComparisonApi.getWorkspaceProjectComparison(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getToRevisionId();
 
         Assert.assertNotNull(projectFromRevision);
         Assert.assertEquals(projectFromRevision.getId(), projectFromRevisionId);

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabEntityApiTestResource.java
@@ -28,6 +28,8 @@ import org.finos.legend.sdlc.domain.model.version.Version;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
 import org.finos.legend.sdlc.server.domain.api.version.NewVersionType;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.gitlab.GitLabProjectId;
 import org.finos.legend.sdlc.server.gitlab.api.server.AbstractGitLabServerApiTest;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabUserContext;
@@ -387,7 +389,7 @@ public class GitLabEntityApiTestResource
         Version version = this.gitLabVersionApi.newVersion(projectId, NewVersionType.MINOR, this.gitLabRevisionApi.getProjectRevisionContext(projectId).getCurrentRevision().getId(), "");
         Patch patch = this.gitLabPatchApi.newPatch(projectId, version.getId());
         VersionId patchReleaseVersionId = patch.getPatchReleaseVersionId();
-        SourceSpecification sourceSpecification = SourceSpecification.newUserWorkspaceSourceSpecification(workspaceName, patchReleaseVersionId);
+        SourceSpecification sourceSpecification = SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceName, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)));
 
         Workspace createdWorkspace = this.gitLabWorkspaceApi.newWorkspace(projectId, sourceSpecification);
 
@@ -540,7 +542,7 @@ public class GitLabEntityApiTestResource
         Version version = this.gitLabVersionApi.newVersion(projectId, NewVersionType.PATCH, this.gitLabRevisionApi.getProjectRevisionContext(projectId).getCurrentRevision().getId(), "");
         Patch patch = this.gitLabPatchApi.newPatch(projectId, version.getId());
         VersionId patchReleaseVersionId = patch.getPatchReleaseVersionId();
-        SourceSpecification sourceSpecification = SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceName, patchReleaseVersionId);
+        SourceSpecification sourceSpecification = SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceName, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)));
 
         Workspace createdWorkspace = this.gitLabWorkspaceApi.newWorkspace(projectId, sourceSpecification);
 

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectApiTestResource.java
@@ -76,7 +76,7 @@ public class GitLabProjectApiTestResource
                 "/testprojone-file-generation/pom.xml",
                 "/testprojone-service-execution/pom.xml",
                 "/testprojone-versioned-entities/pom.xml"
-        ), this.gitLabProjectApi.getProjectFileAccessProvider().getProjectFileAccessContext(projectId).getFiles().map(ProjectFileAccessProvider.ProjectFile::getPath).collect(Collectors.toSet()));
+        ), this.gitLabProjectApi.getProjectFileAccessProvider().getFileAccessContext(projectId, SourceSpecification.projectSourceSpecification()).getFiles().map(ProjectFileAccessProvider.ProjectFile::getPath).collect(Collectors.toSet()));
     }
 
     public void runCreateManagedProjectTest() throws LegendSDLCServerException

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectConfigurationApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabProjectConfigurationApiTestResource.java
@@ -21,10 +21,13 @@ import org.finos.legend.sdlc.domain.model.project.Project;
 import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.Version;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
 import org.finos.legend.sdlc.server.domain.api.version.NewVersionType;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.gitlab.api.server.AbstractGitLabServerApiTest;
 import org.junit.Assert;
 
@@ -122,27 +125,27 @@ public class GitLabProjectConfigurationApiTestResource
         Patch patch = this.gitlabPatchApi.newPatch(projectId, version.getId());
         VersionId patchReleaseVersionId = patch.getPatchReleaseVersionId();
 
-        Workspace createdWorkspaceOne = this.gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId));
+        Workspace createdWorkspaceOne = this.gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertNotNull(createdWorkspaceOne);
         Assert.assertEquals(workspaceOneId, createdWorkspaceOne.getWorkspaceId());
         Assert.assertEquals(projectId, createdWorkspaceOne.getProjectId());
         Assert.assertNotNull(createdWorkspaceOne.getUserId());
 
-        ProjectConfiguration projectConfiguration = this.gitLabProjectConfigurationApi.getWorkspaceProjectConfiguration(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId));
+        ProjectConfiguration projectConfiguration = this.gitLabProjectConfigurationApi.getWorkspaceProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertNotNull(projectConfiguration);
         Assert.assertEquals(artifactId, projectConfiguration.getArtifactId());
         Assert.assertEquals(groupId, projectConfiguration.getGroupId());
 
-        Workspace createdWorkspaceTwo = this.gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId));
+        Workspace createdWorkspaceTwo = this.gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertNotNull(createdWorkspaceTwo);
         Assert.assertEquals(workspaceTwoId, createdWorkspaceTwo.getWorkspaceId());
         Assert.assertEquals(projectId, createdWorkspaceTwo.getProjectId());
         Assert.assertNull(createdWorkspaceTwo.getUserId());
 
-        ProjectConfiguration projectConfigurationTwo = this.gitLabProjectConfigurationApi.getWorkspaceProjectConfiguration(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId));
+        ProjectConfiguration projectConfigurationTwo = this.gitLabProjectConfigurationApi.getWorkspaceProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertNotNull(projectConfigurationTwo);
         Assert.assertEquals(artifactId, projectConfigurationTwo.getArtifactId());

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabRevisionApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabRevisionApiTestResource.java
@@ -22,11 +22,14 @@ import org.finos.legend.sdlc.domain.model.patch.Patch;
 import org.finos.legend.sdlc.domain.model.project.Project;
 import org.finos.legend.sdlc.domain.model.project.ProjectType;
 import org.finos.legend.sdlc.domain.model.project.workspace.Workspace;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.revision.Revision;
 import org.finos.legend.sdlc.domain.model.version.Version;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.version.NewVersionType;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.gitlab.api.server.AbstractGitLabServerApiTest;
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -261,7 +264,7 @@ public class GitLabRevisionApiTestResource
         Version version = gitlabVersionApi.newVersion(projectId, NewVersionType.PATCH, gitLabRevisionApi.getProjectRevisionContext(projectId).getCurrentRevision().getId(), "");
         Patch patch = gitlabPatchApi.newPatch(projectId, version.getId());
         VersionId patchReleaseVersionId = patch.getPatchReleaseVersionId();
-        SourceSpecification sourceSpecification = SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId);
+        SourceSpecification sourceSpecification = SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)));
 
         Workspace createdWorkspaceOne = gitLabWorkspaceApi.newWorkspace(projectId, sourceSpecification);
 
@@ -357,7 +360,7 @@ public class GitLabRevisionApiTestResource
         Version version = gitlabVersionApi.newVersion(projectId, NewVersionType.PATCH, gitLabRevisionApi.getProjectRevisionContext(projectId).getCurrentRevision().getId(), "");
         Patch patch = gitlabPatchApi.newPatch(projectId, version.getId());
         VersionId patchReleaseVersionId = patch.getPatchReleaseVersionId();
-        SourceSpecification sourceSpecification = SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId);
+        SourceSpecification sourceSpecification = SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)));
 
         Workspace createdWorkspaceOne = gitLabWorkspaceApi.newWorkspace(projectId, sourceSpecification);
 

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabWorkspaceApiTestResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/gitlab/api/GitLabWorkspaceApiTestResource.java
@@ -29,6 +29,8 @@ import org.finos.legend.sdlc.domain.model.version.Version;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.version.NewVersionType;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.gitlab.GitLabProjectId;
 import org.finos.legend.sdlc.server.gitlab.api.server.AbstractGitLabServerApiTest;
 import org.finos.legend.sdlc.server.gitlab.auth.GitLabUserContext;
@@ -456,21 +458,21 @@ public class GitLabWorkspaceApiTestResource
         Patch patch = gitlabPatchApi.newPatch(projectId, version.getId());
         VersionId patchReleaseVersionId = patch.getPatchReleaseVersionId();
 
-        Workspace createdWorkspaceOne = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId));
+        Workspace createdWorkspaceOne = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertNotNull(createdWorkspaceOne);
         Assert.assertEquals(workspaceOneId, createdWorkspaceOne.getWorkspaceId());
         Assert.assertEquals(projectId, createdWorkspaceOne.getProjectId());
         Assert.assertNotNull(createdWorkspaceOne.getUserId());
 
-        Workspace createdWorkspaceTwo = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId));
+        Workspace createdWorkspaceTwo = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertNotNull(createdWorkspaceTwo);
         Assert.assertEquals(workspaceTwoId, createdWorkspaceTwo.getWorkspaceId());
         Assert.assertEquals(projectId, createdWorkspaceTwo.getProjectId());
         Assert.assertNotNull(createdWorkspaceTwo.getUserId());
 
-        Workspace createdWorkspaceThree = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceThreeId, patchReleaseVersionId));
+        Workspace createdWorkspaceThree = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceThreeId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertNotNull(createdWorkspaceThree);
         Assert.assertEquals(workspaceThreeId, createdWorkspaceThree.getWorkspaceId());
@@ -488,28 +490,28 @@ public class GitLabWorkspaceApiTestResource
         Assert.assertEquals(2, allUserWorkspaces.size());
         Assert.assertEquals(1, allGroupWorkspaces.size());
 
-        Workspace retriedUserWorkspace = gitLabWorkspaceApi.getWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId));
+        Workspace retriedUserWorkspace = gitLabWorkspaceApi.getWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertNotNull(retriedUserWorkspace);
         Assert.assertEquals(workspaceOneId, retriedUserWorkspace.getWorkspaceId());
         Assert.assertEquals(projectId, retriedUserWorkspace.getProjectId());
         Assert.assertNotNull(retriedUserWorkspace.getUserId());
 
-        Workspace retriedGroupWorkspace = gitLabWorkspaceApi.getWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceThreeId, patchReleaseVersionId));
+        Workspace retriedGroupWorkspace = gitLabWorkspaceApi.getWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceThreeId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertNotNull(retriedGroupWorkspace);
         Assert.assertEquals(workspaceThreeId, retriedGroupWorkspace.getWorkspaceId());
         Assert.assertEquals(projectId, retriedGroupWorkspace.getProjectId());
         Assert.assertNull(retriedGroupWorkspace.getUserId());
 
-        boolean isUserWorkspaceInConflictResolution = gitLabWorkspaceApi.isWorkspaceInConflictResolutionMode(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId));
-        boolean isGroupWorkspaceInConflictResolution = gitLabWorkspaceApi.isWorkspaceInConflictResolutionMode(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceThreeId, patchReleaseVersionId));
+        boolean isUserWorkspaceInConflictResolution = gitLabWorkspaceApi.isWorkspaceInConflictResolutionMode(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
+        boolean isGroupWorkspaceInConflictResolution = gitLabWorkspaceApi.isWorkspaceInConflictResolutionMode(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceThreeId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertFalse(isUserWorkspaceInConflictResolution);
         Assert.assertFalse(isGroupWorkspaceInConflictResolution);
 
-        boolean isUserWorkspaceOutdated = gitLabWorkspaceApi.isWorkspaceOutdated(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceOneId, patchReleaseVersionId));
-        boolean isGroupWorkspaceOutdated = gitLabWorkspaceApi.isWorkspaceOutdated(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceThreeId, patchReleaseVersionId));
+        boolean isUserWorkspaceOutdated = gitLabWorkspaceApi.isWorkspaceOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceOneId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
+        boolean isGroupWorkspaceOutdated = gitLabWorkspaceApi.isWorkspaceOutdated(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceThreeId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         Assert.assertFalse(isUserWorkspaceOutdated);
         Assert.assertFalse(isGroupWorkspaceOutdated);
@@ -532,10 +534,10 @@ public class GitLabWorkspaceApiTestResource
         Patch patch = gitlabPatchApi.newPatch(projectId, version.getId());
         VersionId patchReleaseVersionId = patch.getPatchReleaseVersionId();
 
-        Workspace createdWorkspace = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceName, patchReleaseVersionId));
+        Workspace createdWorkspace = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceName, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         String workspaceId = createdWorkspace.getWorkspaceId();
-        List<Entity> initialWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, patchReleaseVersionId)).getEntities(null, null, null);
+        List<Entity> initialWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntities(null, null, null);
         List<Entity> initialProjectEntities = gitLabEntityApi.getProjectEntityAccessContext(projectId, patchReleaseVersionId).getEntities(null, null, null);
 
         Assert.assertEquals(Collections.emptyList(), initialWorkspaceEntities);
@@ -543,9 +545,9 @@ public class GitLabWorkspaceApiTestResource
 
         // Create another workspace, commit, review, merge to move project HEAD forward -- use workspace two
         String workspaceTwoName = "workspacetwo";
-        Workspace createdWorkspaceTwo = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceTwoName, patchReleaseVersionId));
+        Workspace createdWorkspaceTwo = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoName, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
         String workspaceTwoId = createdWorkspaceTwo.getWorkspaceId();
-        List<Entity> initialWorkspaceTwoEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId)).getEntities(null, null, null);
+        List<Entity> initialWorkspaceTwoEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntities(null, null, null);
 
         Assert.assertEquals(Collections.emptyList(), initialWorkspaceTwoEntities);
 
@@ -556,8 +558,8 @@ public class GitLabWorkspaceApiTestResource
                 "name", "entity",
                 "math-113", "abstract-algebra",
                 "math-185", "complex-analysis");
-        gitLabEntityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId)).createEntity(entityPath, classifierPath, entityContentMap, "initial entity");
-        List<Entity> modifiedWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId)).getEntities(null, null, null);
+        gitLabEntityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).createEntity(entityPath, classifierPath, entityContentMap, "initial entity");
+        List<Entity> modifiedWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntities(null, null, null);
 
         Assert.assertNotNull(modifiedWorkspaceEntities);
         Assert.assertEquals(1, modifiedWorkspaceEntities.size());
@@ -567,7 +569,7 @@ public class GitLabWorkspaceApiTestResource
         Assert.assertEquals(initalEntity.getContent(), entityContentMap);
 
         List<String> labels = Collections.singletonList("default");
-        Review testReview = gitLabCommitterReviewApi.createReview(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId), "Add Courses.", "add two math courses", labels);
+        Review testReview = gitLabCommitterReviewApi.createReview(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))), "Add Courses.", "add two math courses", labels);
         String reviewId = testReview.getId();
         Review approvedReview = gitLabApproverReviewApi.approveReview(projectId, patchReleaseVersionId, reviewId);
 
@@ -634,8 +636,8 @@ public class GitLabWorkspaceApiTestResource
                 "name", "entity",
                 "math-113", "abstract-algebra",
                 "math-185", "complex-analysis");
-        gitLabEntityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, patchReleaseVersionId)).createEntity(entityPath, classifierPath, currentEntityContentMap, "initial entity");
-        List<Entity> modifiedWorkspaceEntitiesNew = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, patchReleaseVersionId)).getEntities(null, null, null);
+        gitLabEntityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).createEntity(entityPath, classifierPath, currentEntityContentMap, "initial entity");
+        List<Entity> modifiedWorkspaceEntitiesNew = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntities(null, null, null);
 
         Assert.assertNotNull(modifiedWorkspaceEntitiesNew);
         Assert.assertEquals(1, modifiedWorkspaceEntities.size());
@@ -645,8 +647,8 @@ public class GitLabWorkspaceApiTestResource
         Assert.assertEquals(initalEntityNew.getContent(), currentEntityContentMap);
 
         // Update workspace branch and trigger rebase
-        gitLabWorkspaceApi.updateWorkspace(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, patchReleaseVersionId));
-        List<Entity> updatedWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newUserWorkspaceSourceSpecification(workspaceId, patchReleaseVersionId)).getEntities(null, null, null);
+        gitLabWorkspaceApi.updateWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
+        List<Entity> updatedWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntities(null, null, null);
 
         Assert.assertNotNull(updatedWorkspaceEntities);
         Assert.assertEquals(1, updatedWorkspaceEntities.size());
@@ -673,10 +675,10 @@ public class GitLabWorkspaceApiTestResource
         Patch patch = gitlabPatchApi.newPatch(projectId, version.getId());
         VersionId patchReleaseVersionId = patch.getPatchReleaseVersionId();
 
-        Workspace createdWorkspace = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceName, patchReleaseVersionId));
+        Workspace createdWorkspace = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceName, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
 
         String workspaceId = createdWorkspace.getWorkspaceId();
-        List<Entity> initialWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, patchReleaseVersionId)).getEntities(null, null, null);
+        List<Entity> initialWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntities(null, null, null);
         List<Entity> initialProjectEntities = gitLabEntityApi.getProjectEntityAccessContext(projectId, patchReleaseVersionId).getEntities(null, null, null);
 
         Assert.assertEquals(Collections.emptyList(), initialWorkspaceEntities);
@@ -684,9 +686,9 @@ public class GitLabWorkspaceApiTestResource
 
         // Create another workspace, commit, review, merge to move project HEAD forward -- use workspace two
         String workspaceTwoName = "workspacetwo";
-        Workspace createdWorkspaceTwo = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceTwoName, patchReleaseVersionId));
+        Workspace createdWorkspaceTwo = gitLabWorkspaceApi.newWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoName, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
         String workspaceTwoId = createdWorkspaceTwo.getWorkspaceId();
-        List<Entity> initialWorkspaceTwoEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId)).getEntities(null, null, null);
+        List<Entity> initialWorkspaceTwoEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntities(null, null, null);
 
         Assert.assertEquals(Collections.emptyList(), initialWorkspaceTwoEntities);
 
@@ -697,8 +699,8 @@ public class GitLabWorkspaceApiTestResource
                 "name", "entity",
                 "math-113", "abstract-algebra",
                 "math-185", "complex-analysis");
-        gitLabEntityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId)).createEntity(entityPath, classifierPath, entityContentMap, "initial entity");
-        List<Entity> modifiedWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId)).getEntities(null, null, null);
+        gitLabEntityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).createEntity(entityPath, classifierPath, entityContentMap, "initial entity");
+        List<Entity> modifiedWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntities(null, null, null);
 
         Assert.assertNotNull(modifiedWorkspaceEntities);
         Assert.assertEquals(1, modifiedWorkspaceEntities.size());
@@ -708,7 +710,7 @@ public class GitLabWorkspaceApiTestResource
         Assert.assertEquals(initalEntity.getContent(), entityContentMap);
 
         List<String> labels = Collections.singletonList("default");
-        Review testReview = gitLabCommitterReviewApi.createReview(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceTwoId, patchReleaseVersionId), "Add Courses.", "add two math courses", labels);
+        Review testReview = gitLabCommitterReviewApi.createReview(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceTwoId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))), "Add Courses.", "add two math courses", labels);
         String reviewId = testReview.getId();
         Review approvedReview = gitLabApproverReviewApi.approveReview(projectId, patchReleaseVersionId, reviewId);
 
@@ -775,8 +777,8 @@ public class GitLabWorkspaceApiTestResource
                 "name", "entity",
                 "math-113", "abstract-algebra",
                 "math-185", "complex-analysis");
-        gitLabEntityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, patchReleaseVersionId)).createEntity(entityPath, classifierPath, currentEntityContentMap, "initial entity");
-        List<Entity> modifiedWorkspaceEntitiesNew = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, patchReleaseVersionId)).getEntities(null, null, null);
+        gitLabEntityApi.getWorkspaceEntityModificationContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).createEntity(entityPath, classifierPath, currentEntityContentMap, "initial entity");
+        List<Entity> modifiedWorkspaceEntitiesNew = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntities(null, null, null);
 
         Assert.assertNotNull(modifiedWorkspaceEntitiesNew);
         Assert.assertEquals(1, modifiedWorkspaceEntities.size());
@@ -786,8 +788,8 @@ public class GitLabWorkspaceApiTestResource
         Assert.assertEquals(initalEntityNew.getContent(), currentEntityContentMap);
 
         // Update workspace branch and trigger rebase
-        gitLabWorkspaceApi.updateWorkspace(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, patchReleaseVersionId));
-        List<Entity> updatedWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.newGroupWorkspaceSourceSpecification(workspaceId, patchReleaseVersionId)).getEntities(null, null, null);
+        gitLabWorkspaceApi.updateWorkspace(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId))));
+        List<Entity> updatedWorkspaceEntities = gitLabEntityApi.getWorkspaceEntityAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.GROUP, WorkspaceSource.patchWorkspaceSource(patchReleaseVersionId)))).getEntities(null, null, null);
 
         Assert.assertNotNull(updatedWorkspaceEntities);
         Assert.assertEquals(1, updatedWorkspaceEntities.size());

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestMavenProjectStructure.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestMavenProjectStructure.java
@@ -25,6 +25,8 @@ import org.apache.maven.model.PluginExecution;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Sets;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
+import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.project.maven.MavenProjectStructure;
 import org.junit.Assert;
 
@@ -54,7 +56,7 @@ TestMavenProjectStructure<T extends MavenProjectStructure> extends TestProjectSt
     public void testBuild()
     {
         super.testBuild();
-        Model mavenModel = MavenProjectStructure.getProjectMavenModel(this.fileAccessProvider.getProjectFileAccessContext(PROJECT_ID));
+        Model mavenModel = MavenProjectStructure.getProjectMavenModel(this.fileAccessProvider.getFileAccessContext(PROJECT_ID, SourceSpecification.projectSourceSpecification()));
         Assert.assertNotNull(mavenModel);
         Assert.assertEquals(GROUP_ID, mavenModel.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, mavenModel.getArtifactId());
@@ -64,7 +66,7 @@ TestMavenProjectStructure<T extends MavenProjectStructure> extends TestProjectSt
     public void testUpdateGroupAndArtifactIds()
     {
         super.testUpdateGroupAndArtifactIds();
-        Model mavenModel = MavenProjectStructure.getProjectMavenModel(this.fileAccessProvider.getProjectFileAccessContext(PROJECT_ID));
+        Model mavenModel = MavenProjectStructure.getProjectMavenModel(this.fileAccessProvider.getFileAccessContext(PROJECT_ID, SourceSpecification.projectSourceSpecification()));
         Assert.assertNotNull(mavenModel);
         Assert.assertEquals(GROUP_ID_2, mavenModel.getGroupId());
         Assert.assertEquals(ARTIFACT_ID_2, mavenModel.getArtifactId());
@@ -75,7 +77,10 @@ TestMavenProjectStructure<T extends MavenProjectStructure> extends TestProjectSt
     {
         super.assertStateValid(projectStructure, projectId, workspaceId, revisionId);
 
-        ProjectFileAccessProvider.FileAccessContext fileAccessContext = this.fileAccessProvider.getFileAccessContext(projectId, workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, revisionId);
+        SourceSpecification sourceSpecification = (workspaceId == null) ?
+                                                  SourceSpecification.projectSourceSpecification() :
+                                                  SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE));
+        ProjectFileAccessProvider.FileAccessContext fileAccessContext = this.fileAccessProvider.getFileAccessContext(projectId, sourceSpecification, revisionId);
 
         // Check validity of the main pom.xml
         Model mavenModel = MavenProjectStructure.getProjectMavenModel(fileAccessContext);
@@ -509,16 +514,16 @@ TestMavenProjectStructure<T extends MavenProjectStructure> extends TestProjectSt
         public int hashCode()
         {
             return (this.dependency == null) ?
-                    0 :
-                    Objects.hash(
-                            this.dependency.getGroupId(),
-                            this.dependency.getArtifactId(),
-                            this.dependency.getVersion(),
-                            this.dependency.getScope(),
-                            this.dependency.getClassifier(),
-                            this.dependency.getType(),
-                            this.dependency.getOptional()
-                    );
+                   0 :
+                   Objects.hash(
+                           this.dependency.getGroupId(),
+                           this.dependency.getArtifactId(),
+                           this.dependency.getVersion(),
+                           this.dependency.getScope(),
+                           this.dependency.getClassifier(),
+                           this.dependency.getType(),
+                           this.dependency.getOptional()
+                   );
         }
 
         @Override
@@ -585,12 +590,12 @@ TestMavenProjectStructure<T extends MavenProjectStructure> extends TestProjectSt
         public int hashCode()
         {
             return (this.plugin == null) ?
-                    0 :
-                    Objects.hash(
-                            this.plugin.getGroupId(),
-                            this.plugin.getArtifactId(),
-                            this.plugin.getVersion()
-                    );
+                   0 :
+                   Objects.hash(
+                           this.plugin.getGroupId(),
+                           this.plugin.getArtifactId(),
+                           this.plugin.getVersion()
+                   );
         }
 
         @Override
@@ -655,12 +660,12 @@ TestMavenProjectStructure<T extends MavenProjectStructure> extends TestProjectSt
         public int hashCode()
         {
             return (this.parent == null) ?
-                    0 :
-                    Objects.hash(
-                            this.parent.getGroupId(),
-                            this.parent.getArtifactId(),
-                            this.parent.getVersion()
-                    );
+                   0 :
+                   Objects.hash(
+                           this.parent.getGroupId(),
+                           this.parent.getArtifactId(),
+                           this.parent.getVersion()
+                   );
         }
 
         @Override

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestMultiGenerationProjectStructure.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestMultiGenerationProjectStructure.java
@@ -22,6 +22,7 @@ import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfigura
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.project.maven.LegendVersionPackagePluginMavenHelper;
 import org.finos.legend.sdlc.server.project.maven.MavenProjectStructure;
 import org.finos.legend.sdlc.server.project.maven.MultiModuleMavenProjectStructure;
@@ -67,7 +68,7 @@ public abstract class TestMultiGenerationProjectStructure<T extends MultiModuleM
     @Override
     protected void assertMultiFormatGenerationStateValid(String projectId, String workspaceId, String revisionId, ArtifactType artifactType)
     {
-        ProjectConfiguration configuration = ProjectStructure.getProjectConfiguration(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE), revisionId, this.fileAccessProvider);
+        ProjectConfiguration configuration = ProjectStructure.getProjectConfiguration(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), revisionId, this.fileAccessProvider);
         Assert.assertNotNull(configuration);
 
         T projectStructure = (T) ProjectStructure.getProjectStructure(configuration);
@@ -75,7 +76,7 @@ public abstract class TestMultiGenerationProjectStructure<T extends MultiModuleM
         Assert.assertFalse(artifactType.name() + " module does not exists", generationModuleName.isEmpty());
         Assert.assertTrue(generationModuleName.stream().allMatch(name -> projectStructure.getOtherModulesNames().contains(name)));
 
-        Model mavenModel = MavenProjectStructure.getProjectMavenModel(this.fileAccessProvider.getFileAccessContext(projectId, workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, revisionId));
+        Model mavenModel = MavenProjectStructure.getProjectMavenModel(this.fileAccessProvider.getFileAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), revisionId));
         Assert.assertNotNull(mavenModel);
         List<String> moduleNames = mavenModel.getModules();
         Assert.assertFalse(moduleNames.isEmpty());
@@ -86,7 +87,7 @@ public abstract class TestMultiGenerationProjectStructure<T extends MultiModuleM
 
         for (String otherModuleName : projectStructure.getModuleNamesForType(artifactType).collect(Collectors.toList()))
         {
-            Model otherModuleMavenModel = projectStructure.getModuleMavenModel(otherModuleName, this.fileAccessProvider.getFileAccessContext(projectId, workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, revisionId));
+            Model otherModuleMavenModel = projectStructure.getModuleMavenModel(otherModuleName, this.fileAccessProvider.getFileAccessContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), revisionId));
             Assert.assertNotNull(otherModuleName, otherModuleMavenModel);
             assertMavenOtherModuleModelValid(otherModuleName, otherModuleMavenModel, projectStructure,
                     expectedConfigMethods.getOrDefault(MultiModuleMavenProjectStructure.getModuleConfigName(projectStructure.getOtherModuleArtifactType(otherModuleName)), Collections.emptyMap()));
@@ -117,4 +118,3 @@ public abstract class TestMultiGenerationProjectStructure<T extends MultiModuleM
     }
 
 }
-

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestMultiModuleMavenProjectStructure.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestMultiModuleMavenProjectStructure.java
@@ -14,7 +14,6 @@
 
 package org.finos.legend.sdlc.server.project;
 
-import ch.qos.logback.core.joran.util.PropertySetter;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Parent;
@@ -25,6 +24,8 @@ import org.finos.legend.sdlc.domain.model.project.configuration.ArtifactType;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectConfiguration;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
+import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.project.maven.LegendTestUtilsMavenHelper;
 import org.finos.legend.sdlc.server.project.maven.MavenProjectStructure;
 import org.finos.legend.sdlc.server.project.maven.MultiModuleMavenProjectStructure;
@@ -64,7 +65,10 @@ public abstract class TestMultiModuleMavenProjectStructure<T extends MultiModule
     protected void assertStateValid(T projectStructure, String projectId, String workspaceId, String revisionId)
     {
         super.assertStateValid(projectStructure, projectId, workspaceId, revisionId);
-        ProjectFileAccessProvider.FileAccessContext fileAccessContext = this.fileAccessProvider.getFileAccessContext(projectId, workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, revisionId);
+        SourceSpecification sourceSpecification = (workspaceId == null) ?
+                                                  SourceSpecification.projectSourceSpecification() :
+                                                  SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE));
+        ProjectFileAccessProvider.FileAccessContext fileAccessContext = this.fileAccessProvider.getFileAccessContext(projectId, sourceSpecification, revisionId);
         Model entitiesMavenModel = projectStructure.getModuleMavenModel(projectStructure.getEntitiesModuleName(), fileAccessContext);
         Assert.assertNotNull(projectStructure.getEntitiesModuleName(), entitiesMavenModel);
         assertMavenEntitiesModelValid(entitiesMavenModel, projectStructure);
@@ -129,17 +133,17 @@ public abstract class TestMultiModuleMavenProjectStructure<T extends MultiModule
     protected void assertMavenEntitiesModelValid(Model mavenEntitiesModel, T projectStructure)
     {
         assertMavenModelValid(
-            projectStructure.getEntitiesModuleName(),
-            mavenEntitiesModel,
-            projectStructure,
-            ps -> ps.getProjectConfiguration().getGroupId(),
-            ps -> ps.getModuleFullName(ps.getEntitiesModuleName()),
-            this::getExpectedParent,
-            this::collectExpectedEntitiesModelProperties,
-            this::collectExpectedEntitiesModelDependencies,
-            this::collectExpectedEntitiesModelPlugins,
-            this::collectExpectedEntitiesModelDependencyManagement,
-            null);
+                projectStructure.getEntitiesModuleName(),
+                mavenEntitiesModel,
+                projectStructure,
+                ps -> ps.getProjectConfiguration().getGroupId(),
+                ps -> ps.getModuleFullName(ps.getEntitiesModuleName()),
+                this::getExpectedParent,
+                this::collectExpectedEntitiesModelProperties,
+                this::collectExpectedEntitiesModelDependencies,
+                this::collectExpectedEntitiesModelPlugins,
+                this::collectExpectedEntitiesModelDependencyManagement,
+                null);
     }
 
     protected void assertMavenOtherModuleModelValid(String otherModuleName, Model mavenOtherModuleModel, T projectStructure, Map<ModuleConfigType, Method> moduleExpectedConfigMethods)
@@ -152,17 +156,17 @@ public abstract class TestMultiModuleMavenProjectStructure<T extends MultiModule
         };
         BiConsumer<? super T, Consumer<Plugin>> pluginCollector = (ps, c) -> invokeExpectedConfigMethod(moduleExpectedConfigMethods.get(ModuleConfigType.PLUGINS), otherModuleName, ps, c);
         assertMavenModelValid(
-            otherModuleName,
-            mavenOtherModuleModel,
-            projectStructure,
-            ps -> ps.getProjectConfiguration().getGroupId(),
-            ps -> ps.getModuleFullName(otherModuleName),
-            this::getExpectedParent,
-            propertyCollector,
-            dependencyCollector,
-            pluginCollector,
-            null,
-            null);
+                otherModuleName,
+                mavenOtherModuleModel,
+                projectStructure,
+                ps -> ps.getProjectConfiguration().getGroupId(),
+                ps -> ps.getModuleFullName(otherModuleName),
+                this::getExpectedParent,
+                propertyCollector,
+                dependencyCollector,
+                pluginCollector,
+                null,
+                null);
     }
 
     protected void collectExpectedEntitiesModelProperties(T projectStructure, BiConsumer<String, String> propertyConsumer)

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructure.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/TestProjectStructure.java
@@ -306,7 +306,7 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
                 .withProjectStructureExtensionProvider(this.projectStructureExtensionProvider)
                 .withProjectStructurePlatformExtensions(this.projectStructurePlatformExtensions)
                 .update();
-        ProjectConfiguration afterWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(addDependenciesWorkspaceSpec),null, this.fileAccessProvider);
+        ProjectConfiguration afterWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(addDependenciesWorkspaceSpec), null, this.fileAccessProvider);
         Assert.assertEquals(PROJECT_ID, afterWorkspaceConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, afterWorkspaceConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, afterWorkspaceConfig.getArtifactId());
@@ -435,7 +435,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         operations.add(ProjectFileOperation.modifyFile("/project.json", serializedConfig));
         this.fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.projectSourceSpecification()).submit("set dependencies", operations);
 
-        ProjectConfiguration afterUpdateProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration afterUpdateProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, afterUpdateProjectConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, afterUpdateProjectConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, afterUpdateProjectConfig.getArtifactId());
@@ -507,7 +508,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         List<ProjectFileOperation> addEntityOperations = ListIterate.collectWith(testEntities, this::generateAddOperationForEntity, projectStructure);
         this.fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.projectSourceSpecification()).submit("Add entities", addEntityOperations);
 
-        ProjectConfiguration beforeProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration beforeProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, beforeProjectConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, beforeProjectConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, beforeProjectConfig.getArtifactId());
@@ -519,7 +521,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         String addDependenciesWorkspaceId = "AddDependencies";
         WorkspaceSpecification addDependenciesWorkspaceSpec = WorkspaceSpecification.newWorkspaceSpecification(addDependenciesWorkspaceId, WorkspaceType.USER);
         this.fileAccessProvider.createWorkspace(PROJECT_ID, addDependenciesWorkspaceId);
-        ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, beforeWorkspaceConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, beforeWorkspaceConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, beforeWorkspaceConfig.getArtifactId());
@@ -548,7 +551,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
 
         this.fileAccessProvider.commitWorkspace(PROJECT_ID, addDependenciesWorkspaceId);
 
-        ProjectConfiguration afterProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration afterProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, afterProjectConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, afterProjectConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, afterProjectConfig.getArtifactId());
@@ -614,7 +618,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
 
             this.fileAccessProvider.commitWorkspace(PROJECT_ID, removeDependencyWorkspaceId);
 
-            ProjectConfiguration afterRemovalProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+            ProjectConfiguration afterRemovalProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+            ;
             Assert.assertEquals(PROJECT_ID, afterRemovalProjectConfig.getProjectId());
             Assert.assertEquals(GROUP_ID, afterRemovalProjectConfig.getGroupId());
             Assert.assertEquals(ARTIFACT_ID, afterRemovalProjectConfig.getArtifactId());
@@ -625,7 +630,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
             assertStateValid(PROJECT_ID, null, null);
         }
 
-        ProjectConfiguration projectConfigUpdateRevisionConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration projectConfigUpdateRevisionConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, projectConfigUpdateRevisionConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, projectConfigUpdateRevisionConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, projectConfigUpdateRevisionConfig.getArtifactId());
@@ -658,7 +664,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
             List<ProjectFileOperation> addEntityOperations = ListIterate.collectWith(testEntities, this::generateAddOperationForEntity, otherProjectStructure);
             Revision revision = this.fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.projectSourceSpecification()).submit("Add entities", addEntityOperations);
 
-            ProjectConfiguration beforeConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+            ProjectConfiguration beforeConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+            ;
             Assert.assertEquals(PROJECT_ID, beforeConfig.getProjectId());
             Assert.assertEquals(GROUP_ID, beforeConfig.getGroupId());
             Assert.assertEquals(ARTIFACT_ID, beforeConfig.getArtifactId());
@@ -681,7 +688,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
             this.fileAccessProvider.commitWorkspace(PROJECT_ID, workspaceId);
             assertStateValid(PROJECT_ID, null, null);
 
-            ProjectConfiguration afterConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+            ProjectConfiguration afterConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+            ;
             Assert.assertEquals(PROJECT_ID, afterConfig.getProjectId());
             Assert.assertEquals(GROUP_ID, afterConfig.getGroupId());
             Assert.assertEquals(ARTIFACT_ID, afterConfig.getArtifactId());
@@ -782,7 +790,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
             List<ProjectFileOperation> addEntityOperations = ListIterate.collectWith(testEntities, this::generateAddOperationForEntity, otherProjectStructure);
             Revision revision = this.fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.projectSourceSpecification()).submit("Add entities", addEntityOperations);
 
-            ProjectConfiguration beforeConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+            ProjectConfiguration beforeConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+            ;
             Assert.assertEquals(PROJECT_ID, beforeConfig.getProjectId());
             Assert.assertEquals(GROUP_ID, beforeConfig.getGroupId());
             Assert.assertEquals(ARTIFACT_ID, beforeConfig.getArtifactId());
@@ -808,7 +817,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
             this.fileAccessProvider.commitWorkspace(PROJECT_ID, workspaceId);
             assertStateValid(PROJECT_ID, null, null);
 
-            ProjectConfiguration afterConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+            ProjectConfiguration afterConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+            ;
             Assert.assertEquals(PROJECT_ID, afterConfig.getProjectId());
             Assert.assertEquals(GROUP_ID_2, afterConfig.getGroupId());
             Assert.assertEquals(ARTIFACT_ID_2, afterConfig.getArtifactId());
@@ -853,7 +863,7 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
                 .withProjectStructurePlatformExtensions(this.projectStructurePlatformExtensions)
                 .update();
         Assert.assertNull(revision3);
-        Assert.assertEquals(revision, this.fileAccessProvider.getWorkspaceRevisionAccessContext(PROJECT_ID, workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE).getCurrentRevision());
+        Assert.assertEquals(revision, this.fileAccessProvider.getRevisionAccessContext(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), null).getCurrentRevision());
         assertStateValid(PROJECT_ID, workspaceId, null);
     }
 
@@ -888,7 +898,10 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
 
     protected final void assertStateValid(String projectId, String workspaceId, String revisionId)
     {
-        ProjectConfiguration configuration = ProjectStructure.getProjectConfiguration(projectId, SourceSpecification.newSourceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE), revisionId, this.fileAccessProvider);
+        SourceSpecification sourceSpecification = (workspaceId == null) ?
+                                                  SourceSpecification.projectSourceSpecification() :
+                                                  SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE));
+        ProjectConfiguration configuration = ProjectStructure.getProjectConfiguration(projectId, sourceSpecification, revisionId, this.fileAccessProvider);
         Assert.assertNotNull(configuration);
         ProjectStructure projectStructure = ProjectStructure.getProjectStructure(configuration);
         Assert.assertEquals(this.projectStructureVersion, projectStructure.getVersion());
@@ -905,7 +918,10 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
 
         if (!expectedFiles.isEmpty() || !unexpectedFiles.isEmpty())
         {
-            Map<String, String> actualFiles = this.fileAccessProvider.getFileAccessContext(projectId, workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, revisionId).getFiles().collect(Collectors.toMap(ProjectFileAccessProvider.ProjectFile::getPath, ProjectFileAccessProvider.ProjectFile::getContentAsString));
+            SourceSpecification sourceSpecification = (workspaceId == null) ?
+                                                      SourceSpecification.projectSourceSpecification() :
+                                                      SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE));
+            Map<String, String> actualFiles = this.fileAccessProvider.getFileAccessContext(projectId, sourceSpecification, revisionId).getFiles().collect(Collectors.toMap(ProjectFileAccessProvider.ProjectFile::getPath, ProjectFileAccessProvider.ProjectFile::getContentAsString));
             expectedFiles.forEach((path, expectedContent) ->
             {
                 String actualContent = actualFiles.get(path);
@@ -962,7 +978,10 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
 
     private List<Entity> getActualEntities(String projectId, String workspaceId, String revisionId)
     {
-        return getActualEntities(this.fileAccessProvider.getFileAccessContext(projectId, workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, revisionId));
+        SourceSpecification sourceSpecification = (workspaceId == null) ?
+                                                  SourceSpecification.projectSourceSpecification() :
+                                                  SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE));
+        return getActualEntities(this.fileAccessProvider.getFileAccessContext(projectId, sourceSpecification, revisionId));
     }
 
     private List<Entity> getActualEntities(ProjectFileAccessProvider.FileAccessContext fileAccessContext)
@@ -1102,7 +1121,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         List<ProjectFileOperation> addEntityOperations = ListIterate.collectWith(testEntities, this::generateAddOperationForEntity, projectStructure);
         this.fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.projectSourceSpecification()).submit("Add entities", addEntityOperations);
 
-        ProjectConfiguration beforeProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration beforeProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, beforeProjectConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, beforeProjectConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, beforeProjectConfig.getArtifactId());
@@ -1113,7 +1133,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
 
         String addGenerationsWorkspaceId = "AddGeneration";
         this.fileAccessProvider.createWorkspace(PROJECT_ID, addGenerationsWorkspaceId);
-        ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, beforeWorkspaceConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, beforeWorkspaceConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, beforeWorkspaceConfig.getArtifactId());
@@ -1126,13 +1147,13 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
 
         ProjectStructure.newUpdateBuilder(this.fileAccessProvider, PROJECT_ID)
                 .withProjectConfigurationUpdater(ProjectConfigurationUpdater.newUpdater().withArtifactGenerationsToAdd(generations))
-                .withWorkspace(SourceSpecification.newSourceSpecification(addGenerationsWorkspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE))
+                .withSourceSpecification(SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(addGenerationsWorkspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)))
                 .withMessage("Add generation")
                 .withProjectStructureExtensionProvider(this.projectStructureExtensionProvider)
                 .withProjectStructurePlatformExtensions(this.projectStructurePlatformExtensions)
                 .update();
 
-        ProjectConfiguration afterWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.newSourceSpecification(addGenerationsWorkspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE), null, this.fileAccessProvider);
+        ProjectConfiguration afterWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(addGenerationsWorkspaceId, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), null, this.fileAccessProvider);
         Assert.assertEquals(PROJECT_ID, afterWorkspaceConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, afterWorkspaceConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, afterWorkspaceConfig.getArtifactId());
@@ -1144,7 +1165,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         this.fileAccessProvider.commitWorkspace(PROJECT_ID, addGenerationsWorkspaceId);
 
 
-        ProjectConfiguration afterProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration afterProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, afterProjectConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, afterProjectConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, afterProjectConfig.getArtifactId());
@@ -1180,7 +1202,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
             WorkspaceSpecification removeDependencyWorkspaceSpec = WorkspaceSpecification.newWorkspaceSpecification(removeDependencyWorkspaceId, WorkspaceType.USER);
 
             this.fileAccessProvider.createWorkspace(PROJECT_ID, removeDependencyWorkspaceId);
-            ProjectConfiguration beforeRemovalConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+            ProjectConfiguration beforeRemovalConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+            ;
             Assert.assertEquals(PROJECT_ID, beforeRemovalConfig.getProjectId());
             Assert.assertEquals(GROUP_ID, beforeRemovalConfig.getGroupId());
             Assert.assertEquals(ARTIFACT_ID, beforeRemovalConfig.getArtifactId());
@@ -1210,7 +1233,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
 
             this.fileAccessProvider.commitWorkspace(PROJECT_ID, removeDependencyWorkspaceId);
 
-            ProjectConfiguration afterRemovalProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+            ProjectConfiguration afterRemovalProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+            ;
             Assert.assertEquals(PROJECT_ID, afterRemovalProjectConfig.getProjectId());
             Assert.assertEquals(GROUP_ID, afterRemovalProjectConfig.getGroupId());
             Assert.assertEquals(ARTIFACT_ID, afterRemovalProjectConfig.getArtifactId());
@@ -1221,7 +1245,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
             assertStateValid(PROJECT_ID, null, null);
         }
 
-        ProjectConfiguration projectConfigUpdateRevisionConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration projectConfigUpdateRevisionConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, projectConfigUpdateRevisionConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, projectConfigUpdateRevisionConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, projectConfigUpdateRevisionConfig.getArtifactId());
@@ -1266,7 +1291,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         List<ProjectFileOperation> addEntityOperations = ListIterate.collectWith(testEntities, this::generateAddOperationForEntity, projectStructure);
         this.fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.projectSourceSpecification()).submit("Add entities", addEntityOperations);
 
-        ProjectConfiguration beforeProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration beforeProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, beforeProjectConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, beforeProjectConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, beforeProjectConfig.getArtifactId());
@@ -1278,7 +1304,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         String addGenerationsWorkspaceId = "AddGeneration";
         WorkspaceSpecification addGenerationsWorkspaceSpec = WorkspaceSpecification.newWorkspaceSpecification(addGenerationsWorkspaceId, WorkspaceType.USER);
         this.fileAccessProvider.createWorkspace(PROJECT_ID, addGenerationsWorkspaceId);
-        ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, beforeWorkspaceConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, beforeWorkspaceConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, beforeWorkspaceConfig.getArtifactId());
@@ -1309,7 +1336,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         this.fileAccessProvider.commitWorkspace(PROJECT_ID, addGenerationsWorkspaceId);
 
 
-        ProjectConfiguration afterProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration afterProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, afterProjectConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, afterProjectConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, afterProjectConfig.getArtifactId());
@@ -1328,7 +1356,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         List<ProjectFileOperation> addEntityOperations = ListIterate.collectWith(testEntities, this::generateAddOperationForEntity, projectStructure);
         this.fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.projectSourceSpecification()).submit("Add entities", addEntityOperations);
 
-        ProjectConfiguration beforeProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration beforeProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, beforeProjectConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, beforeProjectConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, beforeProjectConfig.getArtifactId());
@@ -1340,7 +1369,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         String addGenerationsWorkspaceId = "AddInvalidGeneration";
         WorkspaceSpecification addGenerationsWorkspaceSpec = WorkspaceSpecification.newWorkspaceSpecification(addGenerationsWorkspaceId, WorkspaceType.USER);
         this.fileAccessProvider.createWorkspace(PROJECT_ID, addGenerationsWorkspaceId);
-        ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, beforeWorkspaceConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, beforeWorkspaceConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, beforeWorkspaceConfig.getArtifactId());
@@ -1447,7 +1477,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
             List<ProjectFileOperation> addEntityOperations = ListIterate.collectWith(testEntities, this::generateAddOperationForEntity, projectStructure);
             this.fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.projectSourceSpecification()).submit("Add entities", addEntityOperations);
 
-            ProjectConfiguration beforeProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+            ProjectConfiguration beforeProjectConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+            ;
             Assert.assertEquals(PROJECT_ID, beforeProjectConfig.getProjectId());
             Assert.assertEquals(GROUP_ID, beforeProjectConfig.getGroupId());
             Assert.assertEquals(ARTIFACT_ID, beforeProjectConfig.getArtifactId());
@@ -1459,7 +1490,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
             String addGenerationsWorkspaceId = "AddGeneration";
             WorkspaceSpecification addGenerationsWorkspaceSpec = WorkspaceSpecification.newWorkspaceSpecification(addGenerationsWorkspaceId, WorkspaceType.USER);
             this.fileAccessProvider.createWorkspace(PROJECT_ID, addGenerationsWorkspaceId);
-            ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+            ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+            ;
             Assert.assertEquals(PROJECT_ID, beforeWorkspaceConfig.getProjectId());
             Assert.assertEquals(GROUP_ID, beforeWorkspaceConfig.getGroupId());
             Assert.assertEquals(ARTIFACT_ID, beforeWorkspaceConfig.getArtifactId());
@@ -1514,7 +1546,8 @@ public abstract class TestProjectStructure<T extends ProjectStructure>
         String addGenerationsWorkspaceId = "AddGeneration" + type.name();
         WorkspaceSpecification addGenerationsWorkspaceSpec = WorkspaceSpecification.newWorkspaceSpecification(addGenerationsWorkspaceId, WorkspaceType.USER);
         this.fileAccessProvider.createWorkspace(PROJECT_ID, addGenerationsWorkspaceId);
-        ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);;
+        ProjectConfiguration beforeWorkspaceConfig = ProjectStructure.getProjectConfiguration(PROJECT_ID, SourceSpecification.projectSourceSpecification(), null, this.fileAccessProvider);
+        ;
         Assert.assertEquals(PROJECT_ID, beforeWorkspaceConfig.getProjectId());
         Assert.assertEquals(GROUP_ID, beforeWorkspaceConfig.getGroupId());
         Assert.assertEquals(ARTIFACT_ID, beforeWorkspaceConfig.getArtifactId());

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/extension/TestDefaultProjectStructureExtension.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/project/extension/TestDefaultProjectStructureExtension.java
@@ -17,6 +17,8 @@ package org.finos.legend.sdlc.server.project.extension;
 import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.factory.Maps;
 import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
+import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.project.InMemoryProjectFileAccessProvider;
 import org.finos.legend.sdlc.server.project.ProjectFileAccessProvider;
 import org.finos.legend.sdlc.server.project.ProjectFileOperation;
@@ -56,7 +58,7 @@ public class TestDefaultProjectStructureExtension
 
         InMemoryProjectFileAccessProvider fileAccessProvider = new InMemoryProjectFileAccessProvider(AUTHOR, COMMITTER);
         fileAccessProvider.createWorkspace(PROJECT_ID, WORKSPACE_ID);
-        ProjectFileAccessProvider.FileAccessContext fileAccessContext = fileAccessProvider.getFileAccessContext(PROJECT_ID, WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, null);
+        ProjectFileAccessProvider.FileAccessContext fileAccessContext = fileAccessProvider.getFileAccessContext(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), null);
         Assert.assertEquals(0L, fileAccessContext.getFiles().count());
 
         List<ProjectFileOperation> operations = Lists.mutable.empty();
@@ -76,14 +78,14 @@ public class TestDefaultProjectStructureExtension
 
         InMemoryProjectFileAccessProvider fileAccessProvider = new InMemoryProjectFileAccessProvider(AUTHOR, COMMITTER);
         fileAccessProvider.createWorkspace(PROJECT_ID, WORKSPACE_ID);
-        ProjectFileAccessProvider.FileAccessContext fileAccessContext = fileAccessProvider.getFileAccessContext(PROJECT_ID, WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, null);
+        ProjectFileAccessProvider.FileAccessContext fileAccessContext = fileAccessProvider.getFileAccessContext(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), null);
         Assert.assertEquals(0L, fileAccessContext.getFiles().count());
 
         List<ProjectFileOperation> operations = Lists.mutable.empty();
         extension.collectUpdateProjectConfigurationOperations(null, null, fileAccessContext, operations::add);
         Assert.assertEquals(2, operations.size());
 
-        ProjectFileAccessProvider.FileModificationContext modificationContext = fileAccessProvider.getFileModificationContext(PROJECT_ID, WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, null);
+        ProjectFileAccessProvider.FileModificationContext modificationContext = fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), null);
         modificationContext.submit("message", operations);
 
         Assert.assertEquals(2L, fileAccessContext.getFiles().count());
@@ -110,10 +112,10 @@ public class TestDefaultProjectStructureExtension
 
         InMemoryProjectFileAccessProvider fileAccessProvider = new InMemoryProjectFileAccessProvider(AUTHOR, COMMITTER);
         fileAccessProvider.createWorkspace(PROJECT_ID, WORKSPACE_ID);
-        ProjectFileAccessProvider.FileAccessContext fileAccessContext = fileAccessProvider.getFileAccessContext(PROJECT_ID, WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, null);
+        ProjectFileAccessProvider.FileAccessContext fileAccessContext = fileAccessProvider.getFileAccessContext(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), null);
         Assert.assertEquals(0L, fileAccessContext.getFiles().count());
 
-        ProjectFileAccessProvider.FileModificationContext modificationContext = fileAccessProvider.getFileModificationContext(PROJECT_ID, WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, null);
+        ProjectFileAccessProvider.FileModificationContext modificationContext = fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), null);
         modificationContext.submit("initial state", Collections.singletonList(ProjectFileOperation.addFile(file1Path, file1ContentBefore)));
         Assert.assertEquals(1L, fileAccessContext.getFiles().count());
 
@@ -146,7 +148,7 @@ public class TestDefaultProjectStructureExtension
 
         InMemoryProjectFileAccessProvider fileAccessProvider = new InMemoryProjectFileAccessProvider(AUTHOR, COMMITTER);
         fileAccessProvider.createWorkspace(PROJECT_ID, WORKSPACE_ID);
-        ProjectFileAccessProvider.FileAccessContext fileAccessContext = fileAccessProvider.getFileAccessContext(PROJECT_ID, WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, null);
+        ProjectFileAccessProvider.FileAccessContext fileAccessContext = fileAccessProvider.getFileAccessContext(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), null);
         Assert.assertEquals(0L, fileAccessContext.getFiles().count());
 
         DefaultProjectStructureExtension extension = newProjectStructureExtension(0, 0, filePath, fileContent);
@@ -154,7 +156,7 @@ public class TestDefaultProjectStructureExtension
         extension.collectUpdateProjectConfigurationOperations(null, null, fileAccessContext, operations::add);
         Assert.assertEquals(1, operations.size());
 
-        ProjectFileAccessProvider.FileModificationContext modificationContext = fileAccessProvider.getFileModificationContext(PROJECT_ID, WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, null);
+        ProjectFileAccessProvider.FileModificationContext modificationContext = fileAccessProvider.getFileModificationContext(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), null);
         modificationContext.submit("update", operations);
 
         Assert.assertNull(filePath, fileAccessContext.getFile(filePath));
@@ -171,7 +173,7 @@ public class TestDefaultProjectStructureExtension
 
         InMemoryProjectFileAccessProvider fileAccessProvider = new InMemoryProjectFileAccessProvider(AUTHOR, COMMITTER);
         fileAccessProvider.createWorkspace(PROJECT_ID, WORKSPACE_ID);
-        ProjectFileAccessProvider.FileAccessContext fileAccessContext = fileAccessProvider.getFileAccessContext(PROJECT_ID, WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE, null);
+        ProjectFileAccessProvider.FileAccessContext fileAccessContext = fileAccessProvider.getFileAccessContext(PROJECT_ID, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(WORKSPACE_ID, WorkspaceType.USER, ProjectFileAccessProvider.WorkspaceAccessType.WORKSPACE)), null);
         Assert.assertEquals(0L, fileAccessContext.getFiles().count());
 
         RuntimeException e = Assert.assertThrows(RuntimeException.class, () -> newProjectStructureExtension(0, 0, filePath, fileContent, canonicalFilePath, "other content"));

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestDependenciesResource.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/resources/TestDependenciesResource.java
@@ -16,9 +16,12 @@ package org.finos.legend.sdlc.server.resources;
 
 import org.finos.legend.sdlc.domain.model.TestTools;
 import org.finos.legend.sdlc.domain.model.project.configuration.ProjectDependency;
+import org.finos.legend.sdlc.domain.model.project.workspace.WorkspaceType;
 import org.finos.legend.sdlc.domain.model.version.VersionId;
 import org.finos.legend.sdlc.server.domain.api.dependency.ProjectRevision;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSource;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -148,7 +151,7 @@ public class TestDependenciesResource extends AbstractLegendSDLCServerResourceTe
 
         this.backend.project("B").addEntities("w1", Arrays.asList(TestTools.newClassEntity("b3", "B")), VersionId.parseVersionId("1.0.1"));
 
-        String workspace1CurrentRevision = this.backend.getRevisionApi().getWorkspaceRevisionContext("B", SourceSpecification.newUserWorkspaceSourceSpecification("w1", VersionId.parseVersionId("1.0.1"))).getCurrentRevision().getId();
+        String workspace1CurrentRevision = this.backend.getRevisionApi().getWorkspaceRevisionContext("B", SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification("w1", WorkspaceType.USER, WorkspaceSource.patchWorkspaceSource(VersionId.parseVersionId("1.0.1"))))).getCurrentRevision().getId();
 
         // B directly depends on A
         String url = String.format("/api/projects/B/patches/1.0.1/workspaces/w1/revisions/%s/upstreamProjects", workspace1CurrentRevision);

--- a/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/utils/TestModelBuilderTest.java
+++ b/legend-sdlc-server/src/test/java/org/finos/legend/sdlc/server/utils/TestModelBuilderTest.java
@@ -28,6 +28,7 @@ import org.finos.legend.sdlc.server.domain.api.dependency.DependenciesApi;
 import org.finos.legend.sdlc.server.domain.api.dependency.DependenciesApiImpl;
 import org.finos.legend.sdlc.server.domain.api.test.TestModelBuilder;
 import org.finos.legend.sdlc.server.domain.api.project.source.SourceSpecification;
+import org.finos.legend.sdlc.server.domain.api.workspace.WorkspaceSpecification;
 import org.finos.legend.sdlc.server.inmemory.backend.InMemoryBackend;
 import org.finos.legend.sdlc.server.inmemory.backend.metadata.InMemoryMetadataBackend;
 import org.junit.Assert;
@@ -817,17 +818,17 @@ public class TestModelBuilderTest
 
     private String revisionId(String projectId, String workspaceId)
     {
-        return this.backend.getRevisionApi().getUserWorkspaceRevisionContext(projectId, workspaceId).getCurrentRevision().getId();
+        return this.backend.getRevisionApi().getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, WorkspaceType.USER))).getCurrentRevision().getId();
     }
 
     private String revisionId(String projectId, String workspaceId, WorkspaceType type)
     {
-        return this.backend.getRevisionApi().getWorkspaceRevisionContext(projectId, SourceSpecification.newSourceSpecification(workspaceId, type)).getCurrentRevision().getId();
+        return this.backend.getRevisionApi().getRevisionContext(projectId, SourceSpecification.workspaceSourceSpecification(WorkspaceSpecification.newWorkspaceSpecification(workspaceId, type))).getCurrentRevision().getId();
     }
 
     private String revisionId(String projectId)
     {
-        return this.backend.getRevisionApi().getProjectRevisionContext(projectId).getCurrentRevision().getId();
+        return this.backend.getRevisionApi().getRevisionContext(projectId, SourceSpecification.projectSourceSpecification()).getCurrentRevision().getId();
     }
 
     private List<Entity> findEntitiesInMetadata(String projectId, String versionId)


### PR DESCRIPTION
Eliminate some deprecated methods from ProjectFileAccessProvider and SourceSpecification. In passing, add in some missing WorkspaceAccessType parameters.