### PR TITLE
Add LegendSDLCException in legend-shared

### DIFF
--- a/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/error/ExtendedErrorMessage.java
+++ b/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/error/ExtendedErrorMessage.java
@@ -17,12 +17,13 @@ package org.finos.legend.sdlc.server.error;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.jersey.errors.ErrorMessage;
+import org.finos.legend.sdlc.error.LegendSDLCException;
 
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Instant;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 
 class ExtendedErrorMessage extends ErrorMessage
 {
@@ -60,9 +61,9 @@ class ExtendedErrorMessage extends ErrorMessage
 
     static ExtendedErrorMessage fromThrowable(Throwable t, boolean includeStackTrace)
     {
-        if (t instanceof LegendSDLCServerException)
+        if (t instanceof LegendSDLCException)
         {
-            return fromLegendSDLCServerException((LegendSDLCServerException) t, includeStackTrace);
+            return fromLegendSDLCException((LegendSDLCException) t, includeStackTrace);
         }
         if (t instanceof WebApplicationException)
         {
@@ -71,9 +72,15 @@ class ExtendedErrorMessage extends ErrorMessage
         return fromThrowable(t, getDefaultStatusCode(), null, null, includeStackTrace);
     }
 
+    @Deprecated
     static ExtendedErrorMessage fromLegendSDLCServerException(LegendSDLCServerException e, boolean includeStackTrace)
     {
-        return fromThrowable(e, e.getStatus().getStatusCode(), null, null, includeStackTrace);
+        return fromThrowable(e, e.getStatus(), null, null, includeStackTrace);
+    }
+
+    static ExtendedErrorMessage fromLegendSDLCException(LegendSDLCException e, boolean includeStackTrace)
+    {
+        return fromThrowable(e, e.getStatusCode(), null, null, includeStackTrace);
     }
 
     static ExtendedErrorMessage fromWebApplicationException(WebApplicationException e, boolean includeStackTrace)
@@ -94,16 +101,15 @@ class ExtendedErrorMessage extends ErrorMessage
 
     private static String getMessage(Throwable t)
     {
-        String message = t.getMessage();
-        if (message == null)
+        for (Throwable current = t; current != null; current = current.getCause())
         {
-            Throwable cause = t.getCause();
-            if (cause != null)
+            String message = current.getMessage();
+            if (message != null)
             {
-                return getMessage(cause);
+                return message;
             }
         }
-        return message;
+        return null;
     }
 
     private static String getStackTrace(Throwable t)

--- a/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/error/LegendSDLCServerException.java
+++ b/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/error/LegendSDLCServerException.java
@@ -14,43 +14,40 @@
 
 package org.finos.legend.sdlc.server.error;
 
+import org.finos.legend.sdlc.error.LegendSDLCException;
+
+import javax.ws.rs.core.Response.Status;
 import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import javax.ws.rs.core.Response.Status;
 
-public class LegendSDLCServerException extends RuntimeException
+public class LegendSDLCServerException extends LegendSDLCException
 {
     private static final long serialVersionUID = -427388642530259672L;
-    private static final Status DEFAULT_STATUS = Status.INTERNAL_SERVER_ERROR;
-
-    private final Status status;
 
     public LegendSDLCServerException(String message, Status httpStatus, Throwable cause)
     {
-        super(message, cause);
-        this.status = (httpStatus == null) ? DEFAULT_STATUS : httpStatus;
+        super(message, toStatusCode(httpStatus), cause);
     }
 
     public LegendSDLCServerException(String message, Status httpStatus)
     {
-        super(message);
-        this.status = (httpStatus == null) ? DEFAULT_STATUS : httpStatus;
+        super(message, toStatusCode(httpStatus));
     }
 
     public LegendSDLCServerException(String message, Throwable cause)
     {
-        this(message, null, cause);
+        super(message, cause);
     }
 
     public LegendSDLCServerException(String message)
     {
-        this(message, (Status) null);
+        super(message);
     }
 
     public Status getStatus()
     {
-        return this.status;
+        return Status.fromStatusCode(getStatusCode());
     }
 
     public static <T> T validateNonNull(T arg, String message)
@@ -89,5 +86,10 @@ public class LegendSDLCServerException extends RuntimeException
             throw new LegendSDLCServerException((messageFn == null) ? null : messageFn.apply(arg), (httpStatus == null) ? Status.BAD_REQUEST : httpStatus);
         }
         return arg;
+    }
+
+    private static int toStatusCode(Status status)
+    {
+        return (status == null) ? DEFAULT_STATUS_CODE : status.getStatusCode();
     }
 }

--- a/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/error/LegendSDLCServerExceptionMapper.java
+++ b/legend-sdlc-server-shared/src/main/java/org/finos/legend/sdlc/server/error/LegendSDLCServerExceptionMapper.java
@@ -14,17 +14,18 @@
 
 package org.finos.legend.sdlc.server.error;
 
