### PR TITLE
Overide central-publishing plugin version to latest stable 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,7 @@
            <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.11.0</version>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
                      <autoPublish>true</autoPublish>


### PR DESCRIPTION
Overide central-publishing plugin version to latest stable 0.11.0 temporarily to unblock release.
Finos parent pom needs to be updated