+import org.finos.legend.sdlc.error.LegendSDLCException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.Provider;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 @Provider
-public class LegendSDLCServerExceptionMapper extends BaseExceptionMapper<LegendSDLCServerException>
+public class LegendSDLCServerExceptionMapper extends BaseExceptionMapper<LegendSDLCException>
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(LegendSDLCServerExceptionMapper.class);
 
@@ -39,21 +40,22 @@ public class LegendSDLCServerExceptionMapper extends BaseExceptionMapper<LegendS
     }
 
     @Override
-    public Response toResponse(LegendSDLCServerException exception)
+    public Response toResponse(LegendSDLCException exception)
     {
-        Status status = exception.getStatus();
-        switch (status.getFamily())
+        Status status = Status.fromStatusCode(exception.getStatusCode());
+        int statusCode = status.getStatusCode();
+        switch (statusCode / 100)
         {
-            case CLIENT_ERROR:
+            case 4:
             {
                 // we do not return a stack trace for client errors, regardless of the value of includeStackTrace
-                return buildResponse(status, ExtendedErrorMessage.fromLegendSDLCServerException(exception, false));
+                return buildResponse(status, ExtendedErrorMessage.fromLegendSDLCException(exception, false));
             }
-            case SERVER_ERROR:
+            case 5:
             {
-                return buildResponse(status, ExtendedErrorMessage.fromLegendSDLCServerException(exception, this.includeStackTrace));
+                return buildResponse(status, ExtendedErrorMessage.fromLegendSDLCException(exception, this.includeStackTrace));
             }
-            case REDIRECTION:
+            case 3:
             {
                 // TODO consider cases other than 301, 302, 303, and 307
                 URI redirectLocation = getRedirectLocation(exception);
@@ -67,24 +69,24 @@ public class LegendSDLCServerExceptionMapper extends BaseExceptionMapper<LegendS
                 // Could not get a redirect location from an exception indicating there should be a redirect
                 // Send back an internal server error instead
                 LOGGER.warn("Could not get redirect URI from exception with status: {}", status);
-                return buildResponse(Status.INTERNAL_SERVER_ERROR, ExtendedErrorMessage.fromLegendSDLCServerException(exception, this.includeStackTrace));
+                return buildResponse(Status.INTERNAL_SERVER_ERROR, ExtendedErrorMessage.fromLegendSDLCException(exception, this.includeStackTrace));
             }
             default:
             {
                 // Exception with non-error HTTP status
                 // Send back an internal server error instead
                 LOGGER.warn("Exception with non-error HTTP status: {}", status);
-                return buildResponse(Status.INTERNAL_SERVER_ERROR, ExtendedErrorMessage.fromLegendSDLCServerException(exception, this.includeStackTrace));
+                return buildResponse(Status.INTERNAL_SERVER_ERROR, ExtendedErrorMessage.fromLegendSDLCException(exception, this.includeStackTrace));
             }
         }
     }
 
-    private static URI getRedirectLocation(LegendSDLCServerException exception)
+    private static URI getRedirectLocation(LegendSDLCException exception)
     {
         String message = exception.getMessage();
         if (message == null)
         {
-            LOGGER.warn("A LegendSDLCServerException with status {} should have the redirect location as its message, found null", exception.getStatus());
+            LOGGER.warn("A LegendSDLCServerException with status {} should have the redirect location as its message, found null", exception.getStatusCode());
             return null;
         }
 
@@ -94,7 +96,7 @@ public class LegendSDLCServerExceptionMapper extends BaseExceptionMapper<LegendS
         }
         catch (URISyntaxException e)
         {
-            LOGGER.warn("Invalid redirect location for LegendSDLCServerException with status {}: {}", exception.getStatus(), message);
+            LOGGER.warn("Invalid redirect location for LegendSDLCServerException with status {}: {}", exception.getStatusCode(), message);
             return null;
         }
     }

--- a/legend-sdlc-shared/src/main/java/org/finos/legend/sdlc/error/LegendSDLCException.java
+++ b/legend-sdlc-shared/src/main/java/org/finos/legend/sdlc/error/LegendSDLCException.java
@@ -1,0 +1,92 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.error;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class LegendSDLCException extends RuntimeException
+{
+    protected static final int DEFAULT_STATUS_CODE = 500;
+    protected static final int DEFAULT_VALIDATION_STATUS_CODE = 400;
+
+    private final int statusCode;
+
+    public LegendSDLCException(String message, int statusCode, Throwable cause)
+    {
+        super(message, cause);
+        this.statusCode = statusCode;
+    }
+
+    public LegendSDLCException(String message, int statusCode)
+    {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    public LegendSDLCException(String message, Throwable cause)
+    {
+        this(message, DEFAULT_STATUS_CODE, cause);
+    }
+
+    public LegendSDLCException(String message)
+    {
+        this(message, DEFAULT_STATUS_CODE);
+    }
+
+    public int getStatusCode()
+    {
+        return statusCode;
+    }
+
+    public static <T> T validateNonNull(T arg, String message)
+    {
+        return validateNonNull(arg, message, DEFAULT_VALIDATION_STATUS_CODE);
+    }
+
+    public static <T> T validateNonNull(T arg, String message, int statusCode)
+    {
+        return validate(arg, Objects::nonNull, message, statusCode);
+    }
+
+    public static <T> T validate(T arg, Predicate<? super T> predicate, String message)
+    {
+        return validate(arg, predicate, message, DEFAULT_VALIDATION_STATUS_CODE);
+    }
+
+    public static <T> T validate(T arg, Predicate<? super T> predicate, String message, int statusCode)
+    {
+        if (!predicate.test(arg))
+        {
+            throw new LegendSDLCException(message, statusCode);
+        }
+        return arg;
+    }
+
+    public static <T> T validate(T arg, Predicate<? super T> predicate, Function<? super T, String> messageFn)
+    {
+        return validate(arg, predicate, messageFn, DEFAULT_VALIDATION_STATUS_CODE);
+    }
+
+    public static <T> T validate(T arg, Predicate<? super T> predicate, Function<? super T, String> messageFn, int statusCode)
+    {
+        if (!predicate.test(arg))
+        {
+            throw new LegendSDLCException((messageFn == null) ? null : messageFn.apply(arg), statusCode);
+        }
+        return arg;
+    }
+}

--- a/legend-sdlc-shared/src/test/java/org/finos/legend/sdlc/error/TestLegendSDLCException.java
+++ b/legend-sdlc-shared/src/test/java/org/finos/legend/sdlc/error/TestLegendSDLCException.java
@@ -1,0 +1,92 @@
+// Copyright 2026 Goldman Sachs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.finos.legend.sdlc.error;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class TestLegendSDLCException
+{
+    @Test
+    public void testValidateNonNull()
+    {
+        String message = "the quick brown fox jumped over the lazy dog";
+        Object someObject = new Object();
+
+        Assert.assertSame(someObject, LegendSDLCException.validateNonNull(someObject, message));
+
+        LegendSDLCException e1 = Assert.assertThrows(LegendSDLCException.class, () -> LegendSDLCException.validateNonNull(null, message));
+        Assert.assertEquals(message, e1.getMessage());
+        Assert.assertEquals(400, e1.getStatusCode());
+
+        int status = 500;
+        LegendSDLCException e2 = Assert.assertThrows(message, LegendSDLCException.class, () -> LegendSDLCException.validateNonNull(null, message, status));
+        Assert.assertEquals(message, e2.getMessage());
+        Assert.assertEquals(status, e2.getStatusCode());
+    }
+
+    @Test
+    public void testValidate_Message()
+    {
+        String message = "Cogito, ergo sum.";
+        Object validObject = new Object();
+        Object invalidObject = new Object();
+        Predicate<Object> predicate = x -> x == validObject;
+
+        Assert.assertSame(validObject, LegendSDLCException.validate(validObject, predicate, message));
+
+        LegendSDLCException e1 = Assert.assertThrows(LegendSDLCException.class, () -> LegendSDLCException.validate(invalidObject, predicate, message));
+        Assert.assertEquals(message, e1.getMessage());
+        Assert.assertEquals(400, e1.getStatusCode());
+
+        int status = 501;
+        LegendSDLCException e2 = Assert.assertThrows(message, LegendSDLCException.class, () -> LegendSDLCException.validate(invalidObject, predicate, message, status));
+        Assert.assertEquals(message, e2.getMessage());
+        Assert.assertEquals(status, e2.getStatusCode());
+    }
+
+    @Test
+    public void testValidate_MessageFunction()
+    {
+        String message = "Soon you'll be ashes or bones. A mere name at most - and even that is just a sound, an echo. The things we want in life are empty, stale, trivial.";
+        int[] messageFnCount = {0};
+        Function<Object, String> messageFn = x ->
+        {
+            messageFnCount[0]++;
+            return message;
+        };
+
+        Object validObject = new Object();
+        Object invalidObject = new Object();
+        Predicate<Object> predicate = x -> x == validObject;
+
+        Assert.assertSame(validObject, LegendSDLCException.validate(validObject, predicate, messageFn));
+        Assert.assertEquals(0, messageFnCount[0]);
+
+        LegendSDLCException e1 = Assert.assertThrows(LegendSDLCException.class, () -> LegendSDLCException.validate(invalidObject, predicate, messageFn));
+        Assert.assertEquals(message, e1.getMessage());
+        Assert.assertEquals(1, messageFnCount[0]);
+        Assert.assertEquals(400, e1.getStatusCode());
+
+        int status = 409;
+        LegendSDLCException e2 = Assert.assertThrows(message, LegendSDLCException.class, () -> LegendSDLCException.validate(invalidObject, predicate, messageFn, status));
+        Assert.assertEquals(message, e2.getMessage());
+        Assert.assertEquals(2, messageFnCount[0]);
+        Assert.assertEquals(status, e2.getStatusCode());
+    }
+}


### PR DESCRIPTION
Add LegendSDLCException in legend-shared. This is a new superclass of LegendSDLCServerException. It is very similar, except that it takes the status code as an int instead of a Response.Status. This allows us to avoid having a JAX-RS dependency on legend-shared